### PR TITLE
WAR - allow fell cleave below level 90

### DIFF
--- a/Magitek/Logic/Pictomancer/Pvp.cs
+++ b/Magitek/Logic/Pictomancer/Pvp.cs
@@ -114,6 +114,9 @@ namespace Magitek.Logic.Pictomancer
             if (Spells.LivingMusePvp.Masked().Charges < 1 && Core.Me.HasTarget)
                 return false;
 
+            if (WorldManager.ZoneId == 250 && !Core.Me.HasTarget)
+                return false;
+
             return await spell.Cast(Core.Me);
         }
 

--- a/Magitek/Logic/Warrior/SingleTarget.cs
+++ b/Magitek/Logic/Warrior/SingleTarget.cs
@@ -180,7 +180,7 @@ namespace Magitek.Logic.Warrior
             if (Core.Me.ClassLevel > 54)
             {
 
-                if (Core.Me.HasAura(Auras.NascentChaos))
+                if (Core.Me.HasAura(Auras.NascentChaos) && Spells.InnerChaos.IsKnown())
                     return false;
 
                 if (!Core.Me.HasAura(Auras.SurgingTempest))


### PR DESCRIPTION
PCT - no motifs in ship zone