### PR TITLE
Various Improvements (Weaving, Cooldowns, Spell ready checks). 

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -318,7 +318,7 @@ namespace Magitek.Extensions
             {
                 if (!unit.HasAura(aura)) return TankImmunityCheck.HealThem;
                 var result = unit.CharacterAuras.Any(
-                    x => x.Id == aura && x.TimespanLeft.Milliseconds <= 2000)
+                    x => x.Id == aura && x.TimespanLeft.TotalMilliseconds <= 2000)
                     ? TankImmunityCheck.HealThem
                     : TankImmunityCheck.DontHealThem;
 

--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -98,7 +98,7 @@ namespace Magitek.Extensions
             return await DoAction(spell, target);
         }
 
-        public static async Task<bool> CastAura(this SpellData spell, GameObject target, uint aura, bool useRefreshTime = false, int refreshTime = 0, bool needAura = true, [CallerMemberName] string caller = null, [CallerLineNumber] int sourceLineNumber = 0, [CallerFilePath] string sourceFilePath = null)
+        public static async Task<bool> CastAura(this SpellData spell, GameObject target, uint aura, bool useRefreshTime = false, int refreshTime = 0, bool needAura = true, GameObject auraTarget = null, [CallerMemberName] string caller = null, [CallerLineNumber] int sourceLineNumber = 0, [CallerFilePath] string sourceFilePath = null)
         {
             if (BaseSettings.Instance.DebugCastingCallerMemberName)
             {
@@ -116,7 +116,7 @@ namespace Magitek.Extensions
             if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving)
                 Core.Me.Face(target);
 
-            return await DoAction(spell, target, aura, needAura, useRefreshTime, refreshTime);
+            return await DoAction(spell, target, aura, needAura, useRefreshTime, refreshTime, auraTarget: auraTarget);
         }
 
         public static async Task<bool> Heal(this SpellData spell, GameObject target, bool healthChecks = true, [CallerMemberName] string caller = null, [CallerLineNumber] int sourceLineNumber = 0, [CallerFilePath] string sourceFilePath = null)
@@ -134,7 +134,7 @@ namespace Magitek.Extensions
             return await DoActionHeal(spell, target, healthChecks);
         }
 
-        public static async Task<bool> HealAura(this SpellData spell, GameObject target, uint aura, bool healthChecks = true, bool needAura = true, bool useRefreshTime = false, int refreshTime = 0, [CallerMemberName] string caller = null, [CallerLineNumber] int sourceLineNumber = 0, [CallerFilePath] string sourceFilePath = null)
+        public static async Task<bool> HealAura(this SpellData spell, GameObject target, uint aura, bool healthChecks = true, bool needAura = true, bool useRefreshTime = false, int refreshTime = 0, GameObject auraTarget = null, [CallerMemberName] string caller = null, [CallerLineNumber] int sourceLineNumber = 0, [CallerFilePath] string sourceFilePath = null)
         {
             if (BaseSettings.Instance.DebugCastingCallerMemberName)
             {
@@ -146,7 +146,7 @@ namespace Magitek.Extensions
                 }
             }
 
-            return await DoActionHeal(spell, target, healthChecks, aura, needAura, useRefreshTime, refreshTime);
+            return await DoActionHeal(spell, target, healthChecks, aura, needAura, useRefreshTime, refreshTime, auraTarget: auraTarget);
         }
 
         private static bool Check(SpellData spell, GameObject target)
@@ -231,7 +231,7 @@ namespace Magitek.Extensions
             return ActionManager.GetMaskedAction(spell.Id);
         }
 
-        private static async Task<bool> DoAction(SpellData spell, GameObject target, uint aura = 0, bool needAura = false, bool useRefreshTime = false, int refreshTime = 0, bool canCastCheck = true)
+        private static async Task<bool> DoAction(SpellData spell, GameObject target, uint aura = 0, bool needAura = false, bool useRefreshTime = false, int refreshTime = 0, bool canCastCheck = true, GameObject auraTarget = null)
         {
             if (!Check(spell, target))
                 return false;
@@ -263,6 +263,7 @@ namespace Magitek.Extensions
             Casting.SpellTarget = target;
             Casting.NeedAura = needAura;
             Casting.Aura = aura;
+            Casting.AuraTarget = auraTarget;
             Casting.UseRefreshTime = useRefreshTime;
             Casting.RefreshTime = refreshTime;
             Casting.CastingTime.Restart();
@@ -281,7 +282,7 @@ namespace Magitek.Extensions
             return true;
         }
 
-        private static async Task<bool> DoActionHeal(SpellData spell, GameObject target, bool healthChecks = true, uint aura = 0, bool needAura = false, bool useRefreshTime = false, int refreshTime = 0)
+        private static async Task<bool> DoActionHeal(SpellData spell, GameObject target, bool healthChecks = true, uint aura = 0, bool needAura = false, bool useRefreshTime = false, int refreshTime = 0, GameObject auraTarget = null)
         {
             if (!Check(spell, target))
                 return false;
@@ -305,6 +306,7 @@ namespace Magitek.Extensions
             Casting.SpellTarget = target;
             Casting.NeedAura = needAura;
             Casting.Aura = aura;
+            Casting.AuraTarget = auraTarget;
             Casting.UseRefreshTime = useRefreshTime;
             Casting.DoHealthChecks = healthChecks;
             Casting.RefreshTime = refreshTime;

--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -337,7 +337,7 @@ namespace Magitek.Extensions
                 if (spell.Charges >= 1)
                     return true;
 
-                var remainingCooldownTime = spell.Cooldown.TotalMilliseconds - (spell.AdjustedCooldown.TotalMilliseconds * spell.MaxCharges - 1);
+                var remainingCooldownTime = spell.Cooldown.TotalMilliseconds - (spell.AdjustedCooldown.TotalMilliseconds * (spell.MaxCharges - (uint)spell.Charges - 1));
 
                 if (!BaseSettings.Instance.UseCastOrQueue)
                 {

--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -332,6 +332,23 @@ namespace Magitek.Extensions
 
         public static bool IsReady(this SpellData spell, int remainingTimeInMs = 0)
         {
+            if (spell.MaxCharges > 1)
+            {
+                if (spell.Charges >= 1)
+                    return true;
+
+                var remainingCooldownTime = spell.Cooldown.TotalMilliseconds - (spell.AdjustedCooldown.TotalMilliseconds * spell.MaxCharges - 1);
+
+                if (!BaseSettings.Instance.UseCastOrQueue)
+                {
+                    return remainingCooldownTime <= remainingTimeInMs;
+                }
+                else
+                {
+                    return remainingCooldownTime <= 500;
+                }
+            }
+
             if (!BaseSettings.Instance.UseCastOrQueue)
             {
                 return spell.Cooldown.TotalMilliseconds <= remainingTimeInMs;
@@ -340,7 +357,6 @@ namespace Magitek.Extensions
             {
                 return spell.Cooldown.TotalMilliseconds <= 500;
             }
-
         }
 
         public static bool IsKnownAndReady(this SpellData spell, int remainingTimeInMs = 0)

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -23,7 +23,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.BarrelStabilizer.IsReady())
                 return false;
 
-         //   if (ActionResourceManager.Machinist.Heat > 50)
+         //   if (ActionResourceManager.Machin\basicaist.Heat > 50)
          //       return false;
 
             if (Spells.Reassemble.IsKnown() && Spells.Reassemble.Charges > 1)

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -52,8 +52,8 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            // Force cast if barrel stabilizer is active
-            if (Core.Me.HasAura(Auras.Hypercharged, true))
+            // Force cast if barrel stabilizer is active and about to expire
+            if (Core.Me.HasAura(Auras.Hypercharged, true, 3000))
                 return await Spells.Hypercharge.Cast(Core.Me);
 
             if (Spells.Wildfire.IsKnownAndReady())
@@ -65,13 +65,13 @@ namespace Magitek.Logic.Machinist
 
             if (MachinistSettings.Instance.DelayHypercharge)
             {
-                if (Spells.Drill.IsKnown() && Spells.Drill.Cooldown.Seconds <= MachinistSettings.Instance.DelayHyperchargeSeconds)
+                if (Spells.Drill.IsKnown() && Spells.Drill.Cooldown.TotalSeconds <= MachinistSettings.Instance.DelayHyperchargeSeconds)
                     return false;
 
-                if (Spells.AirAnchor.IsKnown() && Spells.AirAnchor.Cooldown.Seconds <= MachinistSettings.Instance.DelayHyperchargeSeconds)
+                if (Spells.AirAnchor.IsKnown() && Spells.AirAnchor.Cooldown.TotalSeconds <= MachinistSettings.Instance.DelayHyperchargeSeconds)
                     return false;
 
-                if (Spells.ChainSaw.IsKnown() && Spells.ChainSaw.Cooldown.Seconds <= MachinistSettings.Instance.DelayHyperchargeSeconds)
+                if (Spells.ChainSaw.IsKnown() && Spells.ChainSaw.Cooldown.TotalSeconds <= MachinistSettings.Instance.DelayHyperchargeSeconds)
                     return false;
             }
 
@@ -86,24 +86,24 @@ namespace Magitek.Logic.Machinist
             if (Core.Me.HasAura(Auras.WildfireBuff, true) || Casting.SpellCastHistory.Any(x => x.Spell == Spells.Wildfire))
                 return false;
 
-            if (ActionResourceManager.Machinist.Heat < 50 && ActionResourceManager.Machinist.OverheatRemaining == TimeSpan.Zero)
+            if (!Core.Me.HasAura(Auras.Hypercharged, true) && ActionResourceManager.Machinist.Heat < 50 && ActionResourceManager.Machinist.OverheatRemaining == TimeSpan.Zero)
                 return false;
 
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
             if (MachinistSettings.Instance.DelayWildfire) { 
-                if (Spells.Drill.IsKnown() && Spells.Drill.Cooldown.Seconds <= MachinistSettings.Instance.DelayWildfireSeconds)
+                if (Spells.Drill.IsKnown() && Spells.Drill.Cooldown.TotalSeconds <= MachinistSettings.Instance.DelayWildfireSeconds)
                     return false;
 
-                if (Spells.AirAnchor.IsKnown() && Spells.AirAnchor.Cooldown.Seconds <= MachinistSettings.Instance.DelayWildfireSeconds)
+                if (Spells.AirAnchor.IsKnown() && Spells.AirAnchor.Cooldown.TotalSeconds <= MachinistSettings.Instance.DelayWildfireSeconds)
                     return false;
 
-                if (Spells.ChainSaw.IsKnown() && Spells.ChainSaw.Cooldown.Seconds <= MachinistSettings.Instance.DelayWildfireSeconds)
+                if (Spells.ChainSaw.IsKnown() && Spells.ChainSaw.Cooldown.TotalSeconds <= MachinistSettings.Instance.DelayWildfireSeconds)
                     return false;
             }
 
-            return await Spells.Wildfire.Cast(Core.Me.CurrentTarget);
+            return await Spells.Wildfire.CastAura(Core.Me.CurrentTarget, Auras.WildfireBuff, auraTarget: Core.Me);
         }
 
         public static async Task<bool> Reassemble()
@@ -132,14 +132,14 @@ namespace Magitek.Logic.Machinist
 
             if (Core.Me.ClassLevel >= 58 && Core.Me.ClassLevel < 76)
             {
-                if (MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100))
+                if (MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100))
                     return false;
             }
 
             if (Core.Me.ClassLevel >= 76 && Core.Me.ClassLevel < 90)
             {
-                if ((MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100))
-                    && (MachinistSettings.Instance.UseHotAirAnchor && !Spells.AirAnchor.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100)))
+                if ((MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100))
+                    && (MachinistSettings.Instance.UseHotAirAnchor && !Spells.AirAnchor.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100)))
                     return false;
             }
 
@@ -147,11 +147,12 @@ namespace Magitek.Logic.Machinist
             {
                 if (Spells.Reassemble.Charges >= 1)
                 {
-                    if (MachinistSettings.Instance.UseDrill && Spells.Drill.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100)
-                        || MachinistSettings.Instance.UseHotAirAnchor && Spells.AirAnchor.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100)
-                        || MachinistSettings.Instance.UseChainSaw && Spells.ChainSaw.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100))
+                    if (MachinistSettings.Instance.UseDrill && MachinistSettings.Instance.UseReassembleOnDrill && Spells.Drill.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100)
+                        || MachinistSettings.Instance.UseHotAirAnchor && MachinistSettings.Instance.UseReassembleOnAA && Spells.AirAnchor.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100)
+                        || MachinistSettings.Instance.UseChainSaw && MachinistSettings.Instance.UseReassembleOnChainSaw && Spells.ChainSaw.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100)
+                        || MachinistSettings.Instance.UseChainSaw && MachinistSettings.Instance.UseReassembleOnChainSaw && Spells.Excavator.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds - 100))
                     {
-                        return await Spells.Reassemble.Cast(Core.Me);
+                        return await Spells.Reassemble.CastAura(Core.Me, Auras.Reassembled);
                     }
                     else
                         return false;
@@ -160,7 +161,7 @@ namespace Magitek.Logic.Machinist
                     return false;
             }
 
-            return await Spells.Reassemble.Cast(Core.Me);
+            return await Spells.Reassemble.CastAura(Core.Me, Auras.Reassembled);
         }
 
         public static async Task<bool> UsePotion()

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -37,7 +37,7 @@ namespace Magitek.Logic.Machinist
 
         public static async Task<bool> Hypercharge()
         {
-            if (Core.Me.ClassLevel < 65)
+            if (Core.Me.ClassLevel < Spells.Hypercharge.LevelAcquired)
                 return false;
 
             if (!MachinistSettings.Instance.UseHypercharge)

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -126,14 +126,14 @@ namespace Magitek.Logic.Machinist
 
             if (Core.Me.ClassLevel >= 58 && Core.Me.ClassLevel < 76)
             {
-                if (MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady() && Spells.Drill.Cooldown.TotalMilliseconds - 100 >= MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds)
+                if (MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100))
                     return false;
             }
 
             if (Core.Me.ClassLevel >= 76 && Core.Me.ClassLevel < 90)
             {
-                if ((MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady() && Spells.Drill.Cooldown.TotalMilliseconds - 100 >= MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds)
-                    && (MachinistSettings.Instance.UseHotAirAnchor && !Spells.AirAnchor.IsKnownAndReady() && Spells.AirAnchor.Cooldown.TotalMilliseconds - 100 >= MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds))
+                if ((MachinistSettings.Instance.UseDrill && !Spells.Drill.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100))
+                    && (MachinistSettings.Instance.UseHotAirAnchor && !Spells.AirAnchor.IsKnownAndReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100)))
                     return false;
             }
 

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -29,7 +29,7 @@ namespace Magitek.Logic.Machinist
             if (Spells.Reassemble.IsKnown() && Spells.Reassemble.Charges > 1)
                 return false;
 
-            if (Spells.Wildfire.Cooldown.Milliseconds > 0 && Spells.Wildfire.Cooldown.Milliseconds <= 6000)
+            if (Spells.Wildfire.Cooldown.TotalMilliseconds > 0 && Spells.Wildfire.Cooldown.TotalMilliseconds <= 6000)
                 return false;
 
             return await Spells.BarrelStabilizer.Cast(Core.Me);
@@ -52,13 +52,16 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
+            // Force cast if barrel stabilizer is active
+            if (Core.Me.HasAura(Auras.Hypercharged, true))
+                return await Spells.Hypercharge.Cast(Core.Me);
+
             if (Spells.Wildfire.IsKnownAndReady())
                 return false;
 
-            //Force cast during wildfire
+            // Force cast during wildfire
             if (Spells.Wildfire.IsKnown() && (Casting.LastSpell == Spells.Wildfire || Core.Me.HasAura(Auras.WildfireBuff, true)))
                 return await Spells.Hypercharge.Cast(Core.Me);
-
 
             if (MachinistSettings.Instance.DelayHypercharge)
             {
@@ -111,6 +114,9 @@ namespace Magitek.Logic.Machinist
             if (Spells.Reassemble.Charges < 1)
                 return false;
 
+            if (Core.Me.HasAura(Auras.Reassembled))
+                return false;
+
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
@@ -120,7 +126,7 @@ namespace Magitek.Logic.Machinist
 
             if (Core.Me.ClassLevel < 58)
             {
-                if (ActionManager.LastSpell != MachinistRoutine.HeatedSlugShot)
+                if (ActionManager.LastSpell == MachinistRoutine.HeatedSlugShot)
                     return false;
             }
 
@@ -139,19 +145,19 @@ namespace Magitek.Logic.Machinist
 
             if (Core.Me.ClassLevel >= 90)
             {
-                if (Spells.Reassemble.Charges >= Spells.Reassemble.MaxCharges)
+                if (Spells.Reassemble.Charges >= 1)
                 {
-                    if (MachinistSettings.Instance.UseDrill && Spells.Drill.IsReady(3000)
-                        || MachinistSettings.Instance.UseHotAirAnchor && Spells.AirAnchor.IsReady(3000)
-                        || MachinistSettings.Instance.UseChainSaw && Spells.ChainSaw.IsReady(3000))
+                    if (MachinistSettings.Instance.UseDrill && Spells.Drill.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100)
+                        || MachinistSettings.Instance.UseHotAirAnchor && Spells.AirAnchor.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100)
+                        || MachinistSettings.Instance.UseChainSaw && Spells.ChainSaw.IsReady((int)MachinistRoutine.HeatedSplitShot.Cooldown.TotalMilliseconds + 100))
+                    {
                         return await Spells.Reassemble.Cast(Core.Me);
-                } 
-                else
-                {
-                    if (MachinistSettings.Instance.UseChainSaw && !Spells.ChainSaw.IsReady(2000))
+                    }
+                    else
                         return false;
                 }
-
+                else
+                    return false;
             }
 
             return await Spells.Reassemble.Cast(Core.Me);

--- a/Magitek/Logic/Machinist/Cooldowns.cs
+++ b/Magitek/Logic/Machinist/Cooldowns.cs
@@ -23,7 +23,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.BarrelStabilizer.IsReady())
                 return false;
 
-         //   if (ActionResourceManager.Machin\basicaist.Heat > 50)
+         //   if (ActionResourceManager.Machinist.Heat > 50)
          //       return false;
 
             if (Spells.Reassemble.IsKnown() && Spells.Reassemble.Charges > 1)

--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -39,10 +39,10 @@ namespace Magitek.Logic.Machinist
             if (!MachinistSettings.Instance.UseAoe)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Reassembled))
+            if (Core.Me.EnemiesInCone(12) < MachinistSettings.Instance.BioBlasterEnemyCount)
                 return false;
 
-            if (Core.Me.EnemiesInCone(12) < MachinistSettings.Instance.BioBlasterEnemyCount)
+            if (Core.Me.CurrentTarget.HasAura(Auras.Bioblaster, true))
                 return false;
 
             return await Spells.Bioblaster.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -102,26 +102,28 @@ namespace Magitek.Logic.Machinist
             if (!MachinistSettings.Instance.UseRicochet)
                 return false;
 
-            if (Casting.LastSpell == Spells.Wildfire || Casting.LastSpell == Spells.Hypercharge || Casting.LastSpell == Spells.Ricochet)
+            var spell = Spells.Ricochet.Masked();
+
+            if (Casting.LastSpell == Spells.Wildfire || Casting.LastSpell == Spells.Hypercharge || Casting.LastSpell == spell)
                 return false;
 
-            if (Spells.Wildfire.IsKnownAndReady() && Spells.Hypercharge.IsKnownAndReady() && Spells.Ricochet.Charges < 1.5f)
+            if (Spells.Wildfire.IsKnownAndReady() && Spells.Hypercharge.IsKnownAndReady() && spell.Charges < 1.5f)
                 return false;
 
-            if (Core.Me.ClassLevel >= 45)
+            if (Core.Me.ClassLevel >= Spells.Wildfire.LevelAcquired)
             {
-                if (Spells.Ricochet.Charges < 1.5f && Spells.Wildfire.IsKnownAndReady(2000))
+                if (spell.Charges < 1.5f && Spells.Wildfire.IsKnownAndReady(2000))
                     return false;
 
                 // Do not run Rico if an hypercharge is almost ready and not enough charges available for Rico and Gauss
                 if (ActionResourceManager.Machinist.Heat > 40 || Spells.Hypercharge.IsKnownAndReady())
                 {
-                    if (Spells.Ricochet.Charges < 1.5f && Spells.GaussRound.Charges < 0.5f)
+                    if (spell.Charges < 1.5f && Spells.GaussRound.Masked().Charges < 0.5f)
                         return false;
                 }
             }
 
-            return await Spells.Ricochet.Cast(Core.Me.CurrentTarget);
+            return await spell.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> ChainSaw()

--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -137,7 +137,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.WildfireBuff))
+            if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
                 return false;
 
             /*
@@ -166,7 +166,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.WildfireBuff))
+            if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
                 return false;
 
             return await Spells.Excavator.Cast(Core.Me.CurrentTarget);
@@ -183,7 +183,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.WildfireBuff))
+            if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
                 return false;
 
             return await Spells.FullMetalField.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Machinist/SingleTarget.cs
+++ b/Magitek/Logic/Machinist/SingleTarget.cs
@@ -162,26 +162,28 @@ namespace Magitek.Logic.Machinist
             if (!MachinistSettings.Instance.UseGaussRound)
                 return false;
 
-            if (Casting.LastSpell == Spells.Wildfire || Casting.LastSpell == Spells.Hypercharge || Casting.LastSpell == Spells.Ricochet)
+            var spell = Spells.GaussRound.Masked();
+
+            if (Casting.LastSpell == Spells.Wildfire || Casting.LastSpell == Spells.Hypercharge || Casting.LastSpell == spell)
                 return false;
 
-            if (Spells.Wildfire.IsKnownAndReady() && Spells.Hypercharge.IsKnownAndReady() && Spells.GaussRound.Charges < 1.5f)
+            if (Spells.Wildfire.IsKnownAndReady() && Spells.Hypercharge.IsKnownAndReady() && spell.Charges < 1.5f)
                 return false;
 
             if (Core.Me.ClassLevel >= 45)
             {
-                if (Spells.GaussRound.Charges < 1.5f && Spells.Wildfire.IsKnownAndReady(2000))
+                if (spell.Charges < 1.5f && Spells.Wildfire.IsKnownAndReady(2000))
                     return false;
 
                 // Do not run Gauss if an hypercharge is almost ready and not enough charges available for Rico and Gauss
                 if (ActionResourceManager.Machinist.Heat > 40 || Spells.Hypercharge.IsKnownAndReady())
                 {
-                    if (Spells.GaussRound.Charges < 1.5f && Spells.Ricochet.Charges < 0.5f)
+                    if (spell.Charges < 1.5f && Spells.Ricochet.Masked().Charges < 0.5f)
                         return false;
                 }
             }
 
-            return await Spells.GaussRound.Cast(Core.Me.CurrentTarget);
+            return await spell.Cast(Core.Me.CurrentTarget);
         }
     }
 }

--- a/Magitek/Logic/Machinist/SingleTarget.cs
+++ b/Magitek/Logic/Machinist/SingleTarget.cs
@@ -94,7 +94,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.WildfireBuff))
+            if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
                 return false;
 
             /*
@@ -127,7 +127,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.WildfireBuff))
+            if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
                 return false;
 
             /*

--- a/Magitek/Logic/Machinist/SingleTarget.cs
+++ b/Magitek/Logic/Machinist/SingleTarget.cs
@@ -31,7 +31,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Reassembled))
+            if (Core.Me.HasAura(Auras.Reassembled) && Spells.Drill.IsKnown())
                 return false;
 
             return await MachinistRoutine.HeatedSplitShot.Cast(Core.Me.CurrentTarget);
@@ -54,7 +54,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Reassembled))
+            if (Core.Me.HasAura(Auras.Reassembled) && Spells.Drill.IsKnown())
                 return false;
 
             return await MachinistRoutine.HeatedSlugShot.Cast(Core.Me.CurrentTarget);
@@ -77,7 +77,7 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining > TimeSpan.Zero)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Reassembled))
+            if (Core.Me.HasAura(Auras.Reassembled) && Spells.Drill.IsKnown())
                 return false;
 
             return await MachinistRoutine.HeatedCleanShot.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Paladin/Aoe.cs
+++ b/Magitek/Logic/Paladin/Aoe.cs
@@ -24,7 +24,7 @@ namespace Magitek.Logic.Paladin
             if (!PaladinSettings.Instance.UseCircleOfScorn)
                 return false;
 
-            if (PaladinSettings.Instance.SaveCircleOfScorn && Spells.FightorFlight.Cooldown.Seconds <= PaladinSettings.Instance.SaveCircleOfScornMseconds)
+            if (PaladinSettings.Instance.SaveCircleOfScorn && Spells.FightorFlight.Cooldown.TotalSeconds <= PaladinSettings.Instance.SaveCircleOfScornMseconds)
                 return false;
 
             if (Spells.Requiescat.IsKnownAndReady())
@@ -75,7 +75,7 @@ namespace Magitek.Logic.Paladin
             if (!PaladinSettings.Instance.UseExpiacion)
                 return false;
 
-            if (PaladinSettings.Instance.SaveCircleOfScorn && Spells.FightorFlight.Cooldown.Seconds <= PaladinSettings.Instance.SaveCircleOfScornMseconds)
+            if (PaladinSettings.Instance.SaveCircleOfScorn && Spells.FightorFlight.Cooldown.TotalSeconds <= PaladinSettings.Instance.SaveCircleOfScornMseconds)
                 return false;
 
             return await PaladinRoutine.Expiacion.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Pictomancer/Pvp.cs
+++ b/Magitek/Logic/Pictomancer/Pvp.cs
@@ -88,7 +88,7 @@ namespace Magitek.Logic.Pictomancer
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (MovementManager.IsMoving && Core.Me.HasAura(Auras.PvpSubtractivePalette) && Spells.ReleaseSubtractivePalettePvp.CanCast())
+            if (MovementManager.IsMoving && Core.Me.HasAura(Auras.PvpSubtractivePalette) && Spells.ReleaseSubtractivePalettePvp.CanCast() && Spells.PaintWBPvp.Masked().Charges < 1)
                 return await Spells.ReleaseSubtractivePalettePvp.Cast(Core.Me);
 
             if (!MovementManager.IsMoving && !Core.Me.HasAura(Auras.PvpSubtractivePalette) && Spells.SubtractivePalettePvp.CanCast())

--- a/Magitek/Logic/Reaper/Normal/AoE.cs
+++ b/Magitek/Logic/Reaper/Normal/AoE.cs
@@ -26,7 +26,7 @@ namespace Magitek.Logic.Reaper
             if (Utilities.Routines.Reaper.EnemiesAroundPlayer5Yards < ReaperSettings.Instance.WhorlOfDeathTargetCount)
                 return false;
 
-            if (!Combat.Enemies.Any(x => (!x.HasMyAura(Auras.DeathsDesign) || (x.HasMyAura(Auras.DeathsDesign) && !x.HasAura(Auras.DeathsDesign, true, Spells.Slice.AdjustedCooldown.Milliseconds)))
+            if (!Combat.Enemies.Any(x => (!x.HasMyAura(Auras.DeathsDesign) || (x.HasMyAura(Auras.DeathsDesign) && !x.HasAura(Auras.DeathsDesign, true, (int)Spells.Slice.AdjustedCooldown.TotalMilliseconds)))
                                          && x.Distance(Core.Me) <= 5 + Core.Me.CombatReach))
                 return false;
 
@@ -75,7 +75,7 @@ namespace Magitek.Logic.Reaper
             if (Utilities.Routines.Reaper.EnemiesAroundPlayer5Yards < ReaperSettings.Instance.WhorlOfDeathTargetCount)
                 return false;
 
-            if (!Combat.Enemies.Any(x => (!x.HasMyAura(Auras.DeathsDesign) || (x.HasMyAura(Auras.DeathsDesign) && !x.HasAura(Auras.DeathsDesign, true, 30000 - Spells.Slice.AdjustedCooldown.Milliseconds)))
+            if (!Combat.Enemies.Any(x => (!x.HasMyAura(Auras.DeathsDesign) || (x.HasMyAura(Auras.DeathsDesign) && !x.HasAura(Auras.DeathsDesign, true, 30000 - (int)Spells.Slice.AdjustedCooldown.TotalMilliseconds)))
                                          && x.Distance(Core.Me) <= 5 + Core.Me.CombatReach))
                 return false;
 

--- a/Magitek/Logic/Reaper/Normal/Cooldown.cs
+++ b/Magitek/Logic/Reaper/Normal/Cooldown.cs
@@ -27,11 +27,12 @@ namespace Magitek.Logic.Reaper
                 return false;
             if (Utilities.Routines.Reaper.CheckTTDIsEnemyDyingSoon())
                 return false;            
-            var gluttonyCast = await Spells.Gluttony.Cast(Core.Me.CurrentTarget);
-            // wait for Executioner aura, but CastAura only wants CurrentTarget but in this case we need to wait for the aura on the player
-            if (Spells.ExecutionersGibbet.IsKnown() && gluttonyCast)
-                await Coroutine.Wait(3000, () => Core.Me.HasAura(Auras.Executioner, true));
-            return gluttonyCast;
+            
+            // wait for Executioner aura on self to prevent canceling it with another action
+            if (Spells.ExecutionersGibbet.IsKnown())
+                return await Spells.Gluttony.CastAura(Core.Me.CurrentTarget, Auras.Executioner, auraTarget: Core.Me);
+            else
+                return await Spells.Gluttony.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> Enshroud()

--- a/Magitek/Logic/Reaper/Normal/Cooldown.cs
+++ b/Magitek/Logic/Reaper/Normal/Cooldown.cs
@@ -1,3 +1,4 @@
+using Buddy.Coroutines;
 using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
@@ -25,8 +26,12 @@ namespace Magitek.Logic.Reaper
             if (ActionResourceManager.Reaper.ShroudGauge > 80)
                 return false;
             if (Utilities.Routines.Reaper.CheckTTDIsEnemyDyingSoon())
-                return false;
-            return await Spells.Gluttony.Cast(Core.Me.CurrentTarget);
+                return false;            
+            var gluttonyCast = await Spells.Gluttony.Cast(Core.Me.CurrentTarget);
+            // wait for Executioner aura, but CastAura only wants CurrentTarget but in this case we need to wait for the aura on the player
+            if (Spells.ExecutionersGibbet.IsKnown() && gluttonyCast)
+                await Coroutine.Wait(3000, () => Core.Me.HasAura(Auras.Executioner, true));
+            return gluttonyCast;
         }
 
         public static async Task<bool> Enshroud()

--- a/Magitek/Logic/Reaper/Normal/SingleTarget.cs
+++ b/Magitek/Logic/Reaper/Normal/SingleTarget.cs
@@ -27,7 +27,7 @@ namespace Magitek.Logic.Reaper
             if (Utilities.Routines.Reaper.EnemiesAroundPlayer5Yards >= ReaperSettings.Instance.WhorlOfDeathTargetCount)
                 return false;
 
-            if (Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true) && Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true, Spells.Slice.AdjustedCooldown.Milliseconds))
+            if (Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true) && Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true, (int)Spells.Slice.AdjustedCooldown.TotalMilliseconds))
                 return false;
 
             if (Utilities.Routines.Reaper.CheckTTDIsEnemyDyingSoon())
@@ -49,7 +49,7 @@ namespace Magitek.Logic.Reaper
             if (Utilities.Routines.Reaper.EnemiesAroundPlayer5Yards >= ReaperSettings.Instance.WhorlOfDeathTargetCount)
                 return false;
 
-            if (Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true) && Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true, 30000 - Spells.Slice.AdjustedCooldown.Milliseconds))
+            if (Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true) && Core.Me.CurrentTarget.HasAura(Auras.DeathsDesign, true, 30000 - (int)Spells.Slice.AdjustedCooldown.TotalMilliseconds))
                 return false;
 
             if (Utilities.Routines.Reaper.CheckTTDIsEnemyDyingSoon())

--- a/Magitek/Logic/RedMage/Aoe.cs
+++ b/Magitek/Logic/RedMage/Aoe.cs
@@ -28,7 +28,7 @@ namespace Magitek.Logic.RedMage
             if (!InAoeCombo())
             {
                 if (Core.Me.ClassLevel >= Spells.Embolden.LevelAcquired
-                    && Spells.Embolden.Cooldown.Seconds <= 10)
+                    && Spells.Embolden.Cooldown.TotalSeconds <= 10)
                     return false;
 
                 if (Core.Me.EnemiesInCone(8) < RedMageSettings.Instance.AoeEnemies)

--- a/Magitek/Logic/RedMage/SingleTarget.cs
+++ b/Magitek/Logic/RedMage/SingleTarget.cs
@@ -30,7 +30,7 @@ namespace Magitek.Logic.RedMage
                 return false;
 
             if (Core.Me.ClassLevel >= Spells.Embolden.LevelAcquired
-                && Spells.Embolden.Cooldown.Seconds <= 10)
+                && Spells.Embolden.Cooldown.TotalSeconds <= 10)
                 return false;
 
             if (InAoeCombo() || Core.Me.EnemiesInCone(8) >= RedMageSettings.Instance.AoeEnemies)

--- a/Magitek/Logic/Summoner/Aoe.cs
+++ b/Magitek/Logic/Summoner/Aoe.cs
@@ -286,7 +286,7 @@ namespace Magitek.Logic.Summoner
             if (SmnResources.Aetherflow + ArcResources.Aetherflow == 0)
                 return false;
             
-            if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < 2) 
+            if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < 3) 
                 return false;
             
             if (!GlobalCooldown.CanWeave())

--- a/Magitek/Models/Pictomancer/PictomancerSettings.cs
+++ b/Magitek/Models/Pictomancer/PictomancerSettings.cs
@@ -73,7 +73,7 @@ namespace Magitek.Models.Pictomancer
         public bool PaletteDuringStarry { get; set; }
 
         [Setting]
-        [DefaultValue(true)]
+        [DefaultValue(false)]
         public bool SwiftcastMotifs { get; set; }
 
         [Setting]

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -115,7 +115,7 @@ namespace Magitek.Rotations
 
             if (ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero)
             {
-                if (MachinistRoutine.GlobalCooldown.CanWeave())
+                if (MachinistRoutine.GlobalCooldown.CanWeave(1))
                 {
                     //Utility
                     if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
@@ -123,19 +123,19 @@ namespace Magitek.Rotations
 
                     //Pets
                     if (await Pet.RookQueen()) return true;
+                }
 
-                    //Cooldowns
-                    if (await Cooldowns.BarrelStabilizer()) return true;
-                    //if (await Cooldowns.Reassemble()) return true;
-
+                if (MachinistRoutine.GlobalCooldown.CanWeave())
+                {
                     //oGCDs
                     if (await SingleTarget.GaussRound()) return true;
                     if (await MultiTarget.Ricochet()) return true;
                 }
-            } 
+            }
             else
             {
-                if (MachinistRoutine.GlobalCooldown.CanWeave()) {
+                if (MachinistRoutine.GlobalCooldown.CanWeave())
+                {
                     //Utility
                     if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
                     if (await Utility.Tactician()) return true;
@@ -149,9 +149,8 @@ namespace Magitek.Rotations
                     if (await Pet.RookQueenOverdrive()) return true;
 
                     //Cooldowns
-                    if (await Cooldowns.Reassemble()) return true;
-                    if (await Cooldowns.Hypercharge()) return true;
                     if (await Cooldowns.Wildfire()) return true;
+                    if (await Cooldowns.Hypercharge()) return true;
                     if (await Cooldowns.BarrelStabilizer()) return true;
 
                     //oGCDs
@@ -166,6 +165,8 @@ namespace Magitek.Rotations
 
             //Use On CD
             if (await MultiTarget.FullMetalField()) return true;
+            // Intentionally leave reassemble outside of weaving to get reliable reassemble usage
+            if (await Cooldowns.Reassemble()) return true;
             if (await MultiTarget.BioBlaster()) return true;
             if (await SingleTarget.HotAirAnchor()) return true;
             if (await SingleTarget.Drill()) return true;

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -115,7 +115,8 @@ namespace Magitek.Rotations
 
             if (ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero)
             {
-                if (MachinistRoutine.GlobalCooldown.CanWeave(1)) {
+                if (MachinistRoutine.GlobalCooldown.CanWeave())
+                {
                     //Utility
                     if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
                     if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
@@ -126,7 +127,7 @@ namespace Magitek.Rotations
                     //Cooldowns
                     if (await Cooldowns.BarrelStabilizer()) return true;
                     //if (await Cooldowns.Reassemble()) return true;
-                    
+
                     //oGCDs
                     if (await SingleTarget.GaussRound()) return true;
                     if (await MultiTarget.Ricochet()) return true;
@@ -156,7 +157,6 @@ namespace Magitek.Rotations
                     //oGCDs
                     if (await SingleTarget.GaussRound()) return true;
                     if (await MultiTarget.Ricochet()) return true;
-
                 }
             }
 

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -33,6 +33,7 @@ namespace Magitek.Utilities
         public static bool DoHealthChecks;
         public static bool NeedAura;
         public static uint Aura;
+        public static GameObject AuraTarget;
         public static bool UseRefreshTime;
         public static int RefreshTime;
         public static readonly Stopwatch CastingTime = new Stopwatch();
@@ -264,15 +265,17 @@ namespace Magitek.Utilities
 
             if (NeedAura)
             {
+                var auraTarget = AuraTarget ?? SpellTarget;
+
                 if (UseRefreshTime)
-                    await Coroutine.Wait(3000, () => SpellTarget.HasAura(Aura, true, RefreshTime) || MovementManager.IsMoving);
+                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura, true, RefreshTime) || MovementManager.IsMoving);
                 else
                 {
-                    await Coroutine.Wait(3000, () => SpellTarget.HasAura(Aura, true) || MovementManager.IsMoving);
+                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura, true) || MovementManager.IsMoving);
                 }
 
                 if (CastingSpell.AdjustedCastTime == TimeSpan.Zero)
-                    await Coroutine.Wait(3000, () => SpellTarget.HasAura(Aura));
+                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura));
             }
 
             #endregion

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -5860,28 +5860,36 @@ namespace Magitek.Utilities
                     new Enemy {
                         Id = 12844,
                         Name = "Antivirus X",
-                        TankBusters = new List<uint> {
-                        },
+                        TankBusters = null,
                         SharedTankBusters = null,
-                        Aoes = null,
+                        Aoes = new List<uint> {
+                            36384, // quarantine
+                            36387, // cytolysis
+                        },
                         BigAoes = null
                     },
                     new Enemy {
                         Id = 12864,
                         Name = "Amalgam",
                         TankBusters = new List<uint> {
+                            36339, // amalgamight
                         },
                         SharedTankBusters = null,
-                        Aoes = null,
+                        Aoes = new List<uint> {
+                            36337, // electrowave
+                            36323, // disassembly
+                            36332, // superbolt
+                        },
                         BigAoes = null
                     },
                     new Enemy {
                         Id = 12729,
                         Name = "Eliminator",
-                        TankBusters = new List<uint> {
-                        },
+                        TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
+                            36765, // disruption
+                            36779, // overexposure
                         },
                         BigAoes = null
                     }

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -6087,6 +6087,88 @@ namespace Magitek.Utilities
                 }
             },
             #endregion
+
+            #region Dawntrail Normal Raids
+            new Encounter {
+                ZoneId = ZoneId.AacLightHeavyweightM1,
+                Name = "AacLightHeavyweightM1",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 0, // Assuming an ID for Black Cat
+                        Name = "Black Cat",
+                        TankBusters = new List<uint>() {
+                            0x934A, // Biscuit Maker
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x9340, // Bloody Scratch
+                            0x933C, // Clawful
+                            0x9319, // Overshadow
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.AacLightHeavyweightM2,
+                Name = "AacLightHeavyweightM2",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 0, // Assuming an ID for Honey B. Lovely
+                        Name = "Honey B. Lovely",
+                        TankBusters = new List<uint>() {
+                            0x9167, // Honeyed Breeze
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x9164, // Call Me Honey
+                            0x917B, // Honey B. Finale
+                            0x9170, // Drop of Venom
+
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.AacLightHeavyweightM3,
+                Name = "AacLightHeavyweightM3",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 0, // Assuming an ID for Brute Bomber
+                        Name = "Brute Bomber",
+                        TankBusters = new List<uint>() {
+                            0x93D5, // Knuckle Sandwich
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x93D6, // Brutal Impact
+                            0x9429, // Brutal Burn
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    }
+                }
+            },
+
+
+            #endregion
         };
 
         internal class Enemy
@@ -6118,6 +6200,10 @@ namespace Magitek.Utilities
                 ARequiemForHeroes = 830,
                 ASleepDisturbed = 914,
                 ASpectacleForTheAges = 533,
+                AacLightHeavyweightM1 = 1225,
+                AacLightHeavyweightM2 = 1227,
+                AacLightHeavyweightM3 = 1229,
+                AacLightHeavyweightM4 = 1231,
                 AccrueEnmityFromMultipleTargets = 540,
                 Aglaia = 1054,
                 AirForceOne = 832,

--- a/Magitek/Views/UserControls/Machinist/Buffs.xaml
+++ b/Magitek/Views/UserControls/Machinist/Buffs.xaml
@@ -56,6 +56,17 @@
             </StackPanel>
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Use Reassemble on" />
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Drill                    " IsChecked="{Binding MachinistSettings.UseReassembleOnDrill, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Air Anchor                  " IsChecked="{Binding MachinistSettings.UseReassembleOnAA, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="ChainSaw / Excavator" IsChecked="{Binding MachinistSettings.UseReassembleOnChainSaw, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
                 <StackPanel Margin="5" Orientation="Horizontal">


### PR DESCRIPTION
Don't merge I need to thoroughly test the the IsReady change as that affects every single class & routine but I wanted to put this PR out there in case someone else notices MCH not using double drill & such. 

Fixes reassemble and hypercharge on low level content.
Fixes not using double drill and double casting bio blaster on high level content.

Also fixes a bunch of weaving and spell ready calculations for abilities that have multiple charges. 