### PR TITLE
RPR, HEALER, BLU, WAR

### DIFF
--- a/Magitek/Logic/Astrologian/SingleTarget.cs
+++ b/Magitek/Logic/Astrologian/SingleTarget.cs
@@ -41,6 +41,11 @@ namespace Magitek.Logic.Astrologian
             if (combustTarget == null)
                 return false;
 
+            if (AstrologianSettings.Instance.DontDotIfMoreEnemies
+                && AstrologianSettings.Instance.DontDotIfMoreEnemiesThan > 0
+                && Combat.Enemies.Count > AstrologianSettings.Instance.DontDotIfMoreEnemiesThan)
+                            return false;
+
             return await Spells.Combust.Cast(combustTarget);
 
             bool NeedsCombust(BattleCharacter unit)
@@ -74,7 +79,8 @@ namespace Magitek.Logic.Astrologian
             if (AstrologianSettings.Instance.UseTTDForCombust)
             {
                 if (Combat.CurrentTargetCombatTimeLeft
-                    <= AstrologianSettings.Instance.DontCombustIfEnemyDyingWithin)
+                    <= AstrologianSettings.Instance.DontCombustIfEnemyDyingWithin
+                    && !Core.Me.CurrentTarget.IsBoss())
                 {
                     return false;
                 }
@@ -90,6 +96,11 @@ namespace Magitek.Logic.Astrologian
 
             if (Core.Me.CurrentTarget.HasAnyAura(CombustAuras, true, msLeft: AstrologianSettings.Instance.CombustRefreshMSeconds))
                 return false;
+
+            if (AstrologianSettings.Instance.DontDotIfMoreEnemies
+                && AstrologianSettings.Instance.DontDotIfMoreEnemiesThan > 0
+                && Combat.Enemies.Count > AstrologianSettings.Instance.DontDotIfMoreEnemiesThan)
+                            return false;
 
             return await Spells.Combust.Cast(Core.Me.CurrentTarget);
         }

--- a/Magitek/Logic/BlueMage/Aoe.cs
+++ b/Magitek/Logic/BlueMage/Aoe.cs
@@ -1,4 +1,5 @@
 using ff14bot;
+using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Models.BlueMage;
 using Magitek.Utilities;
@@ -121,7 +122,7 @@ namespace Magitek.Logic.BlueMage
         }
 
         /************** OTHER SPELLS **************/
-        public static async Task<bool> NightBloom()
+        public static async Task<bool> NightBloomOrBothEnds()
         {
             if (Utilities.Routines.BlueMage.IsMoonFluteTakenActivatedAndWindowReady && !Core.Me.HasAura(Auras.WaxingNocturne))
                 return false;
@@ -130,7 +131,12 @@ namespace Magitek.Logic.BlueMage
             if (Combat.Enemies.Count(r => r.Distance(Core.Me) < 10 + r.CombatReach) < 1)
                 return false;
 
-            return await Spells.NightBloom.Cast(Core.Me.CurrentTarget);
+            if (ActionManager.HasSpell(Spells.NightBloom.Id))
+                return await Spells.NightBloom.Cast(Core.Me.CurrentTarget);
+            if (ActionManager.HasSpell(Spells.BothEnds.Id))
+                return await Spells.BothEnds.Cast(Core.Me.CurrentTarget);
+
+            return false;
         }
 
         public static async Task<bool> PhantomFlurry()

--- a/Magitek/Logic/Reaper/Normal/AoE.cs
+++ b/Magitek/Logic/Reaper/Normal/AoE.cs
@@ -167,7 +167,10 @@ namespace Magitek.Logic.Reaper
                 return false;
             if (Utilities.Routines.Reaper.CheckTTDIsEnemyDyingSoon())
                 return false;
-            return await Spells.GrimSwathe.CastAura(Core.Me.CurrentTarget, Auras.SoulReaver, auraTarget: Core.Me);
+            if (Core.Me.ClassLevel >= Spells.Gibbet.LevelAcquired)
+                return await Spells.GrimSwathe.CastAura(Core.Me.CurrentTarget, Auras.SoulReaver, auraTarget: Core.Me);
+            else
+                return await Spells.GrimSwathe.Cast(Core.Me.CurrentTarget);
         }
 
         #endregion

--- a/Magitek/Logic/Reaper/Normal/SingleTarget.cs
+++ b/Magitek/Logic/Reaper/Normal/SingleTarget.cs
@@ -192,7 +192,10 @@ namespace Magitek.Logic.Reaper
                 return false;
             if (Utilities.Routines.Reaper.CheckTTDIsEnemyDyingSoon())
                 return false;
-            return await Spells.BloodStalk.CastAura(Core.Me.CurrentTarget, Auras.SoulReaver, auraTarget: Core.Me);
+            if (Core.Me.ClassLevel >= Spells.Gibbet.LevelAcquired)
+                return await Spells.BloodStalk.CastAura(Core.Me.CurrentTarget, Auras.SoulReaver, auraTarget: Core.Me);
+            else
+                return await Spells.BloodStalk.Cast(Core.Me.CurrentTarget);
         }
 
         #endregion

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -48,7 +48,10 @@ namespace Magitek.Logic.Roles
             if (Core.Me.HasAnyAura(Auras.Invincibility))
                 return false;
 
-            if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
+            if (Core.Me.HasTarget 
+                && Core.Me.CurrentTarget.CanAttack 
+                && Core.Me.CurrentTarget.InLineOfSight()
+                && Core.Me.CurrentTarget.Distance() < 26)
                 return false;
 
             if (Core.Me.HasAura(Auras.PvpSprint))

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -25,9 +25,6 @@ namespace Magitek.Logic.Roles
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return true;
 
-            if (await Sprint(settings))
-                return true;
-
             if (await Guard(settings))
                 return true;
 
@@ -35,6 +32,9 @@ namespace Magitek.Logic.Roles
                 return true;
 
             if (await Recuperate(settings))
+                return true;
+
+            if (await Sprint(settings))
                 return true;
 
             return false;

--- a/Magitek/Logic/Sage/SingleTarget.cs
+++ b/Magitek/Logic/Sage/SingleTarget.cs
@@ -66,7 +66,7 @@ namespace Magitek.Logic.Sage
             if (!SageSettings.Instance.DoDamage)
                 return false;
 
-            if (SageSettings.Instance.UseTTDForDots && Combat.CurrentTargetCombatTimeLeft <= SageSettings.Instance.DontDotIfEnemyDyingWithin)
+            if (SageSettings.Instance.UseTTDForDots && Combat.CurrentTargetCombatTimeLeft <= SageSettings.Instance.DontDotIfEnemyDyingWithin && !Core.Me.CurrentTarget.IsBoss())
                 return false;
 
             if (!SageSettings.Instance.EukrasianDosis)

--- a/Magitek/Logic/Warrior/Buff.cs
+++ b/Magitek/Logic/Warrior/Buff.cs
@@ -41,7 +41,7 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UseInnerRelease)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 3 + r.CombatReach) < 1)
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= 3 + r.CombatReach + Core.Me.CombatReach) < 1)
                 return false;
 
             //Added level check as this skill is available as berserk at lvl 6 and AoE combo isnt until lvl 40
@@ -49,13 +49,7 @@ namespace Magitek.Logic.Warrior
                 && Core.Me.ClassLevel >= Spells.MythrilTempest.LevelAcquired)
                 return false;
 
-            // trait for nascent chaos acquired at lvl 80 for single target, when we get the trait for that
-            // then only inner release with nascent chaos
-            if (Core.Me.ClassLevel >= 80 && !Core.Me.HasAura(Auras.NascentChaos))
-                return false;
-
-            // We're assuming IR is usable from here. If we're on GCD with more than 800 milliseconds left
-            if (Spells.HeavySwing.Cooldown.TotalMilliseconds > 800)
+            if (Core.Me.HasAura(Auras.NascentChaos))
                 return false;
 
             return await WarriorRoutine.InnerRelease.Cast(Core.Me);

--- a/Magitek/Logic/Warrior/Defensive.cs
+++ b/Magitek/Logic/Warrior/Defensive.cs
@@ -72,7 +72,7 @@ namespace Magitek.Logic.Warrior
             return await Spells.Rampart.CastAura(Core.Me, Auras.Rampart);
         }
 
-        public static async Task<bool> Vengeance()
+        public static async Task<bool> VengeanceDamnation()
         {
             if (!WarriorSettings.Instance.UseVengeance)
                 return false;
@@ -83,24 +83,12 @@ namespace Magitek.Logic.Warrior
             if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.VengeanceHpPercentage)
                 return false;
 
-            return await Spells.Vengeance.CastAura(Core.Me, Auras.Vengeance);
+
+            if (Spells.Damnation.IsKnown())
+                return await Spells.Damnation.CastAura(Core.Me, Auras.Damnation);
+            else
+                return await Spells.Vengeance.CastAura(Core.Me, Auras.Vengeance);
         }
-
-        public static async Task<bool> Damnation()
-        {
-            if (!WarriorSettings.Instance.UseDamnation)
-                return false;
-
-            if (!UseDefensives())
-                return false;
-
-            if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.DamnationHpPercentage)
-                return false;
-
-            return await Spells.Damnation.CastAura(Core.Me, Auras.Damnation);
-        }
-
-
 
         public static async Task<bool> ShakeItOff()
         {

--- a/Magitek/Logic/WhiteMage/SingleTarget.cs
+++ b/Magitek/Logic/WhiteMage/SingleTarget.cs
@@ -62,6 +62,11 @@ namespace Magitek.Logic.WhiteMage
 
         public static async Task<bool> Dots()
         {
+            if (WhiteMageSettings.Instance.DontDotIfMoreEnemies 
+                && WhiteMageSettings.Instance.DontDotIfMoreEnemiesThan > 0 
+                && Combat.Enemies.Count > WhiteMageSettings.Instance.DontDotIfMoreEnemiesThan)
+                return false;
+
             if (Combat.IsMoving(Core.Me) && Core.Me.ClassLevel < 56 || Combat.IsMoving(Core.Me) && WhiteMageSettings.Instance.Dotwhilemoving)
             {
                 return await Spells.Dia.Cast(Core.Me.CurrentTarget);
@@ -71,7 +76,7 @@ namespace Magitek.Logic.WhiteMage
             {
                 var combatTimeLeft = Core.Me.CurrentTarget.CombatTimeLeft();
 
-                if (combatTimeLeft > 0 && combatTimeLeft < WhiteMageSettings.Instance.DontDotIfEnemyDyingWithin)
+                if (combatTimeLeft > 0 && combatTimeLeft < WhiteMageSettings.Instance.DontDotIfEnemyDyingWithin && !Core.Me.CurrentTarget.IsBoss())
                     return false;
             }
             else
@@ -91,6 +96,11 @@ namespace Magitek.Logic.WhiteMage
                 return false;
 
             if (!WhiteMageSettings.Instance.DoDamage)
+                return false;
+
+            if (WhiteMageSettings.Instance.DontDotIfMoreEnemies
+                && WhiteMageSettings.Instance.DontDotIfMoreEnemiesThan > 0
+                && Combat.Enemies.Count > WhiteMageSettings.Instance.DontDotIfMoreEnemiesThan)
                 return false;
 
             var dotTarget = Combat.Enemies.FirstOrDefault(NeedsDot);

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -56,6 +56,14 @@ namespace Magitek.Models.Astrologian
         public int DontCombustIfEnemyDyingWithin { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool DontDotIfMoreEnemies { get; set; }
+
+        [Setting]
+        [DefaultValue(5)]
+        public int DontDotIfMoreEnemiesThan { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool Gravity { get; set; }
 

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -357,6 +357,14 @@ namespace Magitek.Models.Scholar
         public int BioTargetLimit { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool DontDotIfMoreEnemies { get; set; }
+
+        [Setting]
+        [DefaultValue(5)]
+        public int DontDotIfMoreEnemiesThan { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool RuinBroil { get; set; }
 

--- a/Magitek/Models/Warrior/WarriorSettings.cs
+++ b/Magitek/Models/Warrior/WarriorSettings.cs
@@ -95,15 +95,7 @@ namespace Magitek.Models.Warrior
 
         [Setting]
         [DefaultValue(50)]
-        public int VengeanceHpPercentage { get; set; }
-
-        [Setting]
-        [DefaultValue(false)]
-        public bool UseDamnation { get; set; }
-
-        [Setting]
-        [DefaultValue(50)]
-        public int DamnationHpPercentage { get; set; }
+        public int VengeanceHpPercentage { get; set; }        
 
         [Setting]
         [DefaultValue(false)]

--- a/Magitek/Models/WhiteMage/WhiteMageSettings.cs
+++ b/Magitek/Models/WhiteMage/WhiteMageSettings.cs
@@ -411,6 +411,14 @@ namespace Magitek.Models.WhiteMage
 
         [Setting]
         [DefaultValue(false)]
+        public bool DontDotIfMoreEnemies { get; set; }
+
+        [Setting]
+        [DefaultValue(5)]
+        public int DontDotIfMoreEnemiesThan { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
         public bool Dotwhilemoving { get; set; }
 
         [Setting]

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -129,6 +129,7 @@ namespace Magitek.Rotations
             {
 
                 //GCD
+                if (await Spells.MagicHammer.Cast(Core.Me.CurrentTarget)) return true;
                 if (await Buff.Swiftcast()) return true;
                 if (await SingleTarget.TripleTrident()) return true;
                 if (await SingleTarget.MatraMagic()) return true;
@@ -152,9 +153,6 @@ namespace Magitek.Rotations
                         if (await Aoe.MountainBuster()) return true; //ShockStrike if possible, otherwise MountainBuster
                     }
                 }
-
-
-                if (await Spells.MagicHammer.Cast(Core.Me.CurrentTarget)) return true;
 
                 if (await SingleTarget.SharpKnife()) return true; //if melee
                 if (await SingleTarget.AbyssalTransfixion()) return true; //if SonicBoom deactivated

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -140,7 +140,7 @@ namespace Magitek.Rotations
                     if (BlueMageRoutine.GlobalCooldown.CountOGCDs() < 2)
                     {
                         //put oGCD here
-                        if (await Aoe.NightBloom()) return true;
+                        if (await Aoe.NightBloomOrBothEnds()) return true;
                         if (await Aoe.PhantomFlurry()) return true;
                         if (await Aoe.ShockStrike()) return true;
                         if (await Aoe.GlassDance()) return true;
@@ -155,6 +155,8 @@ namespace Magitek.Rotations
 
                 if (await SingleTarget.SharpKnife()) return true; //if melee
                 if (await SingleTarget.AbyssalTransfixion()) return true; //if SonicBoom deactivated
+
+                if (await Spells.MagicHammer.Cast(Core.Me.CurrentTarget)) return true;
 
                 return await SingleTarget.SonicBoom();
             }

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -153,10 +153,11 @@ namespace Magitek.Rotations
                     }
                 }
 
-                if (await SingleTarget.SharpKnife()) return true; //if melee
-                if (await SingleTarget.AbyssalTransfixion()) return true; //if SonicBoom deactivated
 
                 if (await Spells.MagicHammer.Cast(Core.Me.CurrentTarget)) return true;
+
+                if (await SingleTarget.SharpKnife()) return true; //if melee
+                if (await SingleTarget.AbyssalTransfixion()) return true; //if SonicBoom deactivated
 
                 return await SingleTarget.SonicBoom();
             }

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -104,7 +104,7 @@ namespace Magitek.Rotations
                 if (await Defensive.BloodWhetting()) return true;
                 if (await Defensive.Reprisal()) return true;
                 if (await Defensive.Rampart()) return true;
-                if (await Defensive.Vengeance()) return true;
+                if (await Defensive.VengeanceDamnation()) return true;
                 if (await Defensive.ShakeItOff()) return true;
                 if (await Buff.NascentFlash()) return true;
                 if (await Tank.ArmsLength(WarriorSettings.Instance)) return true;

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -454,6 +454,9 @@ namespace Magitek.Utilities
             FireRumination = 3843,
             Mantra = 102,
 
+            //WAR
+            Wrathful = 3901,
+
             //To prevent conflict
             Placeholder = 9999;
 

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -876,6 +876,7 @@ namespace Magitek.Utilities
         public static readonly SpellData NascentFlash = DataManager.GetSpellData(16464);
         public static readonly SpellData LandWaker = DataManager.GetSpellData(4240);
         public static readonly SpellData Damnation = DataManager.GetSpellData(36923);
+        public static readonly SpellData PrimalWrath = DataManager.GetSpellData(36924);
         #endregion
 
         // WHM

--- a/Magitek/Views/UserControls/Astrologian/Combat.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Combat.xaml
@@ -78,6 +78,12 @@
                         <controls:Numeric Margin="2,0,2,0" Increment="1" MaxValue="30" MinValue="1" Value="{Binding AstrologianSettings.DontCombustIfEnemyDyingWithin, Mode=TwoWay}" />
                         <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Seconds" />
                     </StackPanel>
+
+                    <StackPanel Margin="5" Orientation="Horizontal">
+                        <CheckBox Content="Don't Dot if more than " IsChecked="{Binding AstrologianSettings.DontDotIfMoreEnemies, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}"/>
+                        <controls:Numeric MaxValue="100" MinValue="0" Value="{Binding AstrologianSettings.DontDotIfMoreEnemiesThan, Mode=TwoWay}" />
+                        <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies in combat" />
+                    </StackPanel>
                 </StackPanel>
 
             </StackPanel>

--- a/Magitek/Views/UserControls/Scholar/DOTs.xaml
+++ b/Magitek/Views/UserControls/Scholar/DOTs.xaml
@@ -51,6 +51,7 @@
     </Grid>
 
             </Grid>
+            
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
@@ -64,5 +65,12 @@
 
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <CheckBox Content="Don't Dot if more than " IsChecked="{Binding ScholarSettings.DontDotIfMoreEnemies, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}"/>
+                <controls:Numeric MaxValue="100" MinValue="0" Value="{Binding ScholarSettings.DontDotIfMoreEnemiesThan, Mode=TwoWay}" />
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies in combat" />
+            </StackPanel>
+        </controls:SettingsBlock>
     </StackPanel>
 </UserControl>

--- a/Magitek/Views/UserControls/Warrior/Defensives.xaml
+++ b/Magitek/Views/UserControls/Warrior/Defensives.xaml
@@ -63,7 +63,7 @@
                     <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding WarriorSettings.HolmgangHpPercentage, Mode=TwoWay}" />
                     <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
-                    <CheckBox Grid.Row="1" Grid.Column="0" Content="Vengeance" IsChecked="{Binding WarriorSettings.UseVengeance, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Row="1" Grid.Column="0" Content="Vengeance / Damnation" IsChecked="{Binding WarriorSettings.UseVengeance, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="1"
                                       Grid.Column="1"
                                       Margin="0,3"
@@ -107,15 +107,6 @@
                                       MinValue="1"
                                       Value="{Binding WarriorSettings.ShakeItOffHpPercentage, Mode=TwoWay}" />
                     <TextBlock Grid.Row="6" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
-
-                    <CheckBox Grid.Row="7" Grid.Column="0" Content="Damnation" IsChecked="{Binding WarriorSettings.UseDamnation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Grid.Row="7"
-                      Grid.Column="1"
-                      Margin="0,3"
-                      MaxValue="100"
-                      MinValue="1"
-                      Value="{Binding WarriorSettings.DamnationHpPercentage, Mode=TwoWay}" />
-                    <TextBlock Grid.Row="7" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
 
                     <CheckBox Grid.Row="8" Grid.Column="0" Content="Arms Length" IsChecked="{Binding WarriorSettings.UseArmsLength, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="8"

--- a/Magitek/Views/UserControls/WhiteMage/Combat.xaml
+++ b/Magitek/Views/UserControls/WhiteMage/Combat.xaml
@@ -84,6 +84,14 @@
                     <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding WhiteMageSettings.DotHealthMinimumPercent, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
                 </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Dot Multiple Targets" IsChecked="{Binding WhiteMageSettings.DotMultipleTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Don't Dot if more than " IsChecked="{Binding WhiteMageSettings.DontDotIfMoreEnemies, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}"/>
+                    <controls:Numeric MaxValue="100" MinValue="0" Value="{Binding WhiteMageSettings.DontDotIfMoreEnemiesThan, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Enemies in combat" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
RPR - fix getting stuck on blood stalk / grim swathe when under lvl 70. 
WHM - Don't dot if more enemies than X setting. Fix TDD dots on bosses.
SCH - Don't dot if more enemies than X setting. Fixed BioRefreshSeconds and BioTTD settings. 
SGE - Fix TDD dots on bosses.
AST - Don't dot if more enemies than X setting. Fix TDD dots on bosses.
BLU - add magic hammer & both ends
WAR - Fix damnation locking up. More IR tweaks.
PVP - auto sprint if target is >25 yalms away