### PR TITLE
Bard DawnTrail Lvl 90 Aura Fix

### DIFF
--- a/Magitek/Logic/Bard/Cooldowns.cs
+++ b/Magitek/Logic/Bard/Cooldowns.cs
@@ -90,7 +90,7 @@ namespace Magitek.Logic.Bard
                     && (Casting.LastSpell == BardRoutine.BurstShot || Casting.LastSpell == BardRoutine.Stormbite || Casting.LastSpell == BardRoutine.CausticBite || Casting.LastSpell == Spells.IronJaws))
                     return false;
 
-                if (Core.Me.HasAura(Auras.StraighterShot) || Spells.RefulgentArrow.CanCast())
+                if (Core.Me.HasAura(Auras.HawksEye) || Spells.RefulgentArrow.CanCast())
                     return false;
             }
 

--- a/Magitek/Logic/Bard/SingleTarget.cs
+++ b/Magitek/Logic/Bard/SingleTarget.cs
@@ -29,7 +29,7 @@ namespace Magitek.Logic.Bard
             if (!BardSettings.Instance.UseStraightShot)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.StraighterShot))
+            if (!Core.Me.HasAura(Auras.HawksEye))
                 return false;
 
             if (Core.Me.ClassLevel < 70 || !ActionManager.HasSpell(Spells.RefulgentArrow.Id))

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -86,7 +86,7 @@ namespace Magitek.Utilities
             RightEye = 1453,
             LeftEye = 1454,
             Medicated = 49,
-            StraighterShot = 122,
+            HawksEye = 3861,
             VenomousBite = 124,
             RagingStrikes = 125,
             RadiantFinale = 2722,


### PR DESCRIPTION
First PR of Magitek DT.

Changes the Aura of StraighterShot thereby fixing the majority of lvl 90 rotation for bard.