### PR TITLE
FightLogic, PVP, SAM, MCH

### DIFF
--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -44,7 +44,7 @@ namespace Magitek.Extensions
 
             if (target.Distance() > spell.Range)
                 return false;
-
+            
             if (ActionManager.GetPvPComboCurrentActionId(pvpComboId) != spell.Id)
                 return false;
 

--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -94,6 +94,9 @@ namespace Magitek.Logic.Machinist
             if (Core.Me.EnemiesInCone(8) < MachinistSettings.Instance.FlamethrowerEnemyCount)
                 return false;
 
+            if (Spells.FlameThrower.CanCast())
+                Core.Me.CurrentTarget.Face();
+
             return await Spells.Flamethrower.CastAura(Core.Me, Auras.Flamethrower);
         }
 

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Magitek.Models.Account;
 
 namespace Magitek.Logic.Roles
 {
@@ -27,13 +28,15 @@ namespace Magitek.Logic.Roles
                 if (Core.Me.HasAnyAura(defensiveAuras))
                     return false;
 
-                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs, BaseSettings.Instance.FightLogicResponseDelay))
                     return false;
 
                 foreach (var defensiveSpell in defensiveSpells)
                 {
                     if (defensiveSpell.IsKnownAndReady())
                     {
+                        if (BaseSettings.Instance.DebugFightLogic)
+                            Logger.WriteInfo($"[TankDefensive Response] Cast {defensiveSpell.Name}");
                         return await FightLogic.DoAndBuffer(defensiveSpell.Cast(Core.Me));
                     }
                 }
@@ -57,8 +60,11 @@ namespace Magitek.Logic.Roles
                 if (selfAuraCheck && Core.Me.HasAura(aura))
                     return false;
 
-                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs, BaseSettings.Instance.FightLogicResponseDelay))
                     return false;
+
+                if (BaseSettings.Instance.DebugFightLogic)
+                    Logger.WriteInfo($"[SelfShield Response] Cast {spell.Name}");
 
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me));
             }
@@ -84,8 +90,11 @@ namespace Magitek.Logic.Roles
                 if (selfAuraCheck && aura != 0 && Core.Me.HasAura(aura))
                     return false;
 
-                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs, BaseSettings.Instance.FightLogicResponseDelay))
                     return false;
+
+                if (BaseSettings.Instance.DebugFightLogic)
+                    Logger.WriteInfo($"[PartyShield Response] Cast {spell.Name}");
 
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me));
             }
@@ -111,8 +120,11 @@ namespace Magitek.Logic.Roles
                 if (targetAuraCheck && Core.Me.CurrentTarget.HasAura(aura))
                     return false;
 
-                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs, BaseSettings.Instance.FightLogicResponseDelay))
                     return false;
+
+                if (BaseSettings.Instance.DebugFightLogic)
+                    Logger.WriteInfo($"[Debuff Response] Cast {spell.Name} on {Core.Me.CurrentTarget.Name}");
 
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me.CurrentTarget));
             }

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -13,7 +13,7 @@ namespace Magitek.Logic.Roles
 {
     internal class CommonFightLogic
     {
-        public static async Task<bool> FightLogic_TankDefensive(bool useDefensive, SpellData[] defensiveSpells, uint[] defensiveAuras)
+        public static async Task<bool> FightLogic_TankDefensive(bool useDefensive, SpellData[] defensiveSpells, uint[] defensiveAuras, int castTimeRemainingMs = 0)
         {
             if (!useDefensive)
                 return false;
@@ -27,6 +27,9 @@ namespace Magitek.Logic.Roles
                 if (Core.Me.HasAnyAura(defensiveAuras))
                     return false;
 
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                    return false;
+
                 foreach (var defensiveSpell in defensiveSpells)
                 {
                     if (defensiveSpell.IsKnownAndReady())
@@ -38,7 +41,7 @@ namespace Magitek.Logic.Roles
             return false;
         }
 
-        public static async Task<bool> FightLogic_SelfShield(bool useShield, SpellData spell, bool selfAuraCheck = false, uint aura = 0)
+        public static async Task<bool> FightLogic_SelfShield(bool useShield, SpellData spell, bool selfAuraCheck = false, uint aura = 0, int castTimeRemainingMs = 0)
         {
             if (!useShield)
                 return false;
@@ -54,12 +57,15 @@ namespace Magitek.Logic.Roles
                 if (selfAuraCheck && Core.Me.HasAura(aura))
                     return false;
 
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                    return false;
+
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me));
             }
             return false;
         }
 
-        public static async Task<bool> FightLogic_PartyShield(bool useShield, SpellData spell, bool selfAuraCheck = false, uint[] auras = null, uint aura = 0)
+        public static async Task<bool> FightLogic_PartyShield(bool useShield, SpellData spell, bool selfAuraCheck = false, uint[] auras = null, uint aura = 0, int castTimeRemainingMs = 0)
         {
             if (!useShield)
                 return false;
@@ -78,12 +84,15 @@ namespace Magitek.Logic.Roles
                 if (selfAuraCheck && aura != 0 && Core.Me.HasAura(aura))
                     return false;
 
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
+                    return false;
+
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me));
             }
             return false;
         }
 
-        public static async Task<bool> FightLogic_Debuff(bool useDebuff, SpellData spell, bool targetAuraCheck = false, uint aura = 0)
+        public static async Task<bool> FightLogic_Debuff(bool useDebuff, SpellData spell, bool targetAuraCheck = false, uint aura = 0, int castTimeRemainingMs = 0)
         {
             if (!useDebuff)
                 return false;
@@ -100,6 +109,9 @@ namespace Magitek.Logic.Roles
                 || FightLogic.EnemyIsCastingSharedTankBuster() != null)
             {
                 if (targetAuraCheck && Core.Me.CurrentTarget.HasAura(aura))
+                    return false;
+
+                if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs))
                     return false;
 
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me.CurrentTarget));

--- a/Magitek/Logic/Sage/HealFightLogic.cs
+++ b/Magitek/Logic/Sage/HealFightLogic.cs
@@ -29,6 +29,9 @@ namespace Magitek.Logic.Sage
             if (!FightLogic.EnemyIsCastingBigAoe() && !FightLogic.EnemyIsCastingAoe())
                 return false;
 
+            if (!FightLogic.HodlCastTimeRemaining(hodlTillDurationInPct: BaseSettings.Instance.FightLogicResponseDelay))
+                return false;
+
             var useAoEBuffs = Heal.UseAoEHealingBuff(Group.CastableAlliesWithin15);
 
             if (SageSettings.Instance.FightLogic_Kerachole
@@ -129,6 +132,9 @@ namespace Magitek.Logic.Sage
                 if (target == null)
                     return false;
             }
+
+            if (!FightLogic.HodlCastTimeRemaining(hodlTillDurationInPct: BaseSettings.Instance.FightLogicResponseDelay))
+                return false;
 
             if (SageSettings.Instance.FightLogic_Haima
                 && Spells.Haima.IsKnownAndReady()

--- a/Magitek/Logic/Samurai/Aoe.cs
+++ b/Magitek/Logic/Samurai/Aoe.cs
@@ -98,6 +98,9 @@ namespace Magitek.Logic.Samurai
             if (ActionResourceManager.Samurai.Kenki < 25 + SamuraiSettings.Instance.ReservedKenki)
                 return false;
 
+            if (Core.Me.HasAura(Auras.ZanshinReady))
+                return false;
+
             if (SamuraiRoutine.AoeEnemies5Yards < SamuraiSettings.Instance.AoeEnemies)
                 return false;
 
@@ -115,6 +118,9 @@ namespace Magitek.Logic.Samurai
             if (ActionResourceManager.Samurai.Kenki < 25 + SamuraiSettings.Instance.ReservedKenki)
                 return false;
 
+            if (Core.Me.HasAura(Auras.ZanshinReady))
+                return false;
+
             if (!Core.Me.CurrentTarget.InView())
                 return false;
 
@@ -126,7 +132,7 @@ namespace Magitek.Logic.Samurai
 
         public static async Task<bool> Zanshin()
         {
-            if (ActionResourceManager.Samurai.Kenki < 50 + SamuraiSettings.Instance.ReservedKenki)
+            if (ActionResourceManager.Samurai.Kenki < 50)
                 return false;
 
             if (!Core.Me.CurrentTarget.InView())
@@ -186,7 +192,7 @@ namespace Magitek.Logic.Samurai
             if (!SamuraiSettings.Instance.UseKaeshiGoken)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Tendo))
+            if (Spells.TendoKaeshiGoken.IsKnownAndReadyAndCastable())
                 return await Spells.TendoKaeshiGoken.Cast(Core.Me.CurrentTarget);
 
             return await Spells.KaeshiGoken.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Samurai/Buff.cs
+++ b/Magitek/Logic/Samurai/Buff.cs
@@ -64,7 +64,7 @@ namespace Magitek.Logic.Samurai
                 if (SamuraiRoutine.SenCount == 3)
                     return false;
 
-                if (Casting.LastSpell != Spells.KaeshiSetsugekka && Casting.LastSpell != null)
+                if (Spells.KaeshiSetsugekka.IsKnown() && Casting.LastSpell != Spells.KaeshiSetsugekka && Casting.LastSpell != null)
                     return false;
             } 
             else

--- a/Magitek/Logic/Samurai/SingleTarget.cs
+++ b/Magitek/Logic/Samurai/SingleTarget.cs
@@ -265,6 +265,9 @@ namespace Magitek.Logic.Samurai
             if (SamuraiRoutine.AoeEnemies5Yards >= SamuraiSettings.Instance.AoeEnemies)
                 return false;
 
+            if (Utilities.Routines.Common.CheckTTDIsEnemyDyingSoon(SamuraiSettings.Instance))
+                return false;
+
             await Spells.Higanbana.Cast(Core.Me.CurrentTarget);
 
             return true;

--- a/Magitek/Logic/Samurai/SingleTarget.cs
+++ b/Magitek/Logic/Samurai/SingleTarget.cs
@@ -22,7 +22,13 @@ namespace Magitek.Logic.Samurai
                 return false;
 
             if (Spells.Higanbana.CanCast() && !Core.Me.CurrentTarget.HasAura(Auras.Higanbana, true))
-                return false;
+                if (SamuraiSettings.Instance.HiganbanaOnlyBoss)
+                {
+                    if (Core.Me.CurrentTarget.IsBoss())
+                        return false;
+                }
+                else
+                    return false;
 
             if (Spells.Gyofu.IsKnown())
                 return await Spells.Gyofu.Cast(Core.Me.CurrentTarget);
@@ -265,7 +271,7 @@ namespace Magitek.Logic.Samurai
             if (SamuraiRoutine.AoeEnemies5Yards >= SamuraiSettings.Instance.AoeEnemies)
                 return false;
 
-            if (Utilities.Routines.Common.CheckTTDIsEnemyDyingSoon(SamuraiSettings.Instance))
+            if (SamuraiSettings.Instance.HiganbanaOnlyBoss && !Core.Me.CurrentTarget.IsBoss())
                 return false;
 
             await Spells.Higanbana.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Samurai/SingleTarget.cs
+++ b/Magitek/Logic/Samurai/SingleTarget.cs
@@ -177,6 +177,9 @@ namespace Magitek.Logic.Samurai
             if (ActionResourceManager.Samurai.Kenki < 10 + SamuraiSettings.Instance.ReservedKenki) //10 for Yaten + 10 for Guoten
                 return false;
 
+            if (Core.Me.HasAura(Auras.ZanshinReady))
+                return false;
+
             if (!Spells.HissatsuGyoten.IsKnownAndReady())
                 return false;
 
@@ -194,6 +197,9 @@ namespace Magitek.Logic.Samurai
             if (ActionResourceManager.Samurai.Kenki < 25 + SamuraiSettings.Instance.ReservedKenki)
                 return false;
 
+            if (Core.Me.HasAura(Auras.ZanshinReady))
+                return false;
+
             if (Casting.LastSpell != Spells.MidareSetsugekka)
                 return false;
 
@@ -207,7 +213,10 @@ namespace Magitek.Logic.Samurai
 
             if (ActionResourceManager.Samurai.Kenki < 25 + SamuraiSettings.Instance.ReservedKenki)
                 return false;
-            
+
+            if (Core.Me.HasAura(Auras.ZanshinReady))
+                return false;
+
             if (Casting.LastSpell == Spells.HissatsuSenei)
                 return false;
 
@@ -289,7 +298,7 @@ namespace Magitek.Logic.Samurai
             if (!SamuraiSettings.Instance.UseKaeshiSetsugekka)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Tendo))
+            if (Spells.TendoKaeshiSetsugekka.IsKnownAndReadyAndCastable())
                 return await Spells.TendoKaeshiSetsugekka.Cast(Core.Me.CurrentTarget);
 
             if (!await Spells.KaeshiSetsugekka.Cast(Core.Me.CurrentTarget))

--- a/Magitek/Logic/Scholar/HealFightLogic.cs
+++ b/Magitek/Logic/Scholar/HealFightLogic.cs
@@ -28,9 +28,16 @@ namespace Magitek.Logic.Scholar
             if (!FightLogic.ZoneHasFightLogic())
                 return false;
 
-            if (FightLogic.EnemyIsCastingBigAoe()) return await BigAoe();
+            if (FightLogic.EnemyIsCastingBigAoe() || FightLogic.EnemyIsCastingAoe())
+            {
+                if (!FightLogic.HodlCastTimeRemaining(hodlTillDurationInPct: BaseSettings.Instance.FightLogicResponseDelay))
+                    return false;
 
-            if (FightLogic.EnemyIsCastingAoe()) return await JustAoe(); 
+                if (await BigAoe())
+                    return true;
+                if (await JustAoe())    
+                    return true;
+            }
 
             return false;
         }
@@ -120,6 +127,9 @@ namespace Magitek.Logic.Scholar
             var target = FightLogic.EnemyIsCastingTankBuster();
 
             if (target == null)
+                return false;
+
+            if (!FightLogic.HodlCastTimeRemaining(hodlTillDurationInPct: BaseSettings.Instance.FightLogicResponseDelay))
                 return false;
 
             if (!target.BeingTargetedBy(Core.Me.CurrentTarget))

--- a/Magitek/Logic/Viper/Pvp.cs
+++ b/Magitek/Logic/Viper/Pvp.cs
@@ -1,4 +1,5 @@
 ﻿using ff14bot;
+using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Models.Viper;
 using Magitek.Utilities;
@@ -24,7 +25,21 @@ namespace Magitek.Logic.Viper
                 return true;
             if (Spells.FourthGenerationPvp.CanCast() && await Spells.FourthGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
                 return true;
-            if (Spells.OuroborosPvp.CanCast() && await Spells.OuroborosPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
+
+            if (!Spells.OuroborosPvp.CanCast())
+                return false;
+
+            var pvpComboCheck = DataManager.GetSpellData(ActionManager.GetPvPComboCurrentActionId(65));
+
+            if (pvpComboCheck == Spells.FirstGenerationPvp ||
+                pvpComboCheck == Spells.SecondGenerationPvp ||
+                pvpComboCheck == Spells.ThirdGenerationPvp ||
+                pvpComboCheck == Spells.FourthGenerationPvp)
+            {
+                return false;
+            }
+
+            if (await Spells.OuroborosPvp.Cast(Core.Me.CurrentTarget))
                 return true;
 
             return false;
@@ -63,6 +78,9 @@ namespace Magitek.Logic.Viper
         {
             // resets uncoiled fury && snake scales
             var uncoiledFury = Spells.UncoiledFuryPvp;
+
+            if (Spells.OuroborosPvp.CanCast() && Core.Me.CurrentTarget.Distance() <= 5)
+                return false;
 
             if (uncoiledFury.Cooldown.TotalMilliseconds <= 5000)
                 return false;

--- a/Magitek/Logic/WhiteMage/HealFightLogic.cs
+++ b/Magitek/Logic/WhiteMage/HealFightLogic.cs
@@ -26,6 +26,9 @@ namespace Magitek.Logic.WhiteMage
             if (!FightLogic.EnemyIsCastingBigAoe() && !FightLogic.EnemyIsCastingAoe())
                 return false;
 
+            if (!FightLogic.HodlCastTimeRemaining(hodlTillDurationInPct: BaseSettings.Instance.FightLogicResponseDelay))
+                return false;
+
             if (WhiteMageSettings.Instance.FightLogicDivineCaress
                 && Spells.DivineCaress.IsKnownAndReady()
                 && Spells.DivineCaress.CanCast())
@@ -126,6 +129,9 @@ namespace Magitek.Logic.WhiteMage
                 if (target == null)
                     return false;
             }
+
+            if (!FightLogic.HodlCastTimeRemaining(hodlTillDurationInPct: BaseSettings.Instance.FightLogicResponseDelay))
+                return false;
 
             if (WhiteMageSettings.Instance.FightLogicDivineBenison
                 && Spells.DivineBenison.IsKnownAndReady()

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -129,32 +129,13 @@ namespace Magitek
             #endregion
         }
 
-        private async void GameEventsOnOnMapChanged(object sender, EventArgs e)
+        private void GameEventsOnOnMapChanged(object sender, EventArgs e)
         {
-            // Wait 5 seconds for WorldManager.InPvP to have a chance to update it's cache.
-            var delays = 0;
-            while (delays < 50)
+            if (WorldManager.ZoneId != CurrentZone)
             {
-                await Task.Delay(100);
-                delays++;
-            }
+                // Set the current zone
+                CurrentZone = WorldManager.ZoneId;
 
-            CurrentZone = WorldManager.ZoneId;
-            if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
-            {
-                Logger.WriteInfo("Entering PVP Zone. Switching to PvP CombatRoutine.");
-                BaseSettings.Instance.ActivePvpCombatRoutine = true;
-                Application.Current.Dispatcher.Invoke(delegate
-                {
-                    GambitsViewModel.Instance.ApplyGambits();
-                    OpenersViewModel.Instance.ApplyOpeners();
-                    TogglesManager.LoadTogglesForCurrentJob();
-                });
-            }
-            if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
-            {
-                Logger.WriteInfo("Leaving PVP Zone. Switching to PvE CombatRoutine.");
-                BaseSettings.Instance.ActivePvpCombatRoutine = false;
                 Application.Current.Dispatcher.Invoke(delegate
                 {
                     GambitsViewModel.Instance.ApplyGambits();
@@ -282,6 +263,29 @@ namespace Magitek
             {
                 Logger.WriteInfo(@"Resetting Openers Because We're Out Of Combat");
                 CustomOpenerLogic._executedOpeners.Clear();
+            }
+
+            if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
+            {
+                Logger.WriteInfo("Entering PVP Zone. Switching to PvP CombatRoutine.");
+                BaseSettings.Instance.ActivePvpCombatRoutine = true;
+                Application.Current.Dispatcher.Invoke(delegate
+                {
+                    GambitsViewModel.Instance.ApplyGambits();
+                    OpenersViewModel.Instance.ApplyOpeners();
+                    TogglesManager.LoadTogglesForCurrentJob();
+                });
+            }
+            else if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
+            {
+                Logger.WriteInfo("Leaving PVP Zone. Switching to PvE CombatRoutine.");
+                BaseSettings.Instance.ActivePvpCombatRoutine = false;
+                Application.Current.Dispatcher.Invoke(delegate
+                {
+                    GambitsViewModel.Instance.ApplyGambits();
+                    OpenersViewModel.Instance.ApplyOpeners();
+                    TogglesManager.LoadTogglesForCurrentJob();
+                });
             }
 
             var time = DateTime.Now;

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -69,6 +69,7 @@ namespace Magitek
             CurrentJob = Core.Me.CurrentJob;
             GameEvents.OnClassChanged += GameEventsOnOnClassChanged;
             GameEvents.OnLevelUp += GameEventsOnOnLevelUp;
+            GameEvents.OnMapChanged += GameEventsOnOnMapChanged;
 
             HookBehaviors();
 
@@ -126,6 +127,32 @@ namespace Magitek
                 CombatMessageManager.RegisterMessageStrategiesForClass(Core.Me.CurrentJob);
             }
             #endregion
+        }
+
+        private void GameEventsOnOnMapChanged(object sender, EventArgs e)
+        {
+            if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
+            {
+                Logger.WriteInfo("Entering PVP Zone. Switching to PvP CombatRoutine.");
+                BaseSettings.Instance.ActivePvpCombatRoutine = true;
+                Application.Current.Dispatcher.Invoke(delegate
+                {
+                    GambitsViewModel.Instance.ApplyGambits();
+                    OpenersViewModel.Instance.ApplyOpeners();
+                    TogglesManager.LoadTogglesForCurrentJob();
+                });
+            }
+            else if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
+            {
+                Logger.WriteInfo("Leaving PVP Zone. Switching to PvE CombatRoutine.");
+                BaseSettings.Instance.ActivePvpCombatRoutine = false;
+                Application.Current.Dispatcher.Invoke(delegate
+                {
+                    GambitsViewModel.Instance.ApplyGambits();
+                    OpenersViewModel.Instance.ApplyOpeners();
+                    TogglesManager.LoadTogglesForCurrentJob();
+                });
+            }
         }
 
         public void OnStart(BotBase bot)
@@ -246,14 +273,6 @@ namespace Magitek
             {
                 Logger.WriteInfo(@"Resetting Openers Because We're Out Of Combat");
                 CustomOpenerLogic._executedOpeners.Clear();
-            }
-
-            if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
-            {
-                BaseSettings.Instance.ActivePvpCombatRoutine = true;
-            } else if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
-            {
-                BaseSettings.Instance.ActivePvpCombatRoutine = false;
             }
 
             var time = DateTime.Now;

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -248,6 +248,14 @@ namespace Magitek
                 CustomOpenerLogic._executedOpeners.Clear();
             }
 
+            if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
+            {
+                BaseSettings.Instance.ActivePvpCombatRoutine = true;
+            } else if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
+            {
+                BaseSettings.Instance.ActivePvpCombatRoutine = false;
+            }
+
             var time = DateTime.Now;
             if (time < _pulseLimiter) return;
             _pulseLimiter = time.AddSeconds(1);

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -129,8 +129,17 @@ namespace Magitek
             #endregion
         }
 
-        private void GameEventsOnOnMapChanged(object sender, EventArgs e)
+        private async void GameEventsOnOnMapChanged(object sender, EventArgs e)
         {
+            // Wait 5 seconds for WorldManager.InPvP to have a chance to update it's cache.
+            var delays = 0;
+            while (delays < 50)
+            {
+                await Task.Delay(100);
+                delays++;
+            }
+
+            CurrentZone = WorldManager.ZoneId;
             if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
             {
                 Logger.WriteInfo("Entering PVP Zone. Switching to PvP CombatRoutine.");
@@ -142,7 +151,7 @@ namespace Magitek
                     TogglesManager.LoadTogglesForCurrentJob();
                 });
             }
-            else if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
+            if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
             {
                 Logger.WriteInfo("Leaving PVP Zone. Switching to PvE CombatRoutine.");
                 BaseSettings.Instance.ActivePvpCombatRoutine = false;

--- a/Magitek/Models/Account/BaseSettings.cs
+++ b/Magitek/Models/Account/BaseSettings.cs
@@ -60,6 +60,10 @@ namespace Magitek.Models.Account
         public bool UseFightLogic { get; set; }
 
         [Setting]
+        [DefaultValue(20.0f)]
+        public float FightLogicResponseDelay { get; set; }
+
+        [Setting]
         public string ContributorKey { get; set; }
 
         [Setting]

--- a/Magitek/Models/Samurai/SamuraiSettings.cs
+++ b/Magitek/Models/Samurai/SamuraiSettings.cs
@@ -153,6 +153,10 @@ namespace Magitek.Models.Samurai
         public bool UseHiganbana { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool HiganbanaOnlyBoss { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool UseMidareSetsugekka { get; set; }
 

--- a/Magitek/Resources/BossNames.json
+++ b/Magitek/Resources/BossNames.json
@@ -11,5 +11,16 @@
   "Cagnazzo",
   "Lyngbakr",
   "Arkas",
-  "Octomammoth"
+  "Octomammoth",
+  "Thaliak",
+  "Llymlaen",
+  "Oschon",
+  "Eulogia",
+  "Nophica",
+  "Euphrosynos Ktenos",
+  "Euphrosynos Behemoth",
+  "Nymeia",
+  "Althyk",
+  "Halone",
+  "Menphina"
 ]

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -114,7 +114,7 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(BlackMageSettings.Instance.FightLogicManaward, Spells.Manaward)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(BlackMageSettings.Instance.FightLogicManaward, Spells.Manaward, castTimeRemainingMs: 19000)) return true;
             if (await MagicDps.FightLogic_Addle(BlackMageSettings.Instance)) return true;
 
             //DON'T CHANGE THE ORDER OF THESE

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -110,7 +110,7 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift, castTimeRemainingMs: 19000)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(NinjaSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
 
             if (NinjaRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.SpinningEdge.Cooldown.TotalMilliseconds >= 770

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -90,6 +90,7 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
+            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveFastSpells, PaladinRoutine.Defensives, castTimeRemainingMs: 3000)) return true;
             if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveSpells, PaladinRoutine.Defensives)) return true;
             if (await CommonFightLogic.FightLogic_PartyShield(PaladinSettings.Instance.FightLogicPartyShield, Spells.DivineVeil, true, aura: Auras.DivineVeil)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal)) return true;

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -114,7 +114,7 @@ namespace Magitek.Rotations
                 }
             }
 
-            if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false, castTimeRemainingMs: 4000)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false, castTimeRemainingMs: 3000)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(ReaperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
 
             if (SingleTarget.ForceLimitBreak()) return true;

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -114,7 +114,7 @@ namespace Magitek.Rotations
                 }
             }
 
-            if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false, castTimeRemainingMs: 4000)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(ReaperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
 
             if (SingleTarget.ForceLimitBreak()) return true;

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -112,7 +112,7 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_PartyShield(RedMageSettings.Instance.FightLogicMagickBarrier, Spells.MagickBarrier)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(RedMageSettings.Instance.FightLogicMagickBarrier, Spells.MagickBarrier, castTimeRemainingMs: 4500)) return true;
             if (await MagicDps.FightLogic_Addle(RedMageSettings.Instance)) return true;
 
             if (RedMageRoutine.GlobalCooldown.CanWeave())

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -112,7 +112,7 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(RedMageSettings.Instance.FightLogicMagickBarrier, Spells.MagickBarrier)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(RedMageSettings.Instance.FightLogicMagickBarrier, Spells.MagickBarrier)) return true;
             if (await MagicDps.FightLogic_Addle(RedMageSettings.Instance)) return true;
 
             if (RedMageRoutine.GlobalCooldown.CanWeave())

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -89,7 +89,7 @@ namespace Magitek.Rotations
             //Buff for opener
             if (await Buff.MeikyoShisuiNotInCombat()) return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(SamuraiSettings.Instance.FightLogicTengentsu, Spells.Tengentsu, castTimeRemainingMs: 3000)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(SamuraiSettings.Instance.FightLogicTengentsu, Spells.Tengentsu.IsKnown() ? Spells.Tengentsu : Spells.ThirdEye, castTimeRemainingMs: 2000)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(SamuraiSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
 
             //Utility

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -89,7 +89,7 @@ namespace Magitek.Rotations
             //Buff for opener
             if (await Buff.MeikyoShisuiNotInCombat()) return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(SamuraiSettings.Instance.FightLogicTengentsu, Spells.Tengentsu)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(SamuraiSettings.Instance.FightLogicTengentsu, Spells.Tengentsu, castTimeRemainingMs: 3000)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(SamuraiSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
 
             //Utility

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -428,6 +428,7 @@ namespace Magitek.Utilities
             //SAM
             ZanshinReady = 3855,
             Tendo = 3856,
+            ThirdEye = 1232,
 
             //DRG
             StarcrossReady = 3846,

--- a/Magitek/Utilities/Duty.cs
+++ b/Magitek/Utilities/Duty.cs
@@ -1,11 +1,22 @@
 ﻿using ff14bot;
 using ff14bot.Directors;
 using ff14bot.Managers;
+using System.Collections.Generic;
 
 namespace Magitek.Utilities
 {
     public static class Duty
     {
+        public static HashSet<uint> PvpZoneIds = new HashSet<uint>()
+            {
+                1032, // the palaistra
+                1033, // the volcanic heart
+                1058, // the palaistra 2
+                1059, // the volcanic heart 2
+                1034, // cloud nine
+                1060, // cloud nine 2
+            };
+
         /// <summary>
         /// Provides Duty State information. InProgress, NotInDuty, NotStarted, and Ended.
         /// </summary>

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -53,6 +53,8 @@ namespace Magitek.Utilities
 
         public static async Task<bool> DoAndBuffer(Task<bool> task)
         {
+            if (!await task) return false;
+
             var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
             // prevent running duplicate fightlogic responses to the same spell when it's a long cast. 
@@ -60,9 +62,6 @@ namespace Magitek.Utilities
                 return false;
 
             FlHandledCastingSpellId.Add(enemy.CastingSpellId);
-
-            if (!await task) return false;
-
             FlStopwatch.Start();
             return true;
         }
@@ -193,10 +192,10 @@ namespace Magitek.Utilities
 
             return false;
         }
-                
-        public static bool HodlCastTimeRemaining(int hodlTillCastInMs)
+
+        public static bool HodlCastTimeRemaining(int hodlTillCastInMs = 0, double hodlTillDurationInPct = 0.0)
         {
-            if (hodlTillCastInMs == 0)
+            if (hodlTillCastInMs == 0 && hodlTillDurationInPct == 0)
                 return true;
 
             if (ZoneHasFightLogic())
@@ -207,9 +206,22 @@ namespace Magitek.Utilities
                     return true;
 
                 if (enemy.IsCasting)
-                    return enemy.SpellCastInfo.RemainingCastTime.TotalMilliseconds <= hodlTillCastInMs;
+                {
+                    if (hodlTillCastInMs > 0)
+                        return enemy.SpellCastInfo.RemainingCastTime.TotalMilliseconds <= hodlTillCastInMs;
+                    else if (hodlTillDurationInPct > 0)
+                    {
+                        double currentCastTime = enemy.SpellCastInfo.CurrentCastTime.TotalMilliseconds;
+                        double totalCastTime = enemy.SpellCastInfo.CastTime.TotalMilliseconds;
+                        double castProgress = (currentCastTime / totalCastTime) * 100;
+
+                        return castProgress >= hodlTillDurationInPct;
+                    }
+                }
                 else
+                {
                     return true;
+                }
             }
 
             return true;
@@ -2111,7 +2123,7 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            9374 //Stotram
+                            9347 //Stotram
                         },
                         BigAoes = null
                     }
@@ -5838,6 +5850,206 @@ namespace Magitek.Utilities
                 }
             },
 
+            new Encounter {
+                ZoneId = ZoneId.Euphrosyne,
+                Name = "Euphrosyne",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 0, // Assuming an ID for Nophica
+                        Name = "Nophica",
+                        TankBusters = new List<uint>() {
+                            0x7C23, // Heavens' Earth
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x7C24, // Abundance
+                            0x7C1D, // Matron's Harvest
+                            0x7C1E, // Matron's Harvest
+                            0x7C19, // Landwaker
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 1, // Assuming an ID for Euphrosynos Ktenos
+                        Name = "Euphrosynos Ktenos",
+                        TankBusters = new List<uint>() {
+                            0x7D39, // Sweeping Gouge
+                            0x7D3C, // Rapid Sever
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x7D3B, // Roaring Rumble
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 2, // Assuming an ID for Euphrosynos Behemoth
+                        Name = "Euphrosynos Behemoth",
+                        TankBusters = new List<uint>() {
+                            // No tank busters mentioned in the TypeScript data
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            0x7D37, // Localized Maelstrom
+                            0x7A48, // Petrai
+                        },
+                        Aoes = new List<uint>() {
+                            0x7D38, // Trounce
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 3, // Assuming an ID for Nymeia
+                        Name = "Nymeia",
+                        TankBusters = new List<uint>() {
+                            // No tank busters mentioned in the TypeScript data
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x7A47, // Axioma
+                            0x7A44, // Hydroptosis
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 4, // Assuming an ID for Halone
+                        Name = "Halone",
+                        TankBusters = new List<uint>() {
+                            0x7D78, // Spears Three
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x7D79, // Rain of Spears
+                            0x7D63, // Wrath of Halone
+                            0x7D67
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 5, // Assuming an ID for Menphina
+                        Name = "Menphina",
+                        TankBusters = new List<uint>() {
+                            0x019C, 
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x7BFA, // Blue Moon
+                            0x7BFB, // Blue Moon
+                            0x80FA, // Moonset Rays
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    }
+                }
+            },
+
+            new Encounter {
+                ZoneId = ZoneId.Thaleia,
+                Name = "Thaleia",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 0, // Assuming an ID for Thaliak
+                        Name = "Thaliak",
+                        TankBusters = new List<uint>() {
+                            0x01D7, // rhyton
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x88D1, // Katarraktes
+                            0x88C4, // Rheognosis
+                            0x88C5, // Rheognosis Petrine
+                            0x88CF, // Hieroglyphika
+                            0x88D8, // Thlipsis
+                            0x88D5, // Hydroptosis
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 1, // Assuming an ID for Llymlaen
+                        Name = "Llymlaen",
+                        TankBusters = new List<uint>() {
+                            
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x8819, // Deep Dive
+                            0x880B, // Tempest
+                            0x881A, // Torrential Tridents
+                            0x8824, // Godsbane
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 2, // Assuming an ID for Oschon
+                        Name = "Oschon",
+                        TankBusters = new List<uint>() {
+                            0x0158, 0x01F4
+                        },
+                        SharedTankBusters = new List<uint>() {
+                        },
+                        Aoes = new List<uint>() {
+                            0x8999, // Sudden Downpour
+                            0x899A, // downpour
+                            0x013C, // foehn
+
+                        },
+                        BigAoes = new List<uint>() {
+                            // No big Aoes mentioned in the TypeScript data
+                        }
+                    },
+                    new Enemy {
+                        Id = 3, // Assuming an ID for Eulogia
+                        Name = "Eulogia",
+                        TankBusters = new List<uint>() {
+                            0x0158, 0x01F4
+                        },
+                        SharedTankBusters = new List<uint>() {
+                            // No shared tank busters mentioned in the TypeScript data
+                        },
+                        Aoes = new List<uint>() {
+                            0x8A03, // Dawn of Time
+                            0x8A2F, // The Whorl
+                            0x8A2C,
+                            0x8A47, // Hand of the Destroyer Red
+                            0x8A48, // Hand of the Destroyer Blue
+                            0x8A43, // Hieroglyphika
+                            0x8CFD, // Destructive Bolt
+                        },
+                        BigAoes = new List<uint>() {
+                        }
+                    }
+                }
+            },
             #endregion
 
             #region: Dawntrail Dungeons
@@ -6053,6 +6265,7 @@ namespace Magitek.Utilities
                         Aoes = new List<uint>() {
                             37161, // electrowave
                             37345, // heavy blast cannon
+                            37348, // tracking bolt
                         },
                         BigAoes = new List<uint>() {
                             // Add BigAoes here if available
@@ -6489,6 +6702,7 @@ namespace Magitek.Utilities
             internal List<uint> SharedTankBusters { get; set; }
             internal List<uint> Aoes { get; set; }
             internal List<uint> BigAoes { get; set; }
+            internal List<uint> Knockbacks { get; set; }
         }
 
         private class Encounter

--- a/Magitek/Utilities/Routines/Paladin.cs
+++ b/Magitek/Utilities/Routines/Paladin.cs
@@ -19,13 +19,17 @@ namespace Magitek.Utilities.Routines
                                             ? Spells.SpiritsWithin
                                             : Spells.Expiacion;
 
-        public static readonly SpellData[] DefensiveSpells = new SpellData[]
+        public static readonly SpellData[] DefensiveFastSpells = new SpellData[]
         {
             Spells.HolySheltron,
-            Spells.Sheltron,
+            Spells.Sheltron
+        };
+
+        public static readonly SpellData[] DefensiveSpells = new SpellData[]
+        {
             Spells.Rampart,
-            Spells.Sentinel,
             Spells.Guardian,
+            Spells.Sentinel,
         };
 
         public static readonly uint[] Defensives = new uint[]

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -451,7 +451,7 @@ namespace Magitek.Utilities
         public static readonly SpellData Scattergun = DataManager.GetSpellData(25786);
         public static readonly SpellData ChainSaw = DataManager.GetSpellData(25788);
         public static readonly SpellData SatelliteBeam = DataManager.GetSpellData(4245);
-        public static readonly SpellData Dismantle = DataManager.GetSpellData(2287);
+        public static readonly SpellData Dismantle = DataManager.GetSpellData(2887);
         public static readonly SpellData BlazingShot = DataManager.GetSpellData(36978);
         public static readonly SpellData DoubleCheck = DataManager.GetSpellData(36979);
         public static readonly SpellData Checkmate = DataManager.GetSpellData(36980);

--- a/Magitek/Views/UserControls/Bugs/FightLogic.xaml
+++ b/Magitek/Views/UserControls/Bugs/FightLogic.xaml
@@ -2,7 +2,8 @@
     x:Class="Magitek.Views.UserControls.Bugs.FightLogic"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
-    xmlns:viewModels="clr-namespace:Magitek.ViewModels">
+    xmlns:viewModels="clr-namespace:Magitek.ViewModels"
+    xmlns:controls="clr-namespace:Magitek.Controls">
     
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:Debug.Instance}" />
@@ -18,16 +19,23 @@
             <CheckBox Margin="0,0,10,0" Content="Print Fight Logic Detection" IsChecked="{Binding Settings.DebugFightLogic, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             <CheckBox Margin="0,0,0,0" Content="Display Loaded Logic" IsChecked="{Binding Settings.DebugFightLogicFound, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
         </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="5">
+            <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text="Response Delay " />
+            <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="0" Value="{Binding Settings.FightLogicResponseDelay, Mode=TwoWay}" />
+            <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text="% progress into cast bar" />
+        </StackPanel>
         <TextBlock Margin="3" Style="{DynamicResource TextBlockDefault}" TextWrapping="Wrap">
             Fight Logic: <LineBreak/>
             This allows Routines to automatically respond to TankBusters and AoE attacks by pre-shielding, using cooldowns, or applying debuffs. <LineBreak/>
             <LineBreak/>
-            Only works on supported bosses and dungeons and limited to only boss-cast-bar detectable actions.        
+            Only works on supported bosses and dungeons and limited to only boss-cast-bar detectable actions.
         </TextBlock>
         <TextBlock Margin="3" Style="{DynamicResource TextBlockDefault}" TextWrapping="Wrap">
             Detected FightLogic:
         </TextBlock>
-        <TextBlock Margin="3" Style="{DynamicResource TextBlockDefault}" Text="{Binding FightLogicData, Mode=OneWay}" />
+        <ScrollViewer>
+            <TextBlock Margin="3" Style="{DynamicResource TextBlockDefault}" Text="{Binding FightLogicData, Mode=OneWay}" />
+        </ScrollViewer>
     </StackPanel>
 </UserControl>
 

--- a/Magitek/Views/UserControls/MainSettingsOverlay.xaml
+++ b/Magitek/Views/UserControls/MainSettingsOverlay.xaml
@@ -54,7 +54,7 @@
                 <WrapPanel>
                     <WrapPanel Orientation="Horizontal">
                         <CheckBox Content="Active CR" IsChecked="{Binding GeneralSettings.GeneralSettings.ActiveCombatRoutine, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
-                        <CheckBox Content="Enable PVP Mode" IsChecked="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Mode=TwoWay}" Command="{Binding EnablePvpOverlay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
+                        <CheckBox Content="PVP Mode" IsChecked="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Mode=TwoWay}" Command="{Binding EnablePvpOverlay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
                         <CheckBox Content="Use Custom Opener" IsChecked="{Binding GeneralSettings.GeneralSettings.UseOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
                         <CheckBox Content="Reset Custom Opener" IsChecked="{Binding GeneralSettings.GeneralSettings.ResetOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
                         <CheckBox Content="Use Chocobo" IsChecked="{Binding GeneralSettings.GeneralSettings.SummonChocobo, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />

--- a/Magitek/Views/UserControls/Samurai/SingleTarget.xaml
+++ b/Magitek/Views/UserControls/Samurai/SingleTarget.xaml
@@ -74,7 +74,8 @@
 
                 <TextBlock Margin="0 8 0 0" Style="{DynamicResource TextBlockSection}" Text="GCD - Iaijutsu" />
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="Higabana" IsChecked="{Binding SamuraiSettings.UseHiganbana, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Higabana   " IsChecked="{Binding SamuraiSettings.UseHiganbana, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Only Bosses" IsChecked="{Binding SamuraiSettings.HiganbanaOnlyBoss, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="Midare Setsugekka" IsChecked="{Binding SamuraiSettings.UseMidareSetsugekka, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />

--- a/Magitek/Views/UserControls/Samurai/Utility.xaml
+++ b/Magitek/Views/UserControls/Samurai/Utility.xaml
@@ -31,6 +31,16 @@
     <StackPanel Margin="10">
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox Margin="5" Content=" Use TTD Checks/Save Cooldowns When Enemy Dying Within " IsChecked="{Binding SamuraiSettings.UseTTD, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="100000" MinValue="1" Value="{Binding SamuraiSettings.SaveIfEnemyDyingWithin, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Seconds" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <Grid Margin="5">
                 <Grid.RowDefinitions>
                     <RowDefinition />


### PR DESCRIPTION
MCH - not using dismantle
MCH - flamethrow needs to do a explicit /facetarget. 
SAM - Higbana TTD cause i'm tired of doing it on trash
PVP - Magitek now auto toggles to pvp mode when entering and leaving a pvp map. 
FightLogic - Only respond once to each unique 
FightLogic - Holds certain abilities until enough cast time is left for it to have a chance to be effective.
             ex: holds reapers 5s shield until at most 4s are left on the cast