### PR TITLE
PCT adjustments & WAR to 100

### DIFF
--- a/Magitek/Logic/Pictomancer/Buff.cs
+++ b/Magitek/Logic/Pictomancer/Buff.cs
@@ -57,17 +57,28 @@ namespace Magitek.Logic.Pictomancer
 
             if (FightLogic.EnemyIsCastingAoe() || FightLogic.EnemyIsCastingBigAoe())
             {
-                if (Spells.TemperaGrassa.IsKnownAndReady())
-                {
-                    await Spells.TemperaCoat.CastAura(Core.Me, Auras.TempuraCoat);
-                    if (await Coroutine.Wait(2500, () => Core.Me.HasAura(Auras.TempuraCoat, true)))
-                        return await FightLogic.DoAndBuffer(Spells.TemperaGrassa.CastAura(Core.Me, Auras.TempuraGrassa));
-                    else
-                        return false;
-                } else
-                {
-                    return await FightLogic.DoAndBuffer(Spells.TemperaCoat.CastAura(Core.Me, Auras.TempuraCoat));
-                }                
+                return await FightLogic.DoAndBuffer(Spells.TemperaCoat.CastAura(Core.Me, Auras.TempuraCoat));             
+            }
+            return false;
+        }
+
+        public static async Task<bool> FightLogic_TemperaGrassa()
+        {
+            if (!PictomancerSettings.Instance.FightLogicTemperaCoat)
+                return false;
+
+            if (!Spells.TemperaGrassa.IsKnownAndReady())
+                return false;
+
+            if (!Core.Me.HasAura(Auras.TempuraCoat))
+                return false;
+
+            if (!FightLogic.ZoneHasFightLogic() || !FightLogic.EnemyHasAnyAoeLogic())
+                return false;
+
+            if (FightLogic.EnemyIsCastingAoe() || FightLogic.EnemyIsCastingBigAoe())
+            {
+                return await FightLogic.DoAndBuffer(Spells.TemperaGrassa.CastAura(Core.Me, Auras.TempuraGrassa));
             }
             return false;
         }

--- a/Magitek/Logic/Pictomancer/Palette.cs
+++ b/Magitek/Logic/Pictomancer/Palette.cs
@@ -241,6 +241,9 @@ namespace Magitek.Logic.Pictomancer
             if (!PictomancerSettings.Instance.UseStarrySky)
                 return false;
 
+            if (MovementManager.IsMoving && !PictomancerSettings.Instance.UseStarrySkyWhileMoving)
+                return false;
+
             if (Utilities.Routines.Pictomancer.CheckTTDIsEnemyDyingSoon())
                 return false;
 

--- a/Magitek/Logic/Warrior/Aoe.cs
+++ b/Magitek/Logic/Warrior/Aoe.cs
@@ -106,7 +106,7 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UsePrimalRend)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.PrimalRendReady))
+            if (!Core.Me.HasAura(Auras.PrimalRendReady) && !Core.Me.HasAura(Auras.PrimalRuinationReady))
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))

--- a/Magitek/Models/Pictomancer/PictomancerSettings.cs
+++ b/Magitek/Models/Pictomancer/PictomancerSettings.cs
@@ -27,6 +27,10 @@ namespace Magitek.Models.Pictomancer
         public int SaveIfEnemyDyingWithin { get; set; }
 
         [Setting]
+        [DefaultValue(true)]
+        public bool UseWeaving { get; set; }
+
+        [Setting]
         [DefaultValue(false)]
         public bool SaveHammerForStarry { get; set; }
 
@@ -87,6 +91,10 @@ namespace Magitek.Models.Pictomancer
         [Setting]
         [DefaultValue(true)]
         public bool UseStarrySky { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool UseStarrySkyWhileMoving { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -102,8 +102,10 @@ namespace Magitek.Rotations
             if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
 
-            if (PictomancerRoutine.GlobalCooldown.CanWeave(1)) 
+            if (!PictomancerSettings.Instance.UseWeaving || 
+                PictomancerRoutine.GlobalCooldown.CanWeave(1)) 
             {
+                if (await Buff.FightLogic_TemperaGrassa()) return true;
                 if (await Buff.FightLogic_TemperaCoat()) return true;
                 if (await Buff.FightLogic_Addle()) return true;
                 if (await Healer.LucidDreaming(PictomancerSettings.Instance.UseLucidDreaming, PictomancerSettings.Instance.LucidDreamingMinimumManaPercent)) return true;
@@ -114,7 +116,8 @@ namespace Magitek.Rotations
             if (await Palette.RainbowDrip()) return true;
             if (await Palette.ScenicMuse()) return true;
 
-            if (Core.Me.HasAura(Auras.Inspiration) ||
+            if (!PictomancerSettings.Instance.UseWeaving ||
+                Core.Me.HasAura(Auras.Inspiration) ||
                 PictomancerRoutine.GlobalCooldown.CanWeave(1) ||
                 PictomancerRoutine.GlobalCooldown.CanWeave(2))
             {

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -263,6 +263,7 @@ namespace Magitek.Utilities
             OgiReady = 2959,
             ShadowBiteReady = 3002,
             PrimalRendReady = 2624,
+            PrimalRuinationReady = 3834,
             ArmysPaeon = 2218,
             MagesBallad = 2217,
             TheWanderersMinuet = 2216,

--- a/Magitek/Views/UserControls/Pictomancer/Utility.xaml
+++ b/Magitek/Views/UserControls/Pictomancer/Utility.xaml
@@ -46,6 +46,14 @@
             </StackPanel>
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content=" Use Weaving (Only cast Instant Abilities after spell casts)" IsChecked="{Binding PictomancerSettings.UseTTD, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
     </StackPanel>
 </UserControl>
 


### PR DESCRIPTION
- PCT - attempt to fix getting stuck on temperacoat / temperagrassa combo
- PCT - added movement check for starry sky
- PCT - setting to disable weaving instant abilities.
- WAR - Should now be able to cast Primal Ruination after Primal Rend