### PR TITLE
DT Fightlogic & other fixes

### DIFF
--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -168,24 +168,12 @@ namespace Magitek.Extensions
                     return false;
             }
 
-            //if (Core.Me.OnPvpMap())
-            //{
-            //    if (Core.Me.IsCasting && Core.Me.CastingSpellId == spell.Id)
-            //        return false;
-
-            //    if (spell != Spells.PvpPlayDrawn)
-            //    {
-            //        if (target.Distance() > spell.Range)
-            //            return false;
-
-            //        if (spell != Spells.PvpPlayDrawn && spell.Cooldown != TimeSpan.Zero)
-            //            return false;
-            //    }
-            //    else
-            //    {
-            //        if (target.Distance() > 30) return false;
-            //    }
-            //}
+            if (Core.Me.OnPvpMap())
+            {
+                // these spells have cast times, but can be cast while moving
+                if (spell == Spells.BlastChargePvp || spell == Spells.PowerfulShotPvp)
+                    return true;
+            }
 
             if (BotManager.Current.IsAutonomous)
             {

--- a/Magitek/Logic/Bard/Pvp.cs
+++ b/Magitek/Logic/Bard/Pvp.cs
@@ -18,9 +18,6 @@ namespace Magitek.Logic.Bard
             if(!Spells.PowerfulShotPvp.CanCast())
                 return false;
 
-            if (MovementManager.IsMoving)
-                return false;
-
             if(Core.Me.HasAura(Auras.Guard))
                 return false;
 

--- a/Magitek/Logic/Paladin/Defensive.cs
+++ b/Magitek/Logic/Paladin/Defensive.cs
@@ -61,7 +61,10 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.CurrentHealthPercent > PaladinSettings.Instance.SentinelHp)
                 return false;
 
-            return await Spells.Sentinel.CastAura(Core.Me, Auras.Sentinel);
+            if (Spells.Guardian.IsKnown())
+                return await Spells.Guardian.CastAura(Core.Me, Auras.Guardian);
+            else
+                return await Spells.Sentinel.CastAura(Core.Me, Auras.Sentinel);
         }
 
         public static async Task<bool> Reprisal()

--- a/Magitek/Logic/Pictomancer/Palette.cs
+++ b/Magitek/Logic/Pictomancer/Palette.cs
@@ -102,6 +102,13 @@ namespace Magitek.Logic.Pictomancer
             if (!PictomancerSettings.Instance.UseMotifs)
                 return false;
 
+            if (ActionResourceManager.Pictomancer.MadeenPortraitReady
+                || ActionResourceManager.Pictomancer.MooglePortraitReady)
+                return false;
+
+            if (Utilities.Routines.Pictomancer.CheckTTDIsEnemyDyingSoon())
+                return false;
+
             var motif = Spells.CreatureMotif.Masked();
             var muse = Spells.LivingMuse.Masked();
 
@@ -136,6 +143,9 @@ namespace Magitek.Logic.Pictomancer
             if (!PictomancerSettings.Instance.UseMogOfTheAges)
                 return false;
 
+            if (!PictomancerSettings.Instance.UseMogDuringStarry && Core.Me.HasAura(Auras.Hyperphantasia))
+                return false;
+
             if (PictomancerSettings.Instance.SaveMogForStarry
                 && Utilities.Routines.Pictomancer.StarryOffCooldownSoon())
                 return false;
@@ -155,6 +165,9 @@ namespace Magitek.Logic.Pictomancer
         public static async Task<bool> WeaponMotif()
         {
             if (!PictomancerSettings.Instance.UseMotifs)
+                return false;
+
+            if (Utilities.Routines.Pictomancer.CheckTTDIsEnemyDyingSoon())
                 return false;
 
             var motif = Spells.WeaponMotif.Masked();
@@ -195,12 +208,15 @@ namespace Magitek.Logic.Pictomancer
             if (hammerAura == null)
                 return false;
 
+            if (!PictomancerSettings.Instance.UseHammerDuringStarry && Core.Me.HasAura(Auras.Hyperphantasia))
+                return false;
+
             var hammerTimeLeft = hammerAura.TimespanLeft.TotalMilliseconds;
             var hammersLeft = hammerAura.Value;
             var hammerCastTime = Spells.HammerStamp.AdjustedCastTime.TotalMilliseconds + Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset;
             var totalHammerCastTime = hammerCastTime * hammersLeft;
 
-            if (PictomancerSettings.Instance.SaveHammerForStarry 
+            if (PictomancerSettings.Instance.SaveHammerForStarry && PictomancerSettings.Instance.UseHammerDuringStarry
                 && Utilities.Routines.Pictomancer.StarryOffCooldownSoon()
                 && totalHammerCastTime > Utilities.Routines.Pictomancer.StarryCooldownRemaining())
                 return false;
@@ -219,6 +235,9 @@ namespace Magitek.Logic.Pictomancer
                 return false;
 
             if (!PictomancerSettings.Instance.UseStarrySky)
+                return false;
+
+            if (Utilities.Routines.Pictomancer.CheckTTDIsEnemyDyingSoon())
                 return false;
 
             var motif = Spells.LandscapeMotif.Masked();

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -67,6 +67,20 @@ namespace Magitek.Logic.Roles
             return await spell.CastAura(target, aura);
         }
 
+        public static async Task<bool> ArmsLength<T>(T settings) where T : TankSettings
+        {
+            if (!settings.UseArmsLength)
+                return false;
+
+            if (Core.Me.CurrentHealthPercent > settings.ArmsLengthPercentage)
+                return false;
+
+            if (!(Combat.Enemies.Count(r => r.TargetGameObject == Core.Me) >= settings.ArmsLengthEnemies))
+                return false;
+
+            return await Spells.ArmsLength.Cast(Core.Me);
+        }
+
         //If the calling class has stuns or interrupts beyond the default tank abilities (e.g.,
         //Paladin has Shield Bash in addition to Low Blow and Interject), pass them in the
         //extraStuns and extraInterrupts parameters

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -81,7 +81,7 @@
     <PackageReference Include="System.Text.Json">
       <Version>8.0.3</Version>
     </PackageReference>
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.638" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.640" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />

--- a/Magitek/Models/Pictomancer/PictomancerSettings.cs
+++ b/Magitek/Models/Pictomancer/PictomancerSettings.cs
@@ -31,12 +31,20 @@ namespace Magitek.Models.Pictomancer
         public bool UseWeaving { get; set; }
 
         [Setting]
+        [DefaultValue(true)]
+        public bool UseHammerDuringStarry { get; set; }
+
+        [Setting]
         [DefaultValue(false)]
         public bool SaveHammerForStarry { get; set; }
 
         [Setting]
         [DefaultValue(false)]
         public bool SaveCometInBlackForStarry { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseMogDuringStarry { get; set; }
 
         [Setting]
         [DefaultValue(false)]

--- a/Magitek/Models/Roles/TankSettings.cs
+++ b/Magitek/Models/Roles/TankSettings.cs
@@ -46,6 +46,18 @@ namespace Magitek.Models.Roles
         [Setting]
         [DefaultValue(10)]
         public int ReprisalHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseArmsLength { get; set; }
+
+        [Setting]
+        [DefaultValue(75)]
+        public int ArmsLengthPercentage { get; set; }
+
+        [Setting]
+        [DefaultValue(4)]
+        public int ArmsLengthEnemies { get; set; }
         #endregion
 
         #region aggro

--- a/Magitek/Resources/BossDictionary.json
+++ b/Magitek/Resources/BossDictionary.json
@@ -1488,5 +1488,40 @@
   "11398": "Barbariccia",
   "10298": "Barbariccia II",
   "11440": "Proto-Carbuncle",
-  "11381": "Hegemone"
+  "11381": "Hegemone",
+  "12723": "Prime Punutiy",
+  "12716": "Drowsie",
+  "12711": "Apollyon",
+  // worqor zormor
+  "12819": "Ryoqor Terteh",
+  "12703": "Kahderyor",
+  "12705": "Gurfurlur",
+  // the skydeep cenote
+  "12755": "Feather Ray",
+  "12888": "Firearms",
+  "12728": "Maulskull",
+  // vanguard
+  "12750": "Vanguard Commander R8",
+  "12757": "Protector",
+  "12752": "Zander the Snakeskinner",
+  // origenics
+  "12741": "Herpekaris",
+  "12693": "Deceiver",
+  "12695": "Ambrose the Undeparted",
+  // alexandria
+  "12844": "Antivirus X",
+  "12864": "Amalgam",
+  "12729": "Eliminator",
+  // the strayborough deadwalk
+  "13073": "His Royal Headness Leonogg 1",
+  "12760": "Jack in the Pot",
+  "12763": "Traumerei",
+  // tender valley
+  "12889": "Barreltender",
+  "12853": "Anthracite",
+  "12709": "The Greatest Serpent of Tural",
+  // zoraal ja both forms
+  "12881": "Zoraal Ja",
+  "12882": "Zoraal Ja",
+  "12854": "Valigarmanda"
 }

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -81,6 +81,7 @@ namespace Magitek.Rotations
                 if (await Defensive.Execute()) return true;
                 if (await Defensive.Oblation(true)) return true;
                 if (await Defensive.Reprisal()) return true;
+                if (await Tank.ArmsLength(DarkKnightSettings.Instance)) return true;
 
                 if (await SingleTarget.CarveAndSpit()) return true;
                 if (await Aoe.SaltedEarth()) return true;

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -109,6 +109,7 @@ namespace Magitek.Rotations
                 if (await Defensive.Reprisal()) return true;
                 if (await Defensive.HeartofLight()) return true;
                 if (await Defensive.HeartofCorundum()) return true;
+                if (await Tank.ArmsLength(GunbreakerSettings.Instance)) return true;
             }
 
             //oGCD to use with BurstStrike

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -108,6 +108,7 @@ namespace Magitek.Rotations
                     if (await Defensive.Reprisal()) return true;
                     if (await Defensive.Sheltron()) return true;
                     if (await Defensive.DivineVeil()) return true;
+                    if (await Tank.ArmsLength(PaladinSettings.Instance)) return true;
 
                     //Cover
                     if (await Defensive.Intervention()) return true;

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -131,7 +131,9 @@ namespace Magitek.Rotations
 
             // inspiration is on a timer, need to consume those stacks first.
             // don't waste time painting more palettes
-            if (PictomancerSettings.Instance.PaletteDuringStarry || !Core.Me.HasAura(Auras.Hyperphantasia) || Spells.Swiftcast.IsKnownAndReady())
+            if (PictomancerSettings.Instance.PaletteDuringStarry 
+                || !Core.Me.HasAura(Auras.Hyperphantasia) 
+                || (PictomancerSettings.Instance.SwiftcastMotifs && Spells.Swiftcast.IsKnownAndReady()))
             {
                 if (await Palette.LandscapeMotif()) return true;
                 if (await Palette.CreatureMotif()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -104,6 +104,7 @@ namespace Magitek.Rotations
                 if (await Defensive.Vengeance()) return true;
                 if (await Defensive.ShakeItOff()) return true;
                 if (await Buff.NascentFlash()) return true;
+                if (await Tank.ArmsLength(WarriorSettings.Instance)) return true;
 
                 //Cooldowns
                 if (await Buff.InnerRelease()) return true;

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -345,6 +345,7 @@ namespace Magitek.Utilities
             PhantomKamaitachiReady = 2723,
             SupplicationReady = 3827,
             SepulchreReady = 3828,
+            Guardian = 3829,
             ImpactImminent = 3882,
             SacredSight = 3879,
             DivineGrace = 3881,

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -21,6 +21,7 @@ namespace Magitek.Utilities
             Stormblood,
             Shadowbringers,
             Endwalker,
+            Dawntrail
         }
 
         private static readonly Stopwatch FlStopwatch = new Stopwatch();
@@ -205,12 +206,12 @@ namespace Magitek.Utilities
             if (encounter == null)
                 return SetAndReturn();
 
-            enemyLogic = encounter.Enemies.FirstOrDefault(x => Combat.Enemies.Any(y => x.Id == y.NpcId));
+            enemyLogic = encounter.Enemies.FirstOrDefault(x => Combat.Enemies.Any(y => x.Id == y.NpcId), encounter.Enemies.First());
 
             if (enemyLogic == null)
                 return SetAndReturn();
 
-            enemy = Combat.Enemies.FirstOrDefault(y => enemyLogic.Id == y.NpcId);
+            enemy = Combat.Enemies.FirstOrDefault(y => enemyLogic.Id == y.NpcId, Combat.Enemies.First());
 
             return SetAndReturn();
 
@@ -5551,7 +5552,532 @@ namespace Magitek.Utilities
                     }
                 }
             },
-            
+
+            #endregion
+
+            #region: Dawntrail Dungeons
+            new Encounter {
+                ZoneId = ZoneId.Ihuykatumu,
+                Name = "Dungeon: Ihuykatumu",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12723,
+                        Name = "Prime Punutiy",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36492, // punuti press
+                            36506, // song of the punutiy
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12716,
+                        Name = "Drowsie",
+                        TankBusters = new List<uint>() {
+                            39132, // uppercut
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            // Add Aoes here if available
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12711,
+                        Name = "Apollyon",
+                        TankBusters = new List<uint>() {
+                            36347, // blade
+                            36356, // blade
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36341, // high wind
+                            36352, // thunder iii
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.WorqorZormor,
+                Name = "Dungeon: Worqor Zormor",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12819,
+                        Name = "Ryoqor Terteh",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36279, // frosting fracas aoe
+                            36713, // sparling sprinkling
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12703,
+                        Name = "Kahderyor",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36282, // wind unbound
+                            36285, // crystalline crush
+                            36283, // earthen shot
+                            36291, // seed crystals
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12705,
+                        Name = "Gurfurlur",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36269, // heaving haymaker
+                            36313, // sledgehammer
+                        },
+                        BigAoes = new List<uint>() {
+                            36320, // enduring glory
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.TheSkydeepCenote,
+                Name = "Dungeon: The Skydeep Cenote",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12755,
+                        Name = "Feather Ray",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36739, // immersion
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12888,
+                        Name = "Firearms",
+                        TankBusters = new List<uint>() {
+                            36447, // pummel
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36448, // dynamic dominance
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12728,
+                        Name = "Maulskull",
+                        TankBusters = new List<uint>() {
+                            39121, // wrought fire
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36675, // skullcrush
+                            36687, // deep thunder
+                            36711, // ashlayer
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.Vanguard,
+                Name = "Dungeon: Vanguard",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12750,
+                        Name = "Vanguard Commander R8",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36571, // electrowave
+                            36572, // electrosurge
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12757,
+                        Name = "Protector",
+                        TankBusters = new List<uint>() {
+                            37162, // rapid thunder
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            37161, // electrowave
+                            37345, // heavy blast cannon
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12752,
+                        Name = "Zander the Snakeskinner",
+                        TankBusters = new List<uint>() {
+                            36595, // saber rush
+                            36597, // shade shot
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36594, // electrothermia
+                            36596, // screech
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.Origenics,
+                Name = "Dungeon: Origenics",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12741,
+                        Name = "Herpekaris",
+                        TankBusters = new List<uint>() {
+                            36518, // convulsive crush
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36519, // strident shriek
+                            36473, // collective agony
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12693,
+                        Name = "Deceiver",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36371, // electrowave
+                            36367, // surge
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12695,
+                        Name = "Ambrose the Undeparted",
+                        TankBusters = new List<uint>() {
+                            36437, // voltic slash
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36436, // psychic wave
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.Alexandria,
+                Name = "Dungeon: Alexandria",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12844,
+                        Name = "Antivirus X",
+                        TankBusters = new List<uint> {
+                        },
+                        SharedTankBusters = null,
+                        Aoes = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 12864,
+                        Name = "Amalgam",
+                        TankBusters = new List<uint> {
+                        },
+                        SharedTankBusters = null,
+                        Aoes = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 12729,
+                        Name = "Eliminator",
+                        TankBusters = new List<uint> {
+                        },
+                        SharedTankBusters = null,
+                        Aoes = new List<uint> {
+                        },
+                        BigAoes = null
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.TheStrayboroughDeadwalk,
+                Name = "Dungeon: The Strayborough Deadwalk",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 13073,
+                        Name = "His Royal Headness Leonogg 1",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36529, // malicious mist
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12760,
+                        Name = "Jack in the Pot",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36725, // sordid scream
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12763,
+                        Name = "Traumerei",
+                        TankBusters = new List<uint>() {
+                            // Add TankBusters here if available
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            37168, // malicious mist
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.TenderValley,
+                Name = "Dungeon: Tender Valley",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12889,
+                        Name = "Barreltender",
+                        TankBusters = new List<uint>() {
+                            39242, // tender fury
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            37391, // succulent stomp
+                            37392, // barbed bellow
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12853,
+                        Name = "Anthracite",
+                        TankBusters = new List<uint>() {
+                            38467, // chimney smack
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36556, // carbonaceous combustion
+                            36554, // burning coals
+                            36542, // anthrabomb
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    },
+                    new Enemy {
+                        Id = 12709,
+                        Name = "The Greatest Serpent of Tural",
+                        TankBusters = new List<uint>() {
+                            36744, // screes of fury
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // Add SharedTankBusters here if available
+                        },
+                        Aoes = new List<uint>() {
+                            36748, // dubious tulidisaster
+                            36743, // moist summoning
+                        },
+                        BigAoes = new List<uint>() {
+                            // Add BigAoes here if available
+                        }
+                    }
+                }
+            },  
+            #endregion           
+
+            #region: Dawntrail Extreme Trials
+            new Encounter {
+                ZoneId = ZoneId.WorqorLarDorExtreme,
+                Name = "Trial: Valigarmanda (Extreme)",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12854,
+                        Name = "Valigarmanda",
+                        TankBusters = new List<uint>() {
+                            
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            0x8ffb, // ice talon
+                            0x8ffd, // ruinfall tower
+                        },
+                        Aoes = new List<uint>() {
+                            0x8fd4, // skyruin fire
+                            0x8fd2, // skyruin ice
+                            0x8fe7, // triscourge
+                            0x9005, // calamitous cry
+                            0x8fff, // ruinfall knockback
+                        },
+                        BigAoes = new List<uint>() {
+                            0x8fda, // disaster zone
+                            0x9692, // ruin foretold
+                            0x9008, 0x924c, 0x924e, 0x924f // tulidisasters
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.EverkeepExtreme,
+                Name = "Trial: Zoraal Ja (Extreme)",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 12881,
+                        Name = "Zoraal Ja",
+                        TankBusters = new List<uint>() {
+                            0x993e, // bitter whirlwind
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            0x993c, // regicidal rage
+                        },
+                        Aoes = new List<uint>() {
+                            0x9398, // actualize
+                            0x9374, // duty's edge
+                        },
+                        BigAoes = new List<uint>() {
+                            0x9397, // dawn of an age
+                        }
+                    },
+                    new Enemy {
+                        Id = 12882,
+                        Name = "Zoraal Ja",
+                        TankBusters = new List<uint>() {
+                            0x993e, // bitter whirlwind
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            0x993c, // regicidal rage
+                        },
+                        Aoes = new List<uint>() {
+                            0x9398, // actualize
+                            0x9374, // duty's edge
+                        },
+                        BigAoes = new List<uint>() {
+                            0x9397, // dawn of an age
+                        }
+                    }
+                }
+            },
             #endregion
         };
 
@@ -6085,7 +6611,21 @@ namespace Magitek.Utilities
                 WorthyOfHisBack = 1014,
                 Xelphatol = 572,
                 Yanxia = 614,
-                Zadnor = 975;
+                Zadnor = 975,
+                Alexandria = 1199,
+                Everkeep = 1200,
+                EverkeepExtreme = 1201,
+                Ihuykatumu = 1167,
+                Kozamauka = 1188,
+                LivingMemory = 1192,
+                Origenics = 1208,
+                TenderValley = 1203,
+                TheSkydeepCenote = 1194,
+                Vanguard = 1198,
+                WorqorLarDor = 1195,
+                WorqorLarDorExtreme = 1196,
+                WorqorZormor = 1193,
+                TheStrayboroughDeadwalk = 1204;
         }
     }
 }

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -561,6 +561,7 @@ namespace Magitek.Utilities
         public static readonly SpellData BladeOfHonor = DataManager.GetSpellData(36922);
         public static readonly SpellData LastBastion = DataManager.GetSpellData(199);
         public static readonly SpellData Imperator = DataManager.GetSpellData(36921);
+        public static readonly SpellData Guardian = DataManager.GetSpellData(36920);
         #endregion
 
         // RDM

--- a/Magitek/Views/UserControls/DarkKnight/Defensives.xaml
+++ b/Magitek/Views/UserControls/DarkKnight/Defensives.xaml
@@ -47,6 +47,8 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition />
@@ -87,6 +89,21 @@
                                       Value="{Binding DarkKnightSettings.RampartHpPercentage, Mode=TwoWay}" />
                     <TextBlock Grid.Row="5" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
+                    <CheckBox Grid.Row="6" Grid.Column="0" Content="Arms Length" IsChecked="{Binding DarkKnightSettings.UseArmsLength, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="6"
+                          Grid.Column="1"
+                          Margin="0,3"
+                          MaxValue="100"
+                          MinValue="1"
+                          Value="{Binding DarkKnightSettings.ArmsLengthPercentage, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="6" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                    <controls:Numeric Grid.Row="6"
+                           Grid.Column="3"
+                           Margin="0,3"
+                           MaxValue="100"
+                           MinValue="1"
+                           Value="{Binding DarkKnightSettings.ArmsLengthEnemies, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="6" Grid.Column="4" Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
                 </Grid>
 
             </StackPanel>

--- a/Magitek/Views/UserControls/Gunbreaker/Defensives.xaml
+++ b/Magitek/Views/UserControls/Gunbreaker/Defensives.xaml
@@ -43,6 +43,8 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition />
@@ -77,6 +79,22 @@
                     <CheckBox Grid.Row="5" Grid.Column="0" Content="Nebula" IsChecked="{Binding GunbreakerSettings.UseNebula, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="5" Grid.Column="1" Margin="0,3,0,0" MaxValue="100" MinValue="1" Value="{Binding GunbreakerSettings.NebulaHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="5" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+
+                    <CheckBox Grid.Row="6" Grid.Column="0" Content="Arms Length" IsChecked="{Binding GunbreakerSettings.UseArmsLength, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="6"
+                            Grid.Column="1"
+                            Margin="0,3"
+                            MaxValue="100"
+                            MinValue="1"
+                            Value="{Binding GunbreakerSettings.ArmsLengthPercentage, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="6" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                    <controls:Numeric Grid.Row="6"
+                           Grid.Column="3"
+                           Margin="0,3"
+                           MaxValue="100"
+                           MinValue="1"
+                           Value="{Binding GunbreakerSettings.ArmsLengthEnemies, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="6" Grid.Column="4" Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
                 </Grid>
             </StackPanel>
         </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/Paladin/Defensives.xaml
+++ b/Magitek/Views/UserControls/Paladin/Defensives.xaml
@@ -47,6 +47,8 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition />
@@ -102,6 +104,22 @@
                                       MinValue="1"
                                       Value="{Binding PaladinSettings.ReprisalHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="4" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+
+                    <CheckBox Grid.Row="5" Grid.Column="0" Content="Arms Length" IsChecked="{Binding PaladinSettings.UseArmsLength, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="5"
+                              Grid.Column="1"
+                                      Margin="0,3"
+                                      MaxValue="100"
+                                      MinValue="1"
+                                      Value="{Binding PaladinSettings.ArmsLengthPercentage, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="5" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                    <controls:Numeric Grid.Row="5"
+                                       Grid.Column="3"
+                                       Margin="0,3"
+                                       MaxValue="100"
+                                       MinValue="1"
+                                       Value="{Binding PaladinSettings.ArmsLengthEnemies, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="5" Grid.Column="4" Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
                 </Grid>
 
             </StackPanel>

--- a/Magitek/Views/UserControls/Pictomancer/Palettes.xaml
+++ b/Magitek/Views/UserControls/Pictomancer/Palettes.xaml
@@ -97,12 +97,14 @@
 
                 <StackPanel Orientation="Vertical">
                     <StackPanel Orientation="Horizontal">
+                        <CheckBox Margin="5" Content=" Use Hammers During Starry " IsChecked="{Binding PictomancerSettings.UseHammerDuringStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                         <CheckBox Margin="5" Content=" Save Hammers for Starry " IsChecked="{Binding PictomancerSettings.SaveHammerForStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Margin="5" Content=" Save Comet for Starry " IsChecked="{Binding PictomancerSettings.SaveCometInBlackForStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
+                        <CheckBox Margin="5" Content=" Use Mog / Madeen During Starry " IsChecked="{Binding PictomancerSettings.UseMogDuringStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                         <CheckBox Margin="5" Content=" Save Mog / Madeen for Starry " IsChecked="{Binding PictomancerSettings.SaveMogForStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
                 </StackPanel>

--- a/Magitek/Views/UserControls/Warrior/Defensives.xaml
+++ b/Magitek/Views/UserControls/Warrior/Defensives.xaml
@@ -44,6 +44,8 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition />
@@ -114,8 +116,24 @@
                       MinValue="1"
                       Value="{Binding WarriorSettings.DamnationHpPercentage, Mode=TwoWay}" />
                     <TextBlock Grid.Row="7" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+
+                    <CheckBox Grid.Row="8" Grid.Column="0" Content="Arms Length" IsChecked="{Binding WarriorSettings.UseArmsLength, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Row="8"
+                      Grid.Column="1"
+                      Margin="0,3"
+                      MaxValue="100"
+                      MinValue="1"
+                      Value="{Binding WarriorSettings.ArmsLengthPercentage, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="8" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                    <controls:Numeric Grid.Row="8"
+                       Grid.Column="3"
+                       Margin="0,3"
+                       MaxValue="100"
+                       MinValue="1"
+                       Value="{Binding WarriorSettings.ArmsLengthEnemies, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="8" Grid.Column="4" Style="{DynamicResource TextBlockDefault}" Text=" Enemies" />
                 </Grid>
-            </StackPanel>
+            </StackPanel>            
         </controls:SettingsBlock>
 
     </StackPanel>


### PR DESCRIPTION
- Add majority of DT fightlogic and boss ids
- Fix MCH & BRD basic PVP walk & shoot ability
- Add ArmsLength as a defensive to all Tanks
- PCT add option for ignoring motifs during starry to hit rainbow bright
- PCT prevent overwriting mog or madeen with new creature motifs
- PLD fix lockup when using Guardian