### PR TITLE
Correctly detect FoF by aura instead of spell cast - fixes issue wher…

### DIFF
--- a/Magitek/Logic/Paladin/Aoe.cs
+++ b/Magitek/Logic/Paladin/Aoe.cs
@@ -33,9 +33,6 @@ namespace Magitek.Logic.Paladin
             if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= Spells.CircleofScorn.Radius + x.CombatReach) < 1)
                 return false;
 
-            if (!PaladinRoutine.GlobalCooldown.CanDoubleWeave() || !PaladinRoutine.GlobalCooldown.CanWeave(2))
-                return false;
-
             return await Spells.CircleofScorn.Cast(Core.Me);
         }
 

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -155,7 +155,7 @@ namespace Magitek.Logic.Paladin
             /*if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= 5 + x.CombatReach) >= PaladinSettings.Instance.TotalEclipseEnemies)
                 return await Spells.Requiescat.Cast(Core.Me.CurrentTarget);
             */
-            if (Casting.LastSpell != Spells.FightorFlight)
+            if (!Core.Me.HasAura(Auras.FightOrFlight))
                 return false;
 
             if (Spells.Imperator.IsKnown()) 


### PR DESCRIPTION
…e a defensive is cast in between FoF and Requiescat causting it to miss the window.