### PR TITLE
Horoscope fix; New feature to prevent swiftcast and Aspected Helios

### DIFF
--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -574,6 +574,9 @@ namespace Magitek.Logic.Astrologian
             if (!Spells.Swiftcast.IsKnownAndReady())
                 return false;
 
+            if (AstrologianSettings.Instance.DiurnalHeliosNoSwiftcast)
+                return false;
+
             if (!await Buff.Swiftcast())
                 return false;
 
@@ -709,6 +712,9 @@ namespace Magitek.Logic.Astrologian
             if (Group.CastableAlliesWithin20.Count(r => r.CurrentHealthPercent <= AstrologianSettings.Instance.HoroscopeHealthPercent) < AoeThreshold)
                 return false;
 
+            if (Group.CastableAlliesWithin20.Count(r => r.HasMyAura(Auras.Horoscope)) >= AoeThreshold)
+                return await AspectedHelios() ? true : await Spells.Helios.Cast(Core.Me);
+
             if (await Spells.Horoscope.Cast(Core.Me))
                 if (!await AspectedHelios())
                     return await Spells.Helios.Cast(Core.Me);
@@ -721,7 +727,7 @@ namespace Magitek.Logic.Astrologian
             if (!AstrologianSettings.Instance.Horoscope)
                 return false;
                         
-            if (Group.CastableAlliesWithin20.Count(r => r.HasAura(Auras.HoroscopeHelios) && r.CurrentHealthPercent <= AstrologianSettings.Instance.HoroscopeHealthPercent) < AoeThreshold)
+            if (Group.CastableAlliesWithin20.Count(r => r.HasMyAura(Auras.HoroscopeHelios) && r.CurrentHealthPercent <= AstrologianSettings.Instance.HoroscopeHealthPercent) < AoeThreshold)
                 return false;
 
             return await Spells.Horoscope.Cast(Core.Me);

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -216,6 +216,10 @@ namespace Magitek.Models.Astrologian
         public float DiurnalHeliosMinManaPercent { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool DiurnalHeliosNoSwiftcast { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool Horoscope { get; set; }
 

--- a/Magitek/Views/UserControls/Astrologian/DiurnalHealing.xaml
+++ b/Magitek/Views/UserControls/Astrologian/DiurnalHealing.xaml
@@ -74,12 +74,18 @@
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Aspected Helios " IsChecked="{Binding AstrologianSettings.DiurnalHelios, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.DiurnalHeliosHealthPercent, Mode=TwoWay}" />
-                <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent and " />
-                <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.DiurnalHeliosMinManaPercent, Mode=TwoWay}" />
-                <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Minimum Mana To Use" />
+            <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Content="Aspected Helios " IsChecked="{Binding AstrologianSettings.DiurnalHelios, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.DiurnalHeliosHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent and " />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.DiurnalHeliosMinManaPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Minimum Mana To Use" />
+                </StackPanel>
+
+                <StackPanel Margin="0,3,0,0" Orientation="Horizontal">
+                    <CheckBox Content="Prevent Usage of Swiftcast Alongside Aspected Helios "  IsChecked="{Binding AstrologianSettings.DiurnalHeliosNoSwiftcast, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
- Fix of AST casting Horoscope by mistake in the `HoroscopePop` function, if there are two AST in a party and one activates horoscope + helios, and the healing conditions are met later after taking damage, then the one that did not cast it will try to "pop" it. (Change from `r.HasAura(Auras.HoroscopeHelios)` to `r.HasMyAura(Auras.HoroscopeHelios)`.
- Adding an additional check in the `Horoscope` function, in which (Aspected) Helios would not be re-cast due to cast cancelling, and as such would never try again to proc Horoscope Helios. With this fix, the check is re-made and the spell re-casted if need be.
- Adding of the new setting and feature `AstrologianSettings.DiurnalHeliosNoSwiftcast` which prevents the usage of swiftcast paired with Aspected Helios, for those in prog who wish to keep their swiftcast for resurrection.