### PR TITLE
Refreshing combat status and checking Gambits out of combat

### DIFF
--- a/Magitek/Controls/GambitsControl.xaml
+++ b/Magitek/Controls/GambitsControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="Magitek.Controls.GambitsControl"
+<UserControl x:Class="Magitek.Controls.GambitsControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:actions="clr-namespace:Magitek.Gambits.Actions"
@@ -732,6 +732,28 @@
                                                                                                      Text="{Binding SpellName, Mode=TwoWay}" />
 
                                                                                             <CheckBox Margin="3" Content="IS PVP SPELL" IsChecked="{Binding IsPvpSpell, Mode=TwoWay}" Style="{DynamicResource CheckBoxGambits}" />
+
+                                                                                            <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveGambitCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                                <Button.CommandParameter>
+                                                                                                    <MultiBinding Converter="{StaticResource ConditionConverter}">
+                                                                                                        <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}, AncestorLevel=2}" />
+                                                                                                        <Binding Path="Id" />
+                                                                                                    </MultiBinding>
+                                                                                                </Button.CommandParameter>
+                                                                                            </Button>
+                                                                                        </StackPanel>
+                                                                                    </ComboBox>
+                                                                                </DataTemplate>
+
+                                                                                <DataTemplate DataType="{x:Type conditions:CountdownTimerCondition}">
+                                                                                    <ComboBox Margin="3,0,0,0" Background="{DynamicResource Success}" Style="{DynamicResource ComboBoxGambitCondition}" Tag="COUNTDOWN TIMER">
+                                                                                        <StackPanel Width="200" Margin="3">
+                                                                                            <TextBox CaretBrush="White"
+                                                                                                     FontSize="10"
+                                                                                                     Foreground="{DynamicResource Light}"
+                                                                                                     Tag="TIMER IN SECONDS"
+                                                                                                     Template="{DynamicResource TextBoxTemplateGambitConditionTextBox}"
+                                                                                                     Text="{Binding CountdownTimerInSeconds, Mode=TwoWay}" />
 
                                                                                             <Button Margin="0,3,0,0" HorizontalAlignment="Right" Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.RemoveGambitCondition}" Content="REMOVE CONDITION" Style="{DynamicResource ButtonGambitAddCondition}">
                                                                                                 <Button.CommandParameter>
@@ -1684,6 +1706,18 @@
                                                                                         <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="HAS PET" Style="{DynamicResource ButtonGambitAddCondition}">
                                                                                             <Button.Resources>
                                                                                                 <sys:String x:Key="Condition">HasPet</sys:String>
+                                                                                            </Button.Resources>
+                                                                                            <Button.CommandParameter>
+                                                                                                <MultiBinding Converter="{StaticResource ConditionAddConverter}">
+                                                                                                    <Binding Path="DataContext" RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}" />
+                                                                                                    <Binding Source="{StaticResource Condition}" />
+                                                                                                </MultiBinding>
+                                                                                            </Button.CommandParameter>
+                                                                                        </Button>
+
+                                                                                        <Button Command="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}, Path=DataContext.AddGambitCondition}" Content="COUNTDOWN TIMER" Style="{DynamicResource ButtonGambitAddCondition}">
+                                                                                            <Button.Resources>
+                                                                                                <sys:String x:Key="Condition">CountdownTimer</sys:String>
                                                                                             </Button.Resources>
                                                                                             <Button.CommandParameter>
                                                                                                 <MultiBinding Converter="{StaticResource ConditionAddConverter}">

--- a/Magitek/Gambits/Actions/UseItemOnSelfAction.cs
+++ b/Magitek/Gambits/Actions/UseItemOnSelfAction.cs
@@ -23,7 +23,7 @@ namespace Magitek.Gambits.Actions
 
         public override async Task<bool> Execute(ObservableCollection<IGambitCondition> conditions)
         {
-            Logger.WriteInfo($@"Looking for Item : {ItemName}");
+            //Logger.WriteInfo($@"Looking for Item : {ItemName}");
 
             var bagSlot = InventoryManager.FilledSlots.FirstOrDefault(r => string.Equals(r.Name, ItemName, StringComparison.CurrentCultureIgnoreCase) &&
                 (AnyQuality || HighQualityOnly && r.IsHighQuality || NormalQualityOnly && !r.IsHighQuality));

--- a/Magitek/Gambits/Conditions/CountdownTimerCondition.cs
+++ b/Magitek/Gambits/Conditions/CountdownTimerCondition.cs
@@ -15,7 +15,7 @@ namespace Magitek.Gambits.Conditions
 
         public override bool Check(GameObject gameObject = null)
         {
-            Logger.WriteInfo($@"[Opener] Current Countdown = {GamelogManagerCountdown.GetCurrentCooldown()} | Step Timer Config = {CountdownTimerInSeconds}");
+            //Logger.WriteInfo($@"[Opener] Current Countdown = {GamelogManagerCountdown.GetCurrentCooldown()} | Step Timer Config = {CountdownTimerInSeconds}");
             if (GamelogManagerCountdown.GetCurrentCooldown() != CountdownTimerInSeconds)
                 return false;
 

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -327,6 +327,21 @@ namespace Magitek
 
         private void GamelogManagerCountdownRecevied(object sender, ChatEventArgs e)
         {
+            Tracking.Update();
+            Utilities.Combat.AdjustCombatTime();
+            Utilities.Combat.AdjustDutyTime();
+
+            if (Utilities.Combat.OutOfCombatTime.ElapsedMilliseconds >= 10500 && CustomOpenerLogic._executedOpeners.Count > 0)
+            {
+                Logger.WriteInfo(@"Resetting Openers Because We're Out Of Combat");
+                CustomOpenerLogic._executedOpeners.Clear();
+            }
+
+            CombatMessageManager.UpdateDisplayedMessage();
+
+            var task = GambitLogic.Gambit();
+            Task.Run(async () => GambitLogic.Gambit());
+            
             if ((int)e.ChatLogEntry.MessageType == 313 || (int)e.ChatLogEntry.MessageType == 185 || MessageType.SystemMessages.Equals(e.ChatLogEntry.MessageType))
             {
                 //Start countdown

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -339,8 +339,7 @@ namespace Magitek
 
             CombatMessageManager.UpdateDisplayedMessage();
 
-            var task = GambitLogic.Gambit();
-            Task.Run(async () => GambitLogic.Gambit());
+            GambitLogic.Gambit().Wait();
             
             if ((int)e.ChatLogEntry.MessageType == 313 || (int)e.ChatLogEntry.MessageType == 185 || MessageType.SystemMessages.Equals(e.ChatLogEntry.MessageType))
             {

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -338,8 +338,6 @@ namespace Magitek
             }
 
             CombatMessageManager.UpdateDisplayedMessage();
-
-            GambitLogic.Gambit().Wait();
             
             if ((int)e.ChatLogEntry.MessageType == 313 || (int)e.ChatLogEntry.MessageType == 185 || MessageType.SystemMessages.Equals(e.ChatLogEntry.MessageType))
             {

--- a/Magitek/Utilities/Globals.cs
+++ b/Magitek/Utilities/Globals.cs
@@ -11,7 +11,7 @@ namespace Magitek.Utilities
     internal static class Globals
     {
         public static bool InParty => PartyManager.IsInParty;
-        public static bool PartyInCombat => Core.Me.InCombat || Combat.Enemies.Any(/*r => r.TaggerType == 2*/);
+        public static bool PartyInCombat => Core.Me.InCombat || (InParty && Group.CastableAlliesWithin50.Any(ally => ally.InCombat));
         public static bool InGcInstance => RaptureAtkUnitManager.Controls.Any(r => r.Name == "GcArmyOrder");
         public static bool OnPvpMap => Core.Me.OnPvpMap();
         public static bool InActiveDuty => DutyManager.InInstance && Duty.State() == Duty.States.InProgress;

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -37,7 +37,8 @@ namespace Magitek.Utilities
                     //In an instance, not autonomous
                     //Track every tagged or aggroed enemy in the vicinity
                     _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => (r.TaggerType > 0
-                                                                                                       || r.HasTarget)
+                                                                                                    || r.HasTarget
+                                                                                                    || (r.IsBoss() && Core.Me.InCombat))
                                                                                                    && Core.Me.Distance(r) < 50)
                                                                                        .ToList();
                 }

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -37,8 +37,7 @@ namespace Magitek.Utilities
                     //In an instance, not autonomous
                     //Track every tagged or aggroed enemy in the vicinity
                     _enemyCache = GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => (r.TaggerType > 0
-                                                                                                       || r.HasTarget
-                                                                                                       || r.IsBoss())
+                                                                                                       || r.HasTarget)
                                                                                                    && Core.Me.Distance(r) < 50)
                                                                                        .ToList();
                 }


### PR DESCRIPTION
1. Refresh the combat time and check Gambits on every GamelogManager.MessageRecevied event, so that it can be fired out of Combat. This fixes many currently broken conditions such as Combat Time, In Combat/Out of Combat, use only once per combat etc.
2. Add CountdownTimer condition to Gambits, combining with the changes in 1 prepulls become possible (you can always add more conditions such as in instance to prevent false countdown)