### PR TITLE
Basic support for Gunbreaker in 7.0

### DIFF
--- a/Magitek/Logic/Gunbreaker/SingleTarget.cs
+++ b/Magitek/Logic/Gunbreaker/SingleTarget.cs
@@ -232,6 +232,41 @@ namespace Magitek.Logic.Gunbreaker
             return await Spells.Hypervelocity.Cast(Core.Me.CurrentTarget);
         }
 
+        /********************************************************************************
+         *                            Fourth combo
+         *******************************************************************************/
+        public static async Task<bool> ReignOfBeasts()
+        {
+            if (!Core.Me.HasAura(Auras.ReadyToReign))
+                return false;
+
+            if (!Spells.ReignOfBeasts.IsKnownAndReady())
+                return false;
+
+            return await Spells.ReignOfBeasts.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> NobleBlood()
+        {
+            if (SecondaryComboStage != 1)
+                return false;
+
+            if (!Spells.NobleBlood.IsKnownAndReady())
+                return false;
+
+            return await Spells.NobleBlood.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> LionHeart()
+        {
+            if (SecondaryComboStage != 2)
+                return false;
+
+            if (!Spells.LionHeart.IsKnownAndReady())
+                return false;
+
+            return await Spells.LionHeart.Cast(Core.Me.CurrentTarget);
+        }
 
         /********************************************************************************
          *                                    oGCD 

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -131,6 +131,11 @@ namespace Magitek.Rotations
                 if (await Aoe.BowShock()) return true;
             }
 
+            //Combo 4 (Dawntrail)
+            if (await SingleTarget.ReignOfBeasts()) return true;
+            if (await SingleTarget.NobleBlood()) return true;
+            if (await SingleTarget.LionHeart()) return true;
+
             //Pull or get back aggro with LightningShot
             if (await SingleTarget.LightningShotToPullOrAggro()) return true;
             if (await SingleTarget.LightningShotToDps()) return true;

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -350,6 +350,9 @@ namespace Magitek.Utilities
             LastDanceReady = 3867,
             Damnation = 3832,
 
+            //GNB
+            ReadyToReign = 3840,
+
             //VPR
             Swiftscaled = 3669,
             HindstungVenom = 3647,

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -388,6 +388,9 @@ namespace Magitek.Utilities
         public static readonly SpellData DoubleDown = DataManager.GetSpellData(25760);
         public static readonly SpellData Hypervelocity = DataManager.GetSpellData(25759);
         public static readonly SpellData GunmetalSoul = DataManager.GetSpellData(17105);
+        public static readonly SpellData ReignOfBeasts = DataManager.GetSpellData(36937);
+        public static readonly SpellData NobleBlood = DataManager.GetSpellData(36938);
+        public static readonly SpellData LionHeart = DataManager.GetSpellData(36939);
         #endregion
 
         // MCH


### PR DESCRIPTION
Updated GNB code to add basic support the new spells. It's good enough for solo grinding which is my use case for this. Things to note:

- The new combo is not synced with "No Mercy".
- This does not add the new DOT.