### PR TITLE
PCT, SMN, Tanks, PVP, NPE guards, improved opener resetting. 

### DIFF
--- a/Magitek/Gambits/Gambit.cs
+++ b/Magitek/Gambits/Gambit.cs
@@ -48,7 +48,14 @@ namespace Magitek.Gambits
 
         public async Task<bool> Execute()
         {
-            return await Action.Execute(Conditions);
+            try
+            {
+                return await Action.Execute(Conditions);
+            }
+            catch (System.Exception)
+            {
+                return false;
+            }
         }
     }
 }

--- a/Magitek/Logic/CustomOpenerLogic.cs
+++ b/Magitek/Logic/CustomOpenerLogic.cs
@@ -25,7 +25,17 @@ namespace Magitek.Logic
         public static HashSet<OpenerGroup> _executedOpeners = new HashSet<OpenerGroup>();
         private static Gambit _executingGambit = null;
         private static Stopwatch GambitTimer { get; set; }
+        public static DateTime LastReset = DateTime.UtcNow;
 
+        internal static void ResetOpener()
+        {
+            InOpener = false;
+            _executingOpener = null;
+            _executingGambit = null;
+            _executedOpeners.Clear();
+            LastReset = DateTime.UtcNow;
+            BaseSettings.Instance.ResetOpeners = false;
+        }
         
         internal static async Task<bool> Opener()
         {
@@ -33,11 +43,7 @@ namespace Magitek.Logic
             // User sets it to true, when it iterates through we set it back to false
             if (BaseSettings.Instance.ResetOpeners)
             {
-                InOpener = false;
-                _executingOpener = null;
-                _executingGambit = null;
-                _executedOpeners.Clear();
-                BaseSettings.Instance.ResetOpeners = false;
+                ResetOpener();
                 Logger.WriteInfo(@"Opener Reset");
                 return true;
             }

--- a/Magitek/Logic/DarkKnight/Pvp.cs
+++ b/Magitek/Logic/DarkKnight/Pvp.cs
@@ -177,10 +177,24 @@ namespace Magitek.Logic.DarkKnight
             if(Core.Me.CurrentHealthPercent > DarkKnightSettings.Instance.Pvp_EventideHealthPercent)
                 return false;
 
-            if (Core.Me.CurrentTarget.Distance(Core.Me) > 3)
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 8)
                 return false;
 
             return await Spells.EventidePvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> SaltAndDarkness()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!DarkKnightSettings.Instance.Pvp_SaltAndDarkness)
+                return false;
+
+            if (!Spells.SaltAndDarknessPvp.CanCast())
+                return false;
+
+            return await Spells.SaltAndDarknessPvp.Cast(Core.Me);
         }
     }
 }

--- a/Magitek/Logic/Pictomancer/SingleTarget.cs
+++ b/Magitek/Logic/Pictomancer/SingleTarget.cs
@@ -75,7 +75,10 @@ namespace Magitek.Logic.Pictomancer
                 return false;
 
             if (PictomancerSettings.Instance.SaveCometInBlackForStarry
-                && Utilities.Routines.Pictomancer.StarryOffCooldownSoon())
+                && Utilities.Routines.Pictomancer.StarryOffCooldownSoon(PictomancerSettings.Instance.SaveForStarryMsComet)
+                && !Core.Me.HasAura(Auras.StarryMuse, true)
+                && !Spells.SubtractivePalette.CanCast()
+                && ActionResourceManager.Pictomancer.PalleteGauge < 50)
                 return false;
             else if (PictomancerSettings.Instance.SaveCometInBlackForStarry
                 && !Core.Me.HasAura(Auras.StarryMuse, true)
@@ -83,6 +86,13 @@ namespace Magitek.Logic.Pictomancer
                 return false;
 
             if (PictomancerSettings.Instance.CometInBlackOnlyDuringStarry
+                && !Core.Me.HasAura(Auras.StarryMuse, true))
+                return false;
+
+            if (PictomancerSettings.Instance.SaveCometInBlackForStarry
+                && PictomancerSettings.Instance.SaveCometInBlackForStarryMovement
+                && !MovementManager.IsMoving
+                && ActionResourceManager.Pictomancer.PalleteGauge < 100
                 && !Core.Me.HasAura(Auras.StarryMuse, true))
                 return false;
 

--- a/Magitek/Logic/Summoner/Aoe.cs
+++ b/Magitek/Logic/Summoner/Aoe.cs
@@ -121,10 +121,10 @@ namespace Magitek.Logic.Summoner
             if (!SummonerSettings.Instance.CrimsonStrike) 
                 return false;
 
-            if (SmnResources.ActivePet != SmnResources.ActivePetType.Ifrit)
-                return false;
+            //if (SmnResources.ActivePet != SmnResources.ActivePetType.Ifrit)
+            //    return false;
 
-            if (!Spells.CrimsonStrike.IsKnown()) return false;
+            if (!Spells.CrimsonStrike.IsKnownAndReady()) return false;
 
             if (Casting.LastSpell != Spells.CrimsonCyclone) return false;
 

--- a/Magitek/Logic/Viper/Pvp.cs
+++ b/Magitek/Logic/Viper/Pvp.cs
@@ -19,28 +19,14 @@ namespace Magitek.Logic.Viper
                 return false;
             if (Spells.FirstGenerationPvp.CanCast() && await Spells.FirstGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
                 return true;
-            if (Spells.SecondGenerationPvp.CanCast() && await Spells.SecondGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
+            if (Spells.FirstGenerationPvp.HasCastRecently() && Spells.SecondGenerationPvp.CanCast() && await Spells.SecondGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
                 return true;
-            if (Spells.ThirdGenerationPvp.CanCast() && await Spells.ThirdGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
+            if (Spells.SecondGenerationPvp.HasCastRecently() && Spells.ThirdGenerationPvp.CanCast() && await Spells.ThirdGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
                 return true;
-            if (Spells.FourthGenerationPvp.CanCast() && await Spells.FourthGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
+            if (Spells.ThirdGenerationPvp.HasCastRecently() && Spells.FourthGenerationPvp.CanCast() && await Spells.FourthGenerationPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
                 return true;
-
-            if (!Spells.OuroborosPvp.CanCast())
-                return false;
-
-            var pvpComboCheck = DataManager.GetSpellData(ActionManager.GetPvPComboCurrentActionId(65));
-
-            if (pvpComboCheck == Spells.FirstGenerationPvp ||
-                pvpComboCheck == Spells.SecondGenerationPvp ||
-                pvpComboCheck == Spells.ThirdGenerationPvp ||
-                pvpComboCheck == Spells.FourthGenerationPvp)
-            {
-                return false;
-            }
-
-            if (await Spells.OuroborosPvp.Cast(Core.Me.CurrentTarget))
-                return true;
+            if (Spells.FourthGenerationPvp.HasCastRecently() && Spells.OuroborosPvp.CanCast())
+                return await Spells.OuroborosPvp.Cast(Core.Me.CurrentTarget);
 
             return false;
         }

--- a/Magitek/Logic/Viper/Pvp.cs
+++ b/Magitek/Logic/Viper/Pvp.cs
@@ -47,6 +47,8 @@ namespace Magitek.Logic.Viper
 
         public static async Task<bool> DualFang()
         {
+            if (Core.Me.HasAura(Auras.PvpReawakened, true))
+                return false;
             if (Spells.RavenousBitePvp.CanCast() && await Spells.RavenousBitePvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
                 return true;
             if (Spells.SwiftskinsStingPvp.CanCast() && await Spells.SwiftskinsStingPvp.CastPvpCombo(Spells.DualFangPvpCombo, Core.Me.CurrentTarget))
@@ -85,11 +87,11 @@ namespace Magitek.Logic.Viper
             if (uncoiledFury.Cooldown.TotalMilliseconds <= 5000)
                 return false;
 
-            if (!Spells.RattlingCoilPvp.CanCast())
+            if (Core.Me.HasAura(Auras.PvpReawakened, true))
                 return false;
 
-            //if (Spells.SnakeScalesPvp.Cooldown == TimeSpan.Zero)
-            //    return false;
+            if (!Spells.RattlingCoilPvp.CanCast())
+                return false;
 
             return await Spells.RattlingCoilPvp.Cast(Core.Me);
         }
@@ -98,7 +100,13 @@ namespace Magitek.Logic.Viper
         {
             var spell = Spells.UncoiledFuryPvp;
 
+            if (Core.Me.HasAura(Auras.PvpReawakened, true) && Core.Me.CurrentTarget.Distance() <= 5)
+                return false;
+
             if (!spell.CanCast(Core.Me.CurrentTarget))
+                return false;
+
+            if (Core.Me.CurrentTarget.CurrentHealthPercent > ViperSettings.Instance.Pvp_UncoiledFuryHealthPercent)
                 return false;
 
             return await spell.Cast(Core.Me.CurrentTarget);
@@ -109,6 +117,9 @@ namespace Magitek.Logic.Viper
             var spell = Spells.HuntersSnapPvp.Masked();
 
             if (spell.Charges < 1)
+                return false;
+
+            if (Core.Me.HasAura(Auras.PvpReawakened, true))
                 return false;
 
             if (!spell.CanCast(Core.Me.CurrentTarget))

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -259,10 +259,12 @@ namespace Magitek
                 }
             }
 
-            if (Combat.OutOfCombatTime.ElapsedMilliseconds >= 10500 && CustomOpenerLogic._executedOpeners.Count > 0)
+            if (Combat.OutOfCombatTime.ElapsedMilliseconds >= 10500
+                && (CustomOpenerLogic._executedOpeners.Count > 0 || CustomOpenerLogic.InOpener)
+                && (DateTime.UtcNow - CustomOpenerLogic.LastReset).TotalMilliseconds >= 10500)
             {
                 Logger.WriteInfo(@"Resetting Openers Because We're Out Of Combat");
-                CustomOpenerLogic._executedOpeners.Clear();
+                CustomOpenerLogic.ResetOpener();
             }
 
             if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)

--- a/Magitek/Models/DarkKnight/DarkKnightSettings.cs
+++ b/Magitek/Models/DarkKnight/DarkKnightSettings.cs
@@ -247,6 +247,10 @@ namespace Magitek.Models.DarkKnight
 
         [Setting]
         [DefaultValue(true)]
+        public bool Pvp_SaltAndDarkness { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool Pvp_Eventide { get; set; }
 
         [Setting]

--- a/Magitek/Models/Pictomancer/PictomancerSettings.cs
+++ b/Magitek/Models/Pictomancer/PictomancerSettings.cs
@@ -17,10 +17,10 @@ namespace Magitek.Models.Pictomancer
 
         public static PictomancerSettings Instance { get; set; } = new PictomancerSettings();
 
-        #region General-Stuff       
+        #region General-Stuff
         [Setting]
         [DefaultValue(false)]
-        public bool UseHammerDuringStarry { get; set; }
+        public bool UseHammerDuringHyperphantasia { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -35,16 +35,20 @@ namespace Magitek.Models.Pictomancer
         public bool CometInBlackOnlyDuringStarry { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
-        public bool UseMogDuringStarry { get; set; }
+        [DefaultValue(true)]
+        public bool SaveCometInBlackForStarryMovement { get; set; }
 
         [Setting]
         [DefaultValue(true)]
         public bool SaveMogForStarry { get; set; }
 
         [Setting]
-        [DefaultValue(20)]
-        public int SaveForStarryMSeconds { get; set; }
+        [DefaultValue(true)]
+        public bool UseMogDuringHyperphantasia { get; set; }
+
+        [Setting]
+        [DefaultValue(24000)]
+        public int SaveForStarryMsComet { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -77,7 +81,7 @@ namespace Magitek.Models.Pictomancer
         public bool SwiftcastMotifsOnlyWhenMoving { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool SwiftcastCreatureMotifs { get; set; }
 
         [Setting]
@@ -85,7 +89,7 @@ namespace Magitek.Models.Pictomancer
         public bool SwiftcastWeaponMotifs { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool SwiftcastLandscapeMotifs { get; set; }
 
         [Setting]
@@ -119,6 +123,14 @@ namespace Magitek.Models.Pictomancer
         [Setting]
         [DefaultValue(false)]
         public bool UseStarrySkyWhileMoving { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool SaveStarryForHammers { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool SaveStarryForMog { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -637,8 +637,12 @@ namespace Magitek.Models.Scholar
         public bool Pvp_SummonSeraph { get; set; }
 
         [Setting]
-        [DefaultValue(1)]
+        [DefaultValue(3)]
         public int Pvp_SummonSeraphNearbyAllies { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_Consolation { get; set; }
         #endregion
 
         public void Load(string path)

--- a/Magitek/Models/Viper/ViperSettings.cs
+++ b/Magitek/Models/Viper/ViperSettings.cs
@@ -98,6 +98,10 @@ namespace Magitek.Models.Viper
         public float Pvp_SnakeScalesHealthPercent { get; set; }
 
         [Setting]
+        [DefaultValue(100f)]
+        public float Pvp_UncoiledFuryHealthPercent { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool Pvp_WorldSwallower { get; set; }
 

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -122,7 +122,7 @@ namespace Magitek.Rotations
             if (await CommonPvp.CommonTasks(DarkKnightSettings.Instance)) return true;
             
             
-
+            if (await Pvp.SaltAndDarkness()) return true;
             if (await Pvp.EventidePvp()) return true;
             if (await Pvp.BlackestNightPvp()) return true;
             if (await Pvp.SaltedEarthPvp()) return true;

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -67,6 +67,7 @@ namespace Magitek.Rotations
             Casting.DoHealthChecks = false;
 
             if (await GambitLogic.Gambit()) return true;
+            if (await CustomOpenerLogic.Opener()) return true;
             return false;
 
         }
@@ -104,35 +105,37 @@ namespace Magitek.Rotations
             if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
 
-            if (await Buff.FightLogic_TemperaGrassa()) return true;
-            if (await Buff.FightLogic_TemperaCoat()) return true;
-            if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
+            PictomancerRoutine.DetectSmudge();
 
-            if (PictomancerRoutine.GlobalCooldown.CanWeave()) 
+            if (PictomancerRoutine.GlobalCooldown.CanWeave())
             {
-                if (await Healer.LucidDreaming(PictomancerSettings.Instance.UseLucidDreaming, PictomancerSettings.Instance.LucidDreamingMinimumManaPercent)) return true;   
+                if (await Buff.FightLogic_TemperaGrassa()) return true;
+                if (await Buff.FightLogic_TemperaCoat()) return true;
+                if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
+                if (await Healer.LucidDreaming(PictomancerSettings.Instance.UseLucidDreaming, PictomancerSettings.Instance.LucidDreamingMinimumManaPercent)) return true;
             }
 
-            if (await Buff.SubtractivePalette()) return true;
+            if (PictomancerRoutine.GlobalCooldown.CanWeave(1) || MovementManager.IsMoving)
+            {
+                if (await Palette.MogoftheAges()) return true;
+                if (await Palette.CreatureMuse()) return true;
+                if (await Palette.StrikingMuse()) return true;
+            }
 
             // palettes
+            if (await SingleTarget.CometinBlack()) return true;
+            if (await Buff.SubtractivePalette()) return true;
+
             if (await Palette.StarPrism()) return true;
             if (await Palette.RainbowDrip()) return true;
-            if (await Palette.ScenicMuse()) return true;
+            if (await Palette.ScenicMuse()) return true;            
 
-            if (await Palette.MogoftheAges()) return true;
             if (await Palette.HammerStamp()) return true;
-
-            if (await Palette.CreatureMuse()) return true;
-            if (await Palette.StrikingMuse()) return true;
-
-            if (await SingleTarget.CometinBlack()) return true;
 
             // inspiration is on a timer, need to consume those stacks first.
             // don't waste time painting more palettes
             if (PictomancerSettings.Instance.PaletteDuringStarry 
-                || !Core.Me.HasAura(Auras.Hyperphantasia) 
-                || (PictomancerSettings.Instance.SwiftcastMotifs && Spells.Swiftcast.IsKnownAndReady()))
+                || !Core.Me.HasAura(Auras.StarryMuse, true))
             {
                 if (await Palette.LandscapeMotif()) return true;
                 if (await Palette.CreatureMotif()) return true;

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -264,10 +264,10 @@ namespace Magitek.Rotations
 
             ScholarRoutine.RefreshVars();
 
-            if (await CommonPvp.CommonTasks(ScholarSettings.Instance)) return true;
-            
+            if (await CommonPvp.CommonTasks(ScholarSettings.Instance)) return true;           
             
 
+            if (await Pvp.ConsolationPvp()) return true;
             if (await Pvp.SummonSeraphPvp()) return true;
 
             if (await Pvp.DeploymentTacticsEnemyPvp()) return true;

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -183,19 +183,18 @@ namespace Magitek.Rotations
                 return await Combat();
 
             if (await CommonPvp.CommonTasks(ViperSettings.Instance)) return true;
+            if (await Pvp.SnakeScales()) return true;
 
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (await Pvp.RattlingCoil()) return true;
+            if (await Pvp.SerpentsTail()) return true;
             if (await Pvp.WorldGeneration()) return true;
             if (await Pvp.WorldSwallower()) return true;
 
-            if (await Pvp.SnakeScales()) return true;
-
             if (!CommonPvp.GuardCheck(ViperSettings.Instance))
             {
-                if (await Pvp.SerpentsTail()) return true;
+                if (await Pvp.RattlingCoil()) return true;
                 if (await Pvp.UncoiledFury()) return true;
                 if (await Pvp.HuntersSnap()) return true;
             }

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -407,6 +407,7 @@ namespace Magitek.Utilities
             MonochromeTones = 3691,
             Inspiration = 3689,
             HammerTime = 3680,
+            Smudge = 3684,
 
             //RDM
             MagickedSwordplay = 3875,

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -272,14 +272,14 @@ namespace Magitek.Utilities
                 var auraTarget = AuraTarget ?? SpellTarget;
 
                 if (UseRefreshTime)
-                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura, true, RefreshTime) || MovementManager.IsMoving);
+                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura, true, RefreshTime) || MovementManager.IsMoving || !auraTarget.IsValid || auraTarget.CurrentHealth == 0);
                 else
                 {
-                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura, true) || MovementManager.IsMoving);
+                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura, true) || MovementManager.IsMoving || !auraTarget.IsValid || auraTarget.CurrentHealth == 0);
                 }
 
                 if (CastingSpell.AdjustedCastTime == TimeSpan.Zero)
-                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura));
+                    await Coroutine.Wait(3000, () => auraTarget.HasAura(Aura) || !auraTarget.IsValid || auraTarget.CurrentHealth == 0);
             }
 
             #endregion

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -58,10 +58,6 @@ namespace Magitek.Utilities
             if (enemy == null)
                 return false;
 
-            // prevent running duplicate fightlogic responses to the same spell when it's a long cast. 
-            if (FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
-                return false;
-
             if (!await task) return false;
 
             FlHandledCastingSpellId.Add(enemy.CastingSpellId);
@@ -79,6 +75,10 @@ namespace Magitek.Utilities
             if (enemyLogic?.TankBusters == null || enemy == null || encounter == null)
                 return EnemyIsCastingSharedTankBuster();
 
+            if (FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
+                return null;
+            FlHandledCastingSpellId.Clear();
+
             var output = enemyLogic.TankBusters.Contains(enemy.CastingSpellId)
                 ? Group.CastableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
                 : null;
@@ -88,7 +88,9 @@ namespace Magitek.Utilities
                     $"[TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name} on {output.CurrentJob} in our party.");
 
             if (output != null)
+            {
                 FlStopwatch.Start();
+            }
 
             return output;
         }
@@ -102,6 +104,10 @@ namespace Magitek.Utilities
 
             if (enemyLogic?.SharedTankBusters == null || enemy == null || encounter == null)
                 return null;
+
+            if (FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
+                return null;
+            FlHandledCastingSpellId.Clear();
 
             var output = enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
                 ? Group.CastableTanks.FirstOrDefault(x => x != enemy.TargetCharacter)
@@ -128,6 +134,10 @@ namespace Magitek.Utilities
             if (enemyLogic?.Aoes == null || enemy == null || encounter == null)
                 return false;
 
+            if (FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
+                return false;
+            FlHandledCastingSpellId.Clear();
+
             var output = enemyLogic.Aoes.Contains(enemy.CastingSpellId);
 
             if (output && DebugSettings.Instance.DebugFightLogic)
@@ -148,6 +158,10 @@ namespace Magitek.Utilities
 
             if (enemyLogic.BigAoes == null)
                 return EnemyIsCastingAoe();
+
+            if (FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
+                return false;
+            FlHandledCastingSpellId.Clear();
 
             var output = enemyLogic.BigAoes.Contains(enemy.CastingSpellId);
 

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -76,7 +76,7 @@ namespace Magitek.Utilities
 
             var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
-            if (enemyLogic?.TankBusters == null)
+            if (enemyLogic?.TankBusters == null || enemy == null || encounter == null)
                 return EnemyIsCastingSharedTankBuster();
 
             var output = enemyLogic.TankBusters.Contains(enemy.CastingSpellId)

--- a/Magitek/Utilities/Globals.cs
+++ b/Magitek/Utilities/Globals.cs
@@ -25,7 +25,7 @@ namespace Magitek.Utilities
             get {
                 // a lower threshold should be safe to assume if the routine is going to wait for the game to release the lock
                 if (BaseSettings.Instance.DebugActionLockWait)
-                    return 610;
+                    return 625;
                 else
                     return 770;
             }

--- a/Magitek/Utilities/Routines/DarkKnight.cs
+++ b/Magitek/Utilities/Routines/DarkKnight.cs
@@ -20,6 +20,7 @@ namespace Magitek.Utilities.Routines
 
         public static readonly uint[] Defensives = new uint[]
         {
+            Auras.Rampart,
             Auras.LivingDead,
             Auras.ShadowWall,
             Auras.Rampart,

--- a/Magitek/Utilities/Routines/Gunbreaker.cs
+++ b/Magitek/Utilities/Routines/Gunbreaker.cs
@@ -25,6 +25,7 @@ namespace Magitek.Utilities.Routines
 
         public static readonly uint[] Defensives = new uint[]
         {
+            Auras.Rampart,
             Auras.Camouflage,
             Auras.Nebula,
             Auras.Aurora,

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -1477,6 +1477,7 @@ namespace Magitek.Utilities
         public static readonly SpellData SaltedEarthPvp = DataManager.GetSpellData(29094);
         public static readonly SpellData EventidePvp = DataManager.GetSpellData(29097);
         public static readonly SpellData QuietusPvp = DataManager.GetSpellData(29737);
+        public static readonly SpellData SaltAndDarknessPvp = DataManager.GetSpellData(29095);
 
         //WAR
         public static readonly uint StormPathPvpCombo = 51;

--- a/Magitek/Views/UserControls/Pictomancer/Palettes.xaml
+++ b/Magitek/Views/UserControls/Pictomancer/Palettes.xaml
@@ -106,23 +106,26 @@
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
-                <StackPanel Margin="10,0" Orientation="Horizontal">
+                <!-- <StackPanel Margin="10,0" Orientation="Horizontal">
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Save hammer/mog for Starry within " />
-                    <controls:Numeric MaxValue="30" MinValue="0" Value="{Binding PictomancerSettings.SaveForStarryMSeconds, Mode=TwoWay}" />
+                    <controls:Numeric MaxValue="120" MinValue="0" Value="{Binding PictomancerSettings.SaveForStarryMSeconds, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" seconds " />
-                </StackPanel>
+                </StackPanel> -->
 
                 <StackPanel Orientation="Vertical">
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox Margin="5" Content=" Use Hammers During Hyperphantasia " IsChecked="{Binding PictomancerSettings.UseHammerDuringStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <CheckBox Margin="5" Content=" Use Hammers During Hyperphantasia " IsChecked="{Binding PictomancerSettings.UseHammerDuringHyperphantasia, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                         <CheckBox Margin="5" Content=" Save Hammers for Starry " IsChecked="{Binding PictomancerSettings.SaveHammerForStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <CheckBox Margin="5" Content=" Save Comet in Black for Starry " IsChecked="{Binding PictomancerSettings.SaveCometInBlackForStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                         <CheckBox Margin="5" Content=" Only use Comet with Starry " IsChecked="{Binding PictomancerSettings.CometInBlackOnlyDuringStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="10,0">
+                        <CheckBox Margin="5" Content=" Use extra comets only during movement " IsChecked="{Binding PictomancerSettings.SaveCometInBlackForStarryMovement, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox Margin="5" Content=" Use Mog / Madeen During Hyperphantasia " IsChecked="{Binding PictomancerSettings.UseMogDuringStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <CheckBox Margin="5" Content=" Use Mog / Madeen During Hyperphantasia " IsChecked="{Binding PictomancerSettings.UseMogDuringHyperphantasia, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                         <CheckBox Margin="5" Content=" Save Mog / Madeen for Starry " IsChecked="{Binding PictomancerSettings.SaveMogForStarry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     </StackPanel>
                 </StackPanel>

--- a/Magitek/Views/UserControls/Scholar/Pvp.xaml
+++ b/Magitek/Views/UserControls/Scholar/Pvp.xaml
@@ -74,6 +74,9 @@
                     <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="4" MinValue="0" Value="{Binding ScholarSettings.Pvp_SummonSeraphNearbyAllies, Mode=TwoWay}" />
                     <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Allies around" />
                 </StackPanel>
+                <StackPanel Margin="5">
+                    <CheckBox Content="Consolation" IsChecked="{Binding ScholarSettings.Pvp_Consolation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 
@@ -99,7 +102,7 @@
                     <CheckBox Content="Self Heal Only" IsChecked="{Binding ScholarSettings.Pvp_HealSelfOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Grid.Row="0" Grid.Column="0" Content="Aspected Benefic At " IsChecked="{Binding ScholarSettings.Pvp_Adloquium, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Row="0" Grid.Column="0" Content="Adloquium At " IsChecked="{Binding ScholarSettings.Pvp_Adloquium, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="0" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding ScholarSettings.Pvp_AdloquiumHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
                 </StackPanel>

--- a/Magitek/Views/UserControls/Viper/Pvp.xaml
+++ b/Magitek/Views/UserControls/Viper/Pvp.xaml
@@ -68,6 +68,11 @@
             <StackPanel Margin="5">
                 <TextBlock Style="{DynamicResource TextBlockSection}" Text="General" />
                 <StackPanel Margin="5" Orientation="Horizontal">
+                    <TextBlock Grid.Row="1" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text="Uncoiled Fury (ranged) " />
+                    <controls:Numeric Grid.Row="1" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding ViperSettings.Pvp_UncoiledFuryHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="1" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="World Swallower / LB on target at " IsChecked="{Binding ViperSettings.Pvp_WorldSwallower, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <controls:Numeric Grid.Row="1" Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding ViperSettings.Pvp_WorldSwallowerHealthPercent, Mode=TwoWay}" />
                     <TextBlock Grid.Row="1" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />


### PR DESCRIPTION
General

- Fix a few cases where NPE can occur
- Update cooldown calculation for multiple charges.
- Improve Opener reset when out of combat.

Jobs

- FightLogic: Better handling of 1-response-per-unique-cast. 
- PCT: Improved rotation to align with meta.
- SMN: yet another fix crimson strike usage.
- Tanks: Add rampart as a defensive to consider for limiting defensive usage.

PvP

- PVP All: Better sprint usage when melee when chasing or running away, invuln checks for heals and self-guard
- VPR Pvp: improved rotation for kills & limit break reliability
- DRK Pvp: add salt and darkness.
- SCH Pvp: Mummification closest target, add Consolation, improve Expedient usage for bio preading.

