### PR TITLE
Rotation refactor, Openers in Heal, tank & healer fightlogic adjustments, true north, multidotting

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -234,7 +234,7 @@ namespace Magitek.Extensions
                 && Tanks.Contains(gameObject.CurrentJob)
                 && (gameObject.BeingTargetedBy(Core.Me.CurrentTarget)
                     || gameObject.BeingTargetedBy(gameObject.TargetGameObject)
-                    || PartyManager.RawMembers.Where(r => r != null).Select(r => r.BattleCharacter).Count(r => Tanks.Contains(r.CurrentJob)) == 1);
+                    || PartyManager.RawMembers.Where(r => r != null).Select(r => r.BattleCharacter).Count(r => r != null && Tanks.Contains(r.CurrentJob)) == 1);
         }
 
         public static bool IsTank(this GameObject unit, bool mainTank)

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -211,6 +211,16 @@ namespace Magitek.Extensions
             return Combat.Enemies.Where(r => r.Distance(unit) <= distance && r.HasAura(aura, true));
         }
 
+        public static bool IsMelee(this GameObject unit)
+        {
+            return unit.IsTank() || unit.IsMeleeDps();
+        }
+
+        public static bool IsRanged(this GameObject unit)
+        {
+            return unit.IsHealer() || unit.IsRangedDps();
+        }
+
         public static bool IsTank(this GameObject unit)
         {
             var gameObject = unit as Character;
@@ -277,13 +287,19 @@ namespace Magitek.Extensions
         public static bool IsRangedDpsCard(this GameObject unit)
         {
             var gameObject = unit as Character;
-            return gameObject != null && RangedDpsCard.Contains(gameObject.CurrentJob);
+            return gameObject != null && RangedDps.Contains(gameObject.CurrentJob);
         }
 
         public static bool IsMeleeDps(this GameObject unit)
         {
             var gameObject = unit as Character;
             return gameObject != null && MeleeDps.Contains(gameObject.CurrentJob);
+        }
+
+        public static bool IsRangedDps(this GameObject unit)
+        {
+            var gameObject = unit as Character;
+            return gameObject != null && RangedDps.Contains(gameObject.CurrentJob);
         }
 
         public static bool HasMyRegen(this GameObject unit)
@@ -579,7 +595,7 @@ namespace Magitek.Extensions
             ClassJobType.Viper
         };
 
-        private static readonly List<ClassJobType> RangedDpsCard = new List<ClassJobType>()
+        private static readonly List<ClassJobType> RangedDps = new List<ClassJobType>()
         {
             ClassJobType.Archer,
             ClassJobType.Bard,

--- a/Magitek/Logic/Dragoon/Utility.cs
+++ b/Magitek/Logic/Dragoon/Utility.cs
@@ -25,9 +25,6 @@ namespace Magitek.Logic.Dragoon
             if (Core.Me.HasAura(Auras.TrueNorth))
                 return false;
 
-            if (Casting.LastSpell != Spells.FullThrust && Casting.LastSpell != Spells.ChaosThrust && Casting.LastSpell != Spells.WheelingThrust && Casting.LastSpell != Spells.FangAndClaw)
-                return false;
-
             if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= 10 + x.CombatReach) >= DragoonSettings.Instance.AoeEnemies)
                 return false;
 

--- a/Magitek/Logic/Dragoon/Utility.cs
+++ b/Magitek/Logic/Dragoon/Utility.cs
@@ -7,6 +7,7 @@ using Magitek.Toggles;
 using Magitek.Utilities;
 using System.Linq;
 using System.Threading.Tasks;
+using DragoonRoutine = Magitek.Utilities.Routines.Dragoon;
 
 namespace Magitek.Logic.Dragoon
 {
@@ -33,7 +34,7 @@ namespace Magitek.Logic.Dragoon
             if (Spells.TrueThrust.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
                 return false;
 
-            if (ActionManager.LastSpell == Spells.Disembowel)
+            if (ActionManager.LastSpell == DragoonRoutine.Disembowel)
             {
                 if (Core.Me.CurrentTarget.IsBehind)
                     return false;
@@ -41,7 +42,7 @@ namespace Magitek.Logic.Dragoon
                 return await Spells.TrueNorth.CastAura(Core.Me, Auras.TrueNorth);
             }
 
-            if (Core.Me.HasAura(Auras.EnhancedWheelingThrust))
+            if (ActionManager.LastSpell == DragoonRoutine.ChaoticSpring)
             {
                 if (Core.Me.CurrentTarget.IsBehind)
                     return false;
@@ -49,7 +50,7 @@ namespace Magitek.Logic.Dragoon
                 return await Spells.TrueNorth.CastAura(Core.Me, Auras.TrueNorth);
             }
 
-            if (Core.Me.HasAura(Auras.SharperFangandClaw))
+            if (ActionManager.LastSpell == DragoonRoutine.HeavensThrust)
             {
                 if (Core.Me.CurrentTarget.IsFlanking)
                     return false;

--- a/Magitek/Logic/Monk/Buff.cs
+++ b/Magitek/Logic/Monk/Buff.cs
@@ -2,6 +2,7 @@
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.Roles;
+using Magitek.Models.Account;
 using Magitek.Models.Monk;
 using MonkRoutine = Magitek.Utilities.Routines.Monk;
 using Magitek.Utilities;
@@ -24,6 +25,9 @@ namespace Magitek.Logic.Monk
                 return false;
 
             if (Core.Me.CurrentTarget.IsBehind)
+                return false;
+
+            if (Spells.Bootshine.Cooldown.TotalMilliseconds > Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100)
                 return false;
 
             if (Core.Me.HasAura(Auras.CoeurlForm) && ActionResourceManager.Monk.CoeurlFury == 0 && !Core.Me.HasAura(Auras.PerfectBalance))

--- a/Magitek/Logic/Monk/Buff.cs
+++ b/Magitek/Logic/Monk/Buff.cs
@@ -12,6 +12,47 @@ namespace Magitek.Logic.Monk
 {
     internal static class Buff
     {
+        public static async Task<bool> TrueNorth()
+        {
+            if (MonkSettings.Instance.EnemyIsOmni || !MonkSettings.Instance.UseTrueNorth)
+                return false;
+
+            if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= 10 + x.CombatReach) >= MonkSettings.Instance.AoeEnemies)
+                return false;
+
+            if (Core.Me.HasAura(Auras.TrueNorth))
+                return false;
+
+            if (Core.Me.CurrentTarget.IsBehind)
+                return false;
+
+            if (Core.Me.HasAura(Auras.CoeurlForm) && ActionResourceManager.Monk.CoeurlFury == 0 && !Core.Me.HasAura(Auras.PerfectBalance))
+            {
+                 if (Core.Me.CurrentTarget.IsBehind)
+                    return false;
+
+                 return await Spells.TrueNorth.CastAura(Core.Me, Auras.TrueNorth);
+            }
+
+            if (Core.Me.ClassLevel >= Spells.PouncingCoeurl.LevelAcquired && Core.Me.HasAura(Auras.CoeurlForm) && ActionResourceManager.Monk.CoeurlFury >= 0 && !Core.Me.HasAura(Auras.PerfectBalance))
+            {
+                if (Core.Me.CurrentTarget.IsFlanking)
+                    return false;
+
+                return await Spells.TrueNorth.CastAura(Core.Me, Auras.TrueNorth);
+            }
+
+            if (Core.Me.HasAura(Auras.CoeurlForm) && ActionResourceManager.Monk.CoeurlFury >= 1 && !Core.Me.HasAura(Auras.PerfectBalance))
+            {
+                if (Core.Me.CurrentTarget.IsFlanking)
+                    return false;
+
+                return await Spells.TrueNorth.CastAura(Core.Me, Auras.TrueNorth);
+            }
+
+            return false;
+        }
+
         public static async Task<bool> Meditate()
         {
             if (Core.Me.ClassLevel < 54)

--- a/Magitek/Logic/Pictomancer/Buff.cs
+++ b/Magitek/Logic/Pictomancer/Buff.cs
@@ -31,6 +31,9 @@ namespace Magitek.Logic.Pictomancer
             if (!PictomancerSettings.Instance.UseSubtractivePalette)
                 return false;
 
+            if (!Spells.SubtractivePalette.CanCast() || !Spells.SubtractivePalette.IsKnownAndReady())
+                return false;
+
             if (Utilities.Routines.Pictomancer.HasBlackPaint())
                 return false;
 

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -33,11 +33,12 @@ namespace Magitek.Logic.Roles
 
                 foreach (var defensiveSpell in defensiveSpells)
                 {
-                    if (defensiveSpell.IsKnownAndReady())
+                    if (defensiveSpell.IsKnownAndReadyAndCastable(Core.Me))
                     {
                         if (BaseSettings.Instance.DebugFightLogic)
                             Logger.WriteInfo($"[TankDefensive Response] Cast {defensiveSpell.Name}");
-                        return await FightLogic.DoAndBuffer(defensiveSpell.Cast(Core.Me));
+                        if (await FightLogic.DoAndBuffer(defensiveSpell.Cast(Core.Me)))
+                            return true; // intentionally continue to next defensive in the list. 
                     }
                 }
             }

--- a/Magitek/Logic/Sage/AoE.cs
+++ b/Magitek/Logic/Sage/AoE.cs
@@ -86,7 +86,10 @@ namespace Magitek.Logic.Sage
             if (!SageSettings.Instance.EukrasianDyskrasia)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.Dyskrasia.Radius + r.CombatReach) < SageSettings.Instance.AoEEnemies)
+            if (!Spells.EukrasianDyskrasia.IsKnownAndReady())
+                return false;
+
+            if (Combat.Enemies.Count(r => r.Distance(Core.Me) <= Spells.EukrasianDyskrasia.Radius + r.CombatReach) < SageSettings.Instance.AoEEnemies)
                 return false;
 
             if (!Heal.IsEukrasiaReady())
@@ -97,22 +100,20 @@ namespace Magitek.Logic.Sage
             if (targetChar != null && targetChar.CharacterAuras.Count() >= 25)
                 return false;
 
-            if (Core.Me.CurrentTarget.HasAnyAura(DotAuras, true, msLeft: SageSettings.Instance.DotRefreshMSeconds))
-                return false;
-
-            if (Core.Me.CurrentTarget.Distance(Core.Me) > 25 + Core.Me.CurrentTarget.CombatReach)
+            if (!Combat.Enemies.Any(x => (!x.HasAnyAura(DotAuras, true) || (x.HasAnyAura(DotAuras, true) && !x.HasAnyAura(DotAuras, true, SageSettings.Instance.DotRefreshMSeconds)))
+                                         && x.Distance(Core.Me) <= Spells.EukrasianDyskrasia.Radius + Core.Me.CombatReach))
                 return false;
 
             return await UseEukrasianDyskrasia(Core.Me.CurrentTarget);
         }
 
-            private static readonly uint[] DotAuras =
-            {
-                Auras.EukrasianDosis,
-                Auras.EukrasianDosisII,
-                Auras.EukrasianDosisIII,
-                Auras.EukrasianDyskrasia
-            };
+        private static readonly uint[] DotAuras =
+        {
+            Auras.EukrasianDosis,
+            Auras.EukrasianDosisII,
+            Auras.EukrasianDosisIII,
+            Auras.EukrasianDyskrasia
+        };
 
         private static async Task<bool> UseEukrasianDyskrasia(GameObject target)
         {

--- a/Magitek/Logic/Sage/SingleTarget.cs
+++ b/Magitek/Logic/Sage/SingleTarget.cs
@@ -89,7 +89,6 @@ namespace Magitek.Logic.Sage
             return await UseEukrasianDosis(Core.Me.CurrentTarget);
         }
 
-        //No longer in used
         public static async Task<bool> DotMultipleTargets()
         {
             if (!SageSettings.Instance.DoDamage)
@@ -101,7 +100,10 @@ namespace Magitek.Logic.Sage
             if (!SageSettings.Instance.DotMultipleTargets)
                 return false;
 
-            if (SageSettings.Instance.EukrasianDyskrasia)
+            // Don't multidot if we can use the aoe version of it. 
+            // but multidot if we are out of range enough to use the aoe dot.
+            if (Spells.EukrasianDyskrasia.IsKnown()
+                && Combat.Enemies.Count(r => r.Distance(Core.Me) <= (Spells.EukrasianDyskrasia.Radius*1.5) + r.CombatReach) >= SageSettings.Instance.AoEEnemies)
                 return false;
 
             if (!Heal.IsEukrasiaReady())
@@ -139,7 +141,8 @@ namespace Magitek.Logic.Sage
         {
             Auras.EukrasianDosis,
             Auras.EukrasianDosisII,
-            Auras.EukrasianDosisIII
+            Auras.EukrasianDosisIII,
+            Auras.EukrasianDyskrasia
         };
     }
 

--- a/Magitek/Logic/Sage/SingleTarget.cs
+++ b/Magitek/Logic/Sage/SingleTarget.cs
@@ -112,6 +112,9 @@ namespace Magitek.Logic.Sage
             if (Combat.Enemies.Count < 2)
                 return false;
 
+            if (Combat.Enemies.Count(x => x.HasAnyAura(DotAuras, true)) >= SageSettings.Instance.DotTargetLimit)
+                return false;
+
             var DotTarget = Combat.Enemies.Where(NeedsDot).Where(CanDot).FirstOrDefault();
 
             if (DotTarget == null)

--- a/Magitek/Logic/Summoner/Pets.cs
+++ b/Magitek/Logic/Summoner/Pets.cs
@@ -150,8 +150,8 @@ namespace Magitek.Logic.Summoner
                 if (SmnResources.AvailablePets.HasFlag(SmnResources.AvailablePetFlags.Garuda) &&
                     Spells.SummonGaruda.IsKnownAndReady())
                     return Spells.SummonGaruda2.IsKnown()
-                        ? await Spells.SummonGaruda2.Cast(Core.Me.CurrentTarget)
-                        : await Spells.SummonGaruda.Cast(Core.Me.CurrentTarget);
+                        ? await Spells.SummonGaruda2.CastAura(Core.Me.CurrentTarget, Auras.GarudasFavor)
+                        : await Spells.SummonGaruda.CastAura(Core.Me.CurrentTarget, Auras.GarudasFavor);
 
                 if (ArcResources.AvailablePets.HasFlag(ArcResources.AvailablePetFlags.Emerald))
                     return await Spells.SummonEmerald.Cast(Core.Me.CurrentTarget);
@@ -162,8 +162,8 @@ namespace Magitek.Logic.Summoner
                 if (SmnResources.AvailablePets.HasFlag(SmnResources.AvailablePetFlags.Ifrit) &&
                     Spells.SummonIfrit.IsKnownAndReady())
                     return Spells.SummonIfrit2.IsKnown()
-                        ? await Spells.SummonIfrit2.Cast(Core.Me.CurrentTarget)
-                        : await Spells.SummonIfrit.Cast(Core.Me.CurrentTarget);
+                        ? await Spells.SummonIfrit2.CastAura(Core.Me.CurrentTarget, Auras.IfritsFavor)
+                        : await Spells.SummonIfrit.CastAura(Core.Me.CurrentTarget, Auras.IfritsFavor);
 
                 if (ArcResources.AvailablePets.HasFlag(ArcResources.AvailablePetFlags.Ruby))
                     return await Spells.SummonRuby.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Summoner/Pets.cs
+++ b/Magitek/Logic/Summoner/Pets.cs
@@ -150,8 +150,8 @@ namespace Magitek.Logic.Summoner
                 if (SmnResources.AvailablePets.HasFlag(SmnResources.AvailablePetFlags.Garuda) &&
                     Spells.SummonGaruda.IsKnownAndReady())
                     return Spells.SummonGaruda2.IsKnown()
-                        ? await Spells.SummonGaruda2.CastAura(Core.Me.CurrentTarget, Auras.GarudasFavor)
-                        : await Spells.SummonGaruda.CastAura(Core.Me.CurrentTarget, Auras.GarudasFavor);
+                        ? await Spells.SummonGaruda2.CastAura(Core.Me.CurrentTarget, Auras.GarudasFavor, auraTarget: Core.Me)
+                        : await Spells.SummonGaruda.CastAura(Core.Me.CurrentTarget, Auras.GarudasFavor, auraTarget: Core.Me);
 
                 if (ArcResources.AvailablePets.HasFlag(ArcResources.AvailablePetFlags.Emerald))
                     return await Spells.SummonEmerald.Cast(Core.Me.CurrentTarget);
@@ -162,8 +162,8 @@ namespace Magitek.Logic.Summoner
                 if (SmnResources.AvailablePets.HasFlag(SmnResources.AvailablePetFlags.Ifrit) &&
                     Spells.SummonIfrit.IsKnownAndReady())
                     return Spells.SummonIfrit2.IsKnown()
-                        ? await Spells.SummonIfrit2.CastAura(Core.Me.CurrentTarget, Auras.IfritsFavor)
-                        : await Spells.SummonIfrit.CastAura(Core.Me.CurrentTarget, Auras.IfritsFavor);
+                        ? await Spells.SummonIfrit2.CastAura(Core.Me.CurrentTarget, Auras.IfritsFavor, auraTarget: Core.Me)
+                        : await Spells.SummonIfrit.CastAura(Core.Me.CurrentTarget, Auras.IfritsFavor, auraTarget: Core.Me);
 
                 if (ArcResources.AvailablePets.HasFlag(ArcResources.AvailablePetFlags.Ruby))
                     return await Spells.SummonRuby.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Warrior/Aoe.cs
+++ b/Magitek/Logic/Warrior/Aoe.cs
@@ -106,7 +106,7 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UsePrimalRend)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.PrimalRendReady) && !Core.Me.HasAura(Auras.PrimalRuinationReady))
+            if (!Core.Me.HasAura(Auras.PrimalRendReady))
                 return false;
 
             if (!Core.Me.HasAura(Auras.SurgingTempest))
@@ -119,6 +119,20 @@ namespace Magitek.Logic.Warrior
                 return false;
 
             return await Spells.PrimalRend.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> PrimalRuination()
+        {
+            if (!WarriorSettings.Instance.UsePrimalRend)
+                return false;
+
+            if (!Core.Me.HasAura(Auras.PrimalRuinationReady))
+                return false;
+
+            if (!Core.Me.HasAura(Auras.SurgingTempest))
+                return false;
+
+            return await Spells.PrimalRuination.Cast(Core.Me.CurrentTarget);
         }
     }
 }

--- a/Magitek/Logic/WhiteMage/Heal.cs
+++ b/Magitek/Logic/WhiteMage/Heal.cs
@@ -364,7 +364,7 @@ namespace Magitek.Logic.WhiteMage
                                                                        r.CurrentHealthPercent <= WhiteMageSettings.Instance.AsylumHealthPercent &&
                                                                        Group.CastableAlliesWithin30.Count(x => x.CurrentHealth > 0 && x.Distance(r) <= 15 && x.CurrentHealthPercent <= WhiteMageSettings.Instance.AsylumHealthPercent) >= AoeNeedHealing - 1);
 
-            if (WhiteMageSettings.Instance.AsylumCenterParty)
+            if (WhiteMageSettings.Instance.AsylumCenterParty && asylumTarget != null)
             {
                 var targets = Group.CastableAlliesWithin30.OrderBy(r =>
                     Group.CastableAlliesWithin30.Sum(ot => r.Distance(ot.Location))
@@ -378,6 +378,7 @@ namespace Magitek.Logic.WhiteMage
 
             return await Spells.Asylum.Cast(asylumTarget);
         }
+
 
         public static async Task<bool> LiturgyOfTheBell()
         {

--- a/Magitek/Logic/WhiteMage/Heal.cs
+++ b/Magitek/Logic/WhiteMage/Heal.cs
@@ -435,6 +435,9 @@ namespace Magitek.Logic.WhiteMage
             if (Core.Me.ClassLevel < Spells.Medica2.LevelAcquired)
                 return false;
 
+            if (Core.Me.ClassLevel >= Spells.Medica3.LevelAcquired)
+                return false;
+
             if (Casting.LastSpell == Spells.Medica2)
                 return false;
 

--- a/Magitek/Logic/WhiteMage/HealFightLogic.cs
+++ b/Magitek/Logic/WhiteMage/HealFightLogic.cs
@@ -93,20 +93,32 @@ namespace Magitek.Logic.WhiteMage
                 && Spells.PlenaryIndulgence.IsKnownAndReady()
                 && Spells.PlenaryIndulgence.CanCast())
             {
+                if (!FightLogic.HodlCastTimeRemaining(1500))
+                    return false;
+
                 if (BaseSettings.Instance.DebugFightLogic)
                     Logger.WriteInfo($"[AOE Response] Cast Plenary Indulgence");
 
                 return await FightLogic.DoAndBuffer(Spells.PlenaryIndulgence.Cast(Core.Me));
             }
 
-            if (WhiteMageSettings.Instance.FightLogicMedica2
-                && Spells.Medica2.IsKnownAndReady()
-                && Spells.Medica2.CanCast())
+            if (WhiteMageSettings.Instance.FightLogicMedica2)
             {
+                var spell = Spells.Medica3.IsKnown() ? Spells.Medica3 : Spells.Medica2;
+
+                if (!spell.IsKnownAndReady() || !spell.CanCast())
+                    return false;
+
+                if (Group.CastableAlliesWithin30.Any(x => x.HasAura(Auras.Medica2, true) || x.HasAura(Auras.Medica3, true)))
+                    return false;
+
+                if (!FightLogic.HodlCastTimeRemaining(2000))
+                    return false;
+
                 if (BaseSettings.Instance.DebugFightLogic)
                     Logger.WriteInfo($"[AOE Response] Cast Medica 2");
 
-                return await FightLogic.DoAndBuffer(Spells.Medica2.Cast(Core.Me));
+                return await FightLogic.DoAndBuffer(spell.Cast(Core.Me));
             }
 
             return false;

--- a/Magitek/Logic/WhiteMage/SingleTarget.cs
+++ b/Magitek/Logic/WhiteMage/SingleTarget.cs
@@ -103,6 +103,9 @@ namespace Magitek.Logic.WhiteMage
                 && Combat.Enemies.Count > WhiteMageSettings.Instance.DontDotIfMoreEnemiesThan)
                 return false;
 
+            if (Combat.Enemies.Count(x => x.HasAnyAura(DotAuras, true)) >= WhiteMageSettings.Instance.DotTargetLimit)
+                return false;
+
             var dotTarget = Combat.Enemies.FirstOrDefault(NeedsDot);
 
             if (dotTarget == null)

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -257,7 +257,7 @@ namespace Magitek
             {
                 if (BaseSettings.Instance.DebugEnemyInfo)
                 {
-                    Debug.Instance.IsBoss = XivDataHelper.BossDictionary.ContainsKey(Core.Me.CurrentTarget.NpcId) ? "True" : "False";
+                    Debug.Instance.IsBoss = Core.Me.CurrentTarget.IsBoss() ? "True" : "False";
                     Debug.Instance.TargetCombatTimeLeft = Core.Me.CurrentTarget.CombatTimeLeft();
                 }
             }

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -328,19 +328,7 @@ namespace Magitek
         }
 
         private void GamelogManagerCountdownRecevied(object sender, ChatEventArgs e)
-        {
-            Tracking.Update();
-            Utilities.Combat.AdjustCombatTime();
-            Utilities.Combat.AdjustDutyTime();
-
-            if (Utilities.Combat.OutOfCombatTime.ElapsedMilliseconds >= 10500 && CustomOpenerLogic._executedOpeners.Count > 0)
-            {
-                Logger.WriteInfo(@"Resetting Openers Because We're Out Of Combat");
-                CustomOpenerLogic._executedOpeners.Clear();
-            }
-
-            CombatMessageManager.UpdateDisplayedMessage();
-            
+        {            
             if ((int)e.ChatLogEntry.MessageType == 313 || (int)e.ChatLogEntry.MessageType == 185 || MessageType.SystemMessages.Equals(e.ChatLogEntry.MessageType))
             {
                 //Start countdown

--- a/Magitek/Models/Debugging/EnemySpellCastInfo.cs
+++ b/Magitek/Models/Debugging/EnemySpellCastInfo.cs
@@ -1,4 +1,5 @@
-﻿using Magitek.Commands;
+﻿using ff14bot.Managers;
+using Magitek.Commands;
 using Magitek.Extensions;
 using Magitek.Models.WebResources;
 using Magitek.ViewModels;
@@ -14,17 +15,23 @@ namespace Magitek.Models.Debugging
     [AddINotifyPropertyChangedInterface]
     public class EnemySpellCastInfo
     {
-        public EnemySpellCastInfo(string name, uint id, string castedBy)
+        public EnemySpellCastInfo(string name, uint id, string castedBy, uint castedById, ushort zoneId, string zoneName)
         {
             Name = name;
             Id = id;
             CastedBy = castedBy;
+            CastedById = castedById;
+            ZoneId = zoneId;
+            ZoneName = zoneName;
             Icon = this.GetIcon();
         }
 
         public string Name { get; set; }
         public uint Id { get; set; }
         public string CastedBy { get; set; }
+        public uint CastedById { get; set; }
+        public ushort ZoneId { get; set; }        
+        public string ZoneName { get; set; }
         public double Icon { get; set; }
 
         public string IconUrl
@@ -36,6 +43,22 @@ namespace Magitek.Models.Debugging
                 return $@"https://secure.xivdb.com/img/game/{folder}/{image}.png";
             }
         }
+
+        public ICommand AddToFightLogicBuilderAOE => new DelegateCommand<EnemySpellCastInfo>(info =>
+        {
+            if (info == null)
+                return;
+
+            Debug.Instance.FightLogicBuilderAOE.Add(info);
+        });
+
+        public ICommand AddToFightLogicBuilderTB => new DelegateCommand<EnemySpellCastInfo>(info =>
+        {
+            if (info == null)
+                return;
+
+            Debug.Instance.FightLogicBuilderTB.Add(info);
+        });
 
         public ICommand AddToInterruptsAndStuns => new DelegateCommand<EnemySpellCastInfo>(info =>
         {

--- a/Magitek/Models/Dragoon/DragoonSettings.cs
+++ b/Magitek/Models/Dragoon/DragoonSettings.cs
@@ -17,10 +17,6 @@ namespace Magitek.Models.Dragoon
         [Setting]
         [DefaultValue(false)]
         public bool HidePositionalMessage { get; set; }
-
-        [Setting]
-        [DefaultValue(false)]
-        public bool EnemyIsOmni { get; set; }
         #endregion
 
         #region Jumps

--- a/Magitek/Models/Sage/SageSettings.cs
+++ b/Magitek/Models/Sage/SageSettings.cs
@@ -129,6 +129,10 @@ namespace Magitek.Models.Sage
         public int DontDotIfEnemyDyingWithin { get; set; }
 
         [Setting]
+        [DefaultValue(5)]
+        public int DotTargetLimit { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool AoE { get; set; }
 

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -209,6 +209,10 @@ namespace Magitek.Models.Scholar
 
         [Setting]
         [DefaultValue(true)]
+        public bool SacredSoilCenterParty { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool Indomitability { get; set; }
 
         [Setting]

--- a/Magitek/Models/WhiteMage/WhiteMageSettings.cs
+++ b/Magitek/Models/WhiteMage/WhiteMageSettings.cs
@@ -418,6 +418,10 @@ namespace Magitek.Models.WhiteMage
         public int DontDotIfMoreEnemiesThan { get; set; }
 
         [Setting]
+        [DefaultValue(5)]
+        public int DotTargetLimit { get; set; }
+
+        [Setting]
         [DefaultValue(false)]
         public bool Dotwhilemoving { get; set; }
 

--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -26,70 +26,22 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (WorldManager.InSanctuary)
-                return false;
-
-            if (Core.Me.IsMounted)
-                return false;
-
-            if (Core.Me.IsCasting)
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            if (Globals.OnPvpMap)
-                return false;
-            
             return await Cards.Draw();
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (Globals.InParty && Utilities.Combat.Enemies.Count > AstrologianSettings.Instance.StopDamageWhenMoreThanEnemies)
                 return false;
 
             if (!AstrologianSettings.Instance.DoDamage)
                 return false;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
-            if (Core.Me.IsMounted)
-                return false;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            Casting.DoHealthChecks = false;
-
-            if (await GambitLogic.Gambit())
-                return true;
-
             //LimitBreak
             if (Heals.ForceLimitBreak()) return true;
 
@@ -165,9 +117,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> CombatBuff()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
             if (AstrologianSettings.Instance.WeaveOGCDHeals && GlobalCooldown.CanWeave(1)) 
                 
             {
@@ -209,9 +158,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
             await CombatBuff();
 
             if (Globals.InParty)
@@ -227,19 +173,6 @@ namespace Magitek.Rotations
             if (!AstrologianSettings.Instance.DoDamage)
                 return false;
 
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            Casting.DoHealthChecks = false;
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -253,9 +186,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(AstrologianSettings.Instance)) return true;
 
             if (await Pvp.CelestialRiverPvp()) return true;

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -22,22 +22,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            //Openers.OpenerCheck();
-
-            if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
-                return false;
-
-            if (Globals.OnPvpMap)
-                return false;
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await PhysicalDps.Peloton(BardSettings.Instance);
         }
 
@@ -45,25 +29,12 @@ namespace Magitek.Rotations
         {
             BardRoutine.RefreshVars();
 
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -73,30 +44,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             BardRoutine.RefreshVars();
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener()) 
-                return true;
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
@@ -153,9 +104,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(BardSettings.Instance)) return true;
 
             if (await Pvp.FinalFantasiaPvp()) return true;

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -23,24 +23,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-
-            /*if (ActionResourceManager.BlackMage.AstralStacks > 0 && ActionResourceManager.BlackMage.UmbralStacks == 0)
-            {
-                if (Core.Me.CurrentManaPercent < 70 && Spells.Transpose.Cooldown == TimeSpan.Zero)
-                {
-                    return await Spells.Transpose.Cast(Core.Me);
-                }
-            }*/
-            if (WorldManager.InSanctuary)
-                return false;
-
             //Try to keep stacks outside combat
             if (await Buff.UmbralSoul()) return true;
             //if (await Buff.Transpose()) return true;
@@ -50,39 +32,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-
-
-            if (Core.Me.IsMounted)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-
-            if (await GambitLogic.Gambit()) return true;
-
-            // if (await Buff.TransposeMovement()) return true;
-
             return false;
         }
         public static Task<bool> CombatBuff()
@@ -91,25 +45,8 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> Combat()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
-                return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
-
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
@@ -164,14 +101,9 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             BlackMageRoutine.RefreshVars();
 
             if (await CommonPvp.CommonTasks(BlackMageSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.SoulResonancePvp()) return true;
             if (await Pvp.FoulPvp()) return true;

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -29,20 +29,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Pull()
         {
-            if (!BotManager.Current.IsAutonomous)
+            if (BotManager.Current.IsAutonomous)
             {
-                return await Combat();
+                Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 3 + Core.Me.CurrentTarget.CombatReach);
             }
-            Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 3);
 
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
             //Dispell Party if necessary
             if (await Dispel.Exuviation()) return true;
 
@@ -52,7 +48,7 @@ namespace Magitek.Rotations
             //Raise if necessary
             if (await Logic.BlueMage.Heal.AngelWhisper()) return true;
 
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -62,35 +58,13 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (!SpellQueueLogic.SpellQueue.Any())
-            {
-                SpellQueueLogic.InSpellQueue = false;
-            }
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             // Can't attack, so just exit
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             // Can't attack, so just exit
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
-                return false;
-
-            // Can't attack, so just exit
             if (Core.Me.HasAura(Auras.WaningNocturne, true, 1000))
                 return false;
-
-            //Opener
-            if (await CustomOpenerLogic.Opener()) return true;
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod()) return true;
-            }
 
             //Interrupt
             if (await MagicDps.Interrupt(BlueMageSettings.Instance)) return true;

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -23,27 +23,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            //Openers.OpenerCheck();
-
-            if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
-            {
-                return false;
-            }
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             if (await Buff.DancePartner()) return true;
 
             return await PhysicalDps.Peloton(DancerSettings.Instance);
@@ -51,25 +30,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20);
-                }
-            }
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            if (await GambitLogic.Gambit())
-                return true;
-
             return false;
         }
 
@@ -80,28 +45,8 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20);
-            }
-
-            if (!SpellQueueLogic.SpellQueue.Any())
-                SpellQueueLogic.InSpellQueue = false;
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod())
-                    return true;
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener()) return true;
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
@@ -167,18 +112,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             //Partner
             if (await Pvp.ClosedPosition()) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
             // Utilities
-            if (await CommonPvp.CommonTasks(DancerSettings.Instance)) return true;
-            
+            if (await CommonPvp.CommonTasks(DancerSettings.Instance)) return true;            
             
             if (await Pvp.CuringWaltz()) return true;
 

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -16,54 +16,22 @@ namespace Magitek.Rotations
     {
         public static async Task<bool> PreCombatBuff()
         {
-            await Casting.CheckForSuccessfulCast();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await Buff.Grit();
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
             return await Combat();
         }
         public static async Task<bool> Heal()
         {
-            if (await GambitLogic.Gambit())
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return false;
         }
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener()) return true;
 
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
@@ -116,12 +84,8 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(DarkKnightSettings.Instance)) return true;
-            
-            
+
             if (await Pvp.SaltAndDarkness()) return true;
             if (await Pvp.EventidePvp()) return true;
             if (await Pvp.BlackestNightPvp()) return true;

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -27,35 +27,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            await Casting.CheckForSuccessfulCast();
-            if (WorldManager.InSanctuary)
-                return false;
             return false;
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            if (await GambitLogic.Gambit())
-                return true;
-
             return false;
         }
 
@@ -66,23 +47,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget && !Core.Me.InCombat)
                 return false;
 
             if (!Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
 
             #region Off GCD debugging
             if (DragoonRoutine.JumpsList.Contains(Casting.LastSpell))
@@ -177,12 +146,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(DragoonSettings.Instance)) return true;
-            
-            
 
             if (!CommonPvp.GuardCheck(DragoonSettings.Instance))
             {

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -22,44 +22,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            await Casting.CheckForSuccessfulCast();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await Buff.RoyalGuard();
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-            }
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            /*if (GunbreakerSettings.Instance.LightningShotToPullAggro)
-                await Spells.LightningShot.Cast(Core.Me.CurrentTarget);*/
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (Core.Me.IsMounted)
-                return true;
-
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            if (await GambitLogic.Gambit()) return true;
             return await Healing.Aurora();
         }
 
@@ -70,23 +42,8 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
-                return false;
-
-            if (await CustomOpenerLogic.Opener()) 
-                return true;
 
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
@@ -174,12 +131,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(GunbreakerSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.RelentlessRushPvp()) return true;
             if (await Pvp.NebulaPvp()) return true;

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -24,44 +24,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await PhysicalDps.Peloton(MachinistSettings.Instance);
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
         public static async Task<bool> Heal()
         {
-            if (Core.Me.IsMounted)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -71,31 +43,8 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (!SpellQueueLogic.SpellQueue.Any())
-                SpellQueueLogic.InSpellQueue = false;
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod()) return true;
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
 
             if (MachinistSettings.Instance.UseFlamethrower && Core.Me.HasAura(Auras.Flamethrower))
             {
@@ -191,9 +140,6 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             // Utilities
             if (await CommonPvp.CommonTasks(MachinistSettings.Instance)) return true;
 

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -77,8 +77,7 @@ namespace Magitek.Rotations
                     if (await Pet.RookQueen()) return true;
                 }
 
-                // Intentionally only weave 1 guass or richochet to hit 6 gcd's during wildfire. 
-                if (MachinistRoutine.GlobalCooldown.CanWeave(Core.Me.HasAura(Auras.WildfireBuff) ? 1 : 2))
+                if (MachinistRoutine.GlobalCooldown.CanWeave(1))
                 {
                     //oGCDs
                     if (await SingleTarget.GaussRound()) return true;

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -70,6 +70,7 @@ namespace Magitek.Rotations
                     if (await PhysicalDps.Bloodbath(MonkSettings.Instance)) return true;
                     if (await PhysicalDps.Feint(MonkSettings.Instance)) return true;
                     if (await Buff.UsePotion()) return true;
+                    if (await Buff.TrueNorth()) return true;
 
                     if (await Buff.EarthReply()) return true;
                     if (await Buff.Brotherhood()) return true;

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -23,13 +23,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            await Casting.CheckForSuccessfulCast();
-            if (WorldManager.InSanctuary)
-                return false;
-
             if (await Buff.Meditate()) return true;
 
             return false;
@@ -37,26 +30,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            if (await GambitLogic.Gambit()) return true;
             if (await Buff.Mantra()) return true;
 
             return false;
@@ -69,37 +47,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
             MonkRoutine.RefreshVars();
-
-            if (!SpellQueueLogic.SpellQueue.Any())
-            {
-                SpellQueueLogic.InSpellQueue = false;
-            }
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod()) 
-                    return true;
-            }
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener()) 
-                return true;
 
             //Limit Break
             if (SingleTarget.ForceLimitBreak())
@@ -185,14 +136,9 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             MonkRoutine.RefreshVars();
 
             if (await CommonPvp.CommonTasks(MonkSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.MeteodrivePvp()) return true;
 

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -26,19 +26,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-
-            await Casting.CheckForSuccessfulCast();
-
-            if (!SpellQueueLogic.SpellQueue.Any())
-            {
-                SpellQueueLogic.InSpellQueue = false;
-            }
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod()) return true;
-            }
-
             Utilities.Routines.Ninja.RefreshVars();
 
             if (await Utility.PrePullHide()) return true;
@@ -46,34 +33,16 @@ namespace Magitek.Rotations
             if (await Ninjutsu.PrePullSuitonRamp()) return true;
             if (await Ninjutsu.PrePullSuitonUse()) return true;
 
-            if (GamelogManagerCountdown.IsCountdownRunning())
-                return true;
-
             return false;
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (GamelogManagerCountdown.IsCountdownRunning())
-                return true;
-
             return await Combat();
         }
         public static async Task<bool> Heal()
         {
-
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            return await GambitLogic.Gambit();
+            return false;
         }
         public static Task<bool> CombatBuff()
         {
@@ -81,35 +50,11 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> Combat()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
             Utilities.Routines.Ninja.RefreshVars();
             
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
-            if (!SpellQueueLogic.SpellQueue.Any())
-                SpellQueueLogic.InSpellQueue = false;
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod()) return true;
-            }
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await CustomOpenerLogic.Opener()) 
-                return true;
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
             if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift, castTimeRemainingMs: 19000)) return true;
             if (await CommonFightLogic.FightLogic_Debuff(NinjaSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
 
@@ -171,12 +116,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(NinjaSettings.Instance)) return true;
-            
-            
 
             if (!CommonPvp.GuardCheck(NinjaSettings.Instance)) { 
                 if (await Pvp.SeitonTenchuPvp()) return true;

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -25,43 +25,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            await Casting.CheckForSuccessfulCast();
-
-            if (Core.Me.IsMounted)
-                return false;
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await Buff.IronWill();
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (Core.Me.IsMounted)
-                return true;
-
-            if (await GambitLogic.Gambit())
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Healing.Clemency();
         }
 
@@ -72,21 +45,9 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
-
+            
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
@@ -162,12 +123,7 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(PaladinSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.PhalanxPvp()) return true;
             if (await Pvp.BladeofValorPvp()) return true;

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -25,56 +25,20 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            //Openers.OpenerCheck();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             if (await Utility.Soulsow())
                 return true;
 
-            if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
-                return false;
-
-
-            if (Globals.OnPvpMap)
-                return false;
-
-
             return false;
-
         }
 
         public static async Task<bool> Pull()
         {
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -84,34 +48,12 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (Core.Me.IsCasting)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             ReaperRoutine.RefreshVars();
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
             {
                 if (await Utility.Soulsow()) return true;
                 return false;
-            }
-
-            if (await CustomOpenerLogic.Opener()) return true;
-
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-                }
             }
 
             if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false, castTimeRemainingMs: 3000)) return true;
@@ -179,12 +121,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(ReaperSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.ArcaneCrestPvp()) return true;
 

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -30,26 +30,12 @@ namespace Magitek.Rotations
         }
 
         public static async Task<bool> PreCombatBuff()
-        {
-
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-            if (WorldManager.InSanctuary)
-                return false;
-
+        { 
             return false;
         }
 
         public static async Task<bool> Pull()
         {
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
@@ -67,10 +53,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Heal()
         {
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            if (await GambitLogic.Gambit()) return true;
             if (await Logic.RedMage.Heal.Verraise()) return true;
             return await Logic.RedMage.Heal.Vercure();
         }
@@ -82,13 +64,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-                       
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
 
             if (BotManager.Current.IsAutonomous)
@@ -105,9 +81,6 @@ namespace Magitek.Rotations
 
                 }
             }
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
@@ -175,12 +148,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(RedMageSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.DisplacementPvp()) return true;
             if (!CommonPvp.GuardCheck(RedMageSettings.Instance))

--- a/Magitek/Rotations/Sage.cs
+++ b/Magitek/Rotations/Sage.cs
@@ -165,6 +165,8 @@ namespace Magitek.Rotations
             if (await AoE.Toxikon()) return true;
             if (await AoE.Phlegma()) return true;
             if (await AoE.Pneuma()) return true;
+            
+            if (await SingleTarget.DotMultipleTargets()) return true;
             if (await AoE.EukrasianDyskrasia()) return true;
             if (await AoE.Dyskrasia()) return true;
 

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -24,31 +24,17 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            await Casting.CheckForSuccessfulCast();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return false;
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (await Casting.TrackSpellCast()) 
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -58,30 +44,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            SamuraiRoutine.RefreshVars();
-
-            if (BotManager.Current.IsAutonomous)
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            if (!SpellQueueLogic.SpellQueue.Any())
-                SpellQueueLogic.InSpellQueue = false;
-
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
-                return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
-
-            if (SpellQueueLogic.SpellQueue.Any())
-                if (await SpellQueueLogic.SpellQueueMethod())
-                    return true;
+            SamuraiRoutine.RefreshVars();
 
             //LimitBreak
             if (SingleTarget.ForceLimitBreak()) return true;
@@ -185,12 +151,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if(!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(SamuraiSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.ZantetsukenPvp()) return true;
             if (await Pvp.MineuchiPvp()) return true;

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -31,22 +31,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsMounted)
-                return false;
-
-            if (Core.Me.IsCasting)
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            if (Globals.OnPvpMap)
-                return false;
-
-            if (CustomOpenerLogic.InOpener) return false;
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             if (await Buff.SummonPet())
                 return true;
 
@@ -55,53 +39,18 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (Globals.InParty && Utilities.Combat.Enemies.Count > ScholarSettings.Instance.StopDamageWhenMoreThanEnemies)
                 return false;
 
             if (!ScholarSettings.Instance.DoDamage)
                 return false;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
-            if (Core.Me.IsMounted)
-                return false;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             if (await Buff.SummonPet()) return true;
-
-            Casting.DoHealthChecks = false;
-
-            if (await GambitLogic.Gambit()) return true;
-
-            if (CustomOpenerLogic.InOpener) return false;
 
             //LimitBreak
             if (Logic.Scholar.Heal.ForceLimitBreak()) return true;
@@ -212,20 +161,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
-            if (await Casting.TrackSpellCast()) 
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             if (Core.Me.CurrentManaPercent <= ScholarSettings.Instance.MinimumManaPercent)
                 return false;
 
@@ -259,13 +194,9 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             ScholarRoutine.RefreshVars();
 
-            if (await CommonPvp.CommonTasks(ScholarSettings.Instance)) return true;           
-            
+            if (await CommonPvp.CommonTasks(ScholarSettings.Instance)) return true;      
 
             if (await Pvp.ConsolationPvp()) return true;
             if (await Pvp.SummonSeraphPvp()) return true;

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -27,39 +27,15 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-            SpellQueueLogic.SpellQueue.Clear();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await Pets.SummonCarbuncle();
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             return await Combat();
         }
         public static async Task<bool> Heal()
         {
-            if (Core.Me.IsMounted)
-                return true;
-
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            Casting.DoHealthChecks = false;
-
-            if (await GambitLogic.Gambit()) return true;
             if (await Logic.Summoner.Heal.Resurrection()) return true;
             #region Force Toggles
             if (await Logic.Summoner.Heal.ForceRaise()) return true;
@@ -69,7 +45,6 @@ namespace Magitek.Rotations
             if (await Logic.Summoner.Heal.LuxSolaris()) return true;
             if (await Logic.Summoner.Heal.RadiantAegis()) return true;
             return await Logic.Summoner.Heal.Physick();
-
         }
 
         public static Task<bool> CombatBuff()
@@ -79,25 +54,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
-
             if (Core.Me.CurrentTarget.HasAura(Auras.MagicResistance))
-                return false;
-
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
                 return false;
 
             //LimitBreak
@@ -124,13 +81,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
             if (await CommonPvp.CommonTasks(SummonerSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.SummonBahamutPvp()) return true;
             if (await Pvp.SummonPhoenixPvp()) return true;

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -25,53 +25,17 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            //Openers.OpenerCheck();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
-            if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
-                return false;
-
-
-            if (Globals.OnPvpMap)
-                return false;
-
-
             return false;
-
         }
 
         public static async Task<bool> Pull()
         {
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -81,47 +45,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (Core.Me.IsCasting)
-                return true;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            ViperRoutine.RefreshVars();
-
-            if (await CustomOpenerLogic.Opener()) return true;
-
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                {
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-                }
-            }
-
-            if (!SpellQueueLogic.SpellQueue.Any())
-            {
-                SpellQueueLogic.InSpellQueue = false;
-            }
-
-
-            if (SpellQueueLogic.SpellQueue.Any())
-            {
-                if (await SpellQueueLogic.SpellQueueMethod())
-                    return true;
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            if (await CustomOpenerLogic.Opener())
-                return true;
+            ViperRoutine.RefreshVars();
 
             if (SingleTarget.ForceLimitBreak()) return true;
 
@@ -179,9 +106,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(ViperSettings.Instance)) return true;
             if (await Pvp.SnakeScales()) return true;
 

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -88,6 +88,7 @@ namespace Magitek.Rotations
             if (await SingleTarget.InnerChaos()) return true;
 
             //Spell to spam inside Inner Release
+            if (await Aoe.PrimalRuination()) return true;
             if (await Aoe.PrimalRend()) return true;
             if (await Aoe.Decimate()) return true;
             if (await SingleTarget.FellCleave()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -22,38 +22,17 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            await Casting.CheckForSuccessfulCast();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
             return await Buff.Defiance();
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, Core.Me.CurrentTarget.CombatReach);
-            }
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (await Casting.TrackSpellCast()) return true;
-            await Casting.CheckForSuccessfulCast();
-
-            return await GambitLogic.Gambit();
+            return false;
         }
 
         public static Task<bool> CombatBuff()
@@ -63,23 +42,8 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 2 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
-            if (Core.Me.CurrentTarget.HasAnyAura(Auras.Invincibility))
-                return false;
-
-            if (await CustomOpenerLogic.Opener())
-                return true;
 
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
@@ -144,12 +108,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(WarriorSettings.Instance)) return true;
-            
-            
 
             if (!CommonPvp.GuardCheck(WarriorSettings.Instance))
             {

--- a/Magitek/Rotations/WhiteMage.cs
+++ b/Magitek/Rotations/WhiteMage.cs
@@ -30,60 +30,22 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            if (Core.Me.IsCasting)
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
-            if (WorldManager.InSanctuary)
-                return false;
-
-            if (Core.Me.IsMounted)
-                return false;
-
             return false;
         }
 
         public static async Task<bool> Pull()
         {
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
             if (Globals.InParty && Utilities.Combat.Enemies.Count > WhiteMageSettings.Instance.StopDamageWhenMoreThanEnemies)
                 return false;
 
             if (!WhiteMageSettings.Instance.DoDamage)
                 return false;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            if (await Casting.TrackSpellCast())
-                return true;
-
-            await Casting.CheckForSuccessfulCast();
-
             return await Combat();
         }
 
         public static async Task<bool> Heal()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
-            if (await Casting.TrackSpellCast()) 
-                return true;
-            
-            await Casting.CheckForSuccessfulCast();
-
-            Casting.DoHealthChecks = false;
-
-            if (await GambitLogic.Gambit()) 
-                return true;
-
             //LimitBreak
             if (Logic.WhiteMage.Heal.ForceLimitBreak()) return true;
 
@@ -194,8 +156,8 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
             if (Globals.InParty)
             {
@@ -208,16 +170,7 @@ namespace Magitek.Rotations
 
             if (!WhiteMageSettings.Instance.DoDamage)
                 return false;
-
-            if (BotManager.Current.IsAutonomous)
-            {
-                if (Core.Me.HasTarget)
-                    Movement.NavigateToUnitLos(Core.Me.CurrentTarget, 20 + Core.Me.CurrentTarget.CombatReach);
-            }
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
+    
             if (await SingleTarget.Dots()) return true;
             if (await SingleTarget.DotMultipleTargets()) return true;
             if (await Buff.PresenceOfMind()) return true;
@@ -233,12 +186,7 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PvP()
         {
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
-
             if (await CommonPvp.CommonTasks(WhiteMageSettings.Instance)) return true;
-            
-            
 
             if (await Pvp.AfflatusPurgationPvp()) return true;
 

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -460,7 +460,8 @@ namespace Magitek.Utilities
                         Id = 2143,
                         Name = "Lahabrea",
                         TankBusters = new List<uint> {
-                            4348 //Dark Orb
+                            4348, //Dark Orb
+                            31891
                         },
                         SharedTankBusters = null,
                         Aoes = null,
@@ -469,11 +470,14 @@ namespace Magitek.Utilities
                     new Enemy {
                         Id = 3829,
                         Name = "Ascian Prime",
-                        TankBusters = null,
+                        TankBusters = new List<uint> { 31911 },                        
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
                             4361, //Shadowflare
-                            4362 //Annihilation
+                            4362, //Annihilation,
+                            31900,
+                            31906,
+
                         },
                         BigAoes = null
                     }

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -87,11 +87,6 @@ namespace Magitek.Utilities
                 Logger.WriteInfo(
                     $"[TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name} on {output.CurrentJob} in our party.");
 
-            if (output != null)
-            {
-                FlStopwatch.Start();
-            }
-
             return output;
         }
 
@@ -116,9 +111,6 @@ namespace Magitek.Utilities
             if (output != null && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo(
                     $"[Shared TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name}. Handling for {output.CurrentJob} in our party.");
-
-            if (output != null)
-                FlStopwatch.Start();
 
             return output;
 

--- a/Magitek/Utilities/Globals.cs
+++ b/Magitek/Utilities/Globals.cs
@@ -11,7 +11,10 @@ namespace Magitek.Utilities
     internal static class Globals
     {
         public static bool InParty => PartyManager.IsInParty;
-        public static bool PartyInCombat => Core.Me.InCombat || (InParty && Group.CastableAlliesWithin50.Any(ally => ally.InCombat));
+        public static bool PartyInCombat => Core.Me.InCombat ||
+            (InParty && Group.RawPartyMembers.Any(ally => 
+                ally.IsAlive && ally.InCombat
+            ));
         public static bool InGcInstance => RaptureAtkUnitManager.Controls.Any(r => r.Name == "GcArmyOrder");
         public static bool OnPvpMap => Core.Me.OnPvpMap();
         public static bool InActiveDuty => DutyManager.InInstance && Duty.State() == Duty.States.InProgress;

--- a/Magitek/Utilities/Group.cs
+++ b/Magitek/Utilities/Group.cs
@@ -15,10 +15,11 @@ namespace Magitek.Utilities
 {
     public static class Group
     {
-        private static readonly FrameCachedObject<IEnumerable<Character>> _allianceMembers = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(i=> i!=null && i.IsValid).Where(r => r.Type == GameObjectType.Pc && r.IsTargetable && r.InLineOfSight()));
-        private static readonly FrameCachedObject<IEnumerable<Character>> _pets = new(() => GameObjectManager.GetObjectsByNPCIds<GameObject>(PetIds).Where(i=> i!=null && i.IsValid).Where(r => r.IsTargetable && r.InLineOfSight() && r.Distance(Core.Me) <= 30).OfType<Character>().Where(i=> i.IsValid));
-        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _allies = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(i=> i!=null && i.IsValid).Where(r => r.CanAttack && r.InLineOfSight()));
-        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _battleCharacters = new(() => PartyManager.RawMembers.Select(r => r?.BattleCharacter).Where(i=> i!=null && i.IsValid).Where(i=> i.InLineOfSight()));
+        private static readonly FrameCachedObject<IEnumerable<Character>> _allianceMembers = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(i => i != null && i.IsValid).Where(r => r.Type == GameObjectType.Pc && r.IsTargetable && r.InLineOfSight()));
+        private static readonly FrameCachedObject<IEnumerable<Character>> _pets = new(() => GameObjectManager.GetObjectsByNPCIds<GameObject>(PetIds).Where(i => i != null && i.IsValid).Where(r => r.IsTargetable && r.InLineOfSight() && r.Distance(Core.Me) <= 30).OfType<Character>().Where(i => i.IsValid));
+        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _allies = new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(i => i != null && i.IsValid).Where(r => r.CanAttack && r.InLineOfSight()));
+        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _battleCharacters = new(() => PartyManager.RawMembers.Select(r => r?.BattleCharacter).Where(i => i != null && i.IsValid).Where(i => i.InLineOfSight()));
+
         public static IEnumerable<Character> AllianceMembers
         {
             get
@@ -26,7 +27,7 @@ namespace Magitek.Utilities
                 return _allianceMembers.Value;
             }
         }
-        
+
         public static IEnumerable<Character> Pets
         {
             get
@@ -36,7 +37,15 @@ namespace Magitek.Utilities
         }
 
         private static readonly uint[] PetIds = { 1398, 1399, 1400, 1401, 1402, 1403, 1404, 5478 };
-        
+
+        public static IEnumerable<BattleCharacter> RawPartyMembers
+        {
+            get
+            {
+                return _battleCharacters.Value;
+            }
+        }
+
         public static void UpdateAllies(Action extensions = null)
         {
             CastableParty.Clear();

--- a/Magitek/Utilities/Routines/Warrior.cs
+++ b/Magitek/Utilities/Routines/Warrior.cs
@@ -40,11 +40,11 @@ namespace Magitek.Utilities.Routines
         public static readonly SpellData[] DefensiveSpells = new SpellData[]
         {
             Spells.Rampart,
-            Spells.Bloodwhetting,
-            Spells.RawIntuition,
+            Spells.Damnation,
             Spells.Vengeance,
             Spells.ThrillofBattle,
-            Spells.Damnation
+            Spells.Bloodwhetting,
+            Spells.RawIntuition
         };
 
         public static readonly uint[] Defensives = new uint[]

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -877,6 +877,7 @@ namespace Magitek.Utilities
         public static readonly SpellData LandWaker = DataManager.GetSpellData(4240);
         public static readonly SpellData Damnation = DataManager.GetSpellData(36923);
         public static readonly SpellData PrimalWrath = DataManager.GetSpellData(36924);
+        public static readonly SpellData PrimalRuination = DataManager.GetSpellData(36925);
         #endregion
 
         // WHM

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -226,7 +226,7 @@ namespace Magitek.Utilities
             if (Debug.Instance.EnemySpellCasts.ContainsKey(unit.CastingSpellId))
                 return;
 
-            var newSpellCast = new EnemySpellCastInfo(unit.SpellCastInfo.Name, unit.CastingSpellId, unit.Name);
+            var newSpellCast = new EnemySpellCastInfo(unit.SpellCastInfo.Name, unit.CastingSpellId, unit.Name, unit.NpcId, WorldManager.ZoneId, WorldManager.CurrentZoneName);
             Logger.WriteInfo($@"[Debug] Adding [{newSpellCast.Id}] {newSpellCast.Name} To Enemy Spell Casts");
             Debug.Instance.EnemySpellCasts.Add(newSpellCast.Id, newSpellCast);
         }

--- a/Magitek/Views/UserControls/Bugs/EnemySpellCasts.xaml
+++ b/Magitek/Views/UserControls/Bugs/EnemySpellCasts.xaml
@@ -8,10 +8,20 @@
         <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
     </UserControl.Resources>
 
-    <StackPanel Margin="10">
+    <StackPanel Margin="10" Background="{DynamicResource ClassSelectorBackground}">
 
         <CheckBox Content="Enable Tracking Of Enemy Casted Spells" IsChecked="{Binding Settings.EnemySpellCastHistory, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
 
+        <StackPanel Orientation="Horizontal">
+            <Button
+                Content="Copy FightLogic Builder To Clipboard"
+                Command="{Binding CopyFightLogicBuilderCommand}"
+                Style="{DynamicResource ButtonLists}" />
+            <Button 
+                Content="Clear FightLogic Builder"
+                Command="{Binding ClearFightLogicBuilderCommand}"
+                Style="{DynamicResource ButtonLists}" />
+        </StackPanel>
 
         <ListBox Height="405"
                  Margin="0,10,0,0"
@@ -50,6 +60,18 @@
                                 CommandParameter="{Binding Value}"
                                 Content="Add Interrupt/Stun"
                                 Style="{DynamicResource ButtonLists}" />
+                        <Button Grid.Column="5"
+                            HorizontalAlignment="Left"
+                            Command="{Binding Value.AddToFightLogicBuilderTB}"
+                            CommandParameter="{Binding Value}"
+                            Content="FightLogic TankBuster"
+                            Style="{DynamicResource ButtonLists}" />
+                        <Button Grid.Column="6"
+                            HorizontalAlignment="Left"
+                            Command="{Binding Value.AddToFightLogicBuilderAOE}"
+                            CommandParameter="{Binding Value}"
+                            Content="FightLogic AOE"
+                            Style="{DynamicResource ButtonLists}" />
                     </Grid>
 
                 </DataTemplate>

--- a/Magitek/Views/UserControls/Sage/Combat.xaml
+++ b/Magitek/Views/UserControls/Sage/Combat.xaml
@@ -66,10 +66,17 @@
                     <RowDefinition />
                     <RowDefinition />
                 </Grid.RowDefinitions>
-                
-                <CheckBox Grid.Row="0" Content="DoT Multiple Targets" IsChecked="{Binding SageSettings.DotMultipleTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+
+                <StackPanel Orientation="Horizontal" Grid.Row="0">
+                <CheckBox Grid.Row="0" Content="DoT Multiple Targets Up To " IsChecked="{Binding SageSettings.DotMultipleTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <controls:Numeric MaxValue="100" MinValue="1"
+                  Value="{Binding SageSettings.DotTargetLimit, Mode=TwoWay}" />
+                <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Targets" />
+                </StackPanel>
+
                 <CheckBox Grid.Row="1" Content="Dosis" IsChecked="{Binding SageSettings.Dosis , Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <CheckBox Grid.Row="2" Content="Eukrasian Dosis " IsChecked="{Binding SageSettings.EukrasianDosis, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                
 
                 <Grid Grid.Row="3">
                     <Grid.ColumnDefinitions>

--- a/Magitek/Views/UserControls/Sage/Combat.xaml
+++ b/Magitek/Views/UserControls/Sage/Combat.xaml
@@ -66,6 +66,8 @@
                     <RowDefinition />
                     <RowDefinition />
                 </Grid.RowDefinitions>
+                
+                <CheckBox Grid.Row="0" Content="DoT Multiple Targets" IsChecked="{Binding SageSettings.DotMultipleTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <CheckBox Grid.Row="1" Content="Dosis" IsChecked="{Binding SageSettings.Dosis , Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 <CheckBox Grid.Row="2" Content="Eukrasian Dosis " IsChecked="{Binding SageSettings.EukrasianDosis, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
 

--- a/Magitek/Views/UserControls/Scholar/Healing.xaml
+++ b/Magitek/Views/UserControls/Scholar/Healing.xaml
@@ -169,6 +169,10 @@
 
             </Grid>
         </controls:SettingsBlock>
+        
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <CheckBox Margin="5" Content="Place Sacred Soil on the party member closest to the center of the whole party." IsChecked="{Binding ScholarSettings.SacredSoilCenterParty, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+        </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">

--- a/Magitek/Views/UserControls/WhiteMage/Combat.xaml
+++ b/Magitek/Views/UserControls/WhiteMage/Combat.xaml
@@ -85,7 +85,10 @@
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Health Percent" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="Dot Multiple Targets" IsChecked="{Binding WhiteMageSettings.DotMultipleTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Dot up to " IsChecked="{Binding WhiteMageSettings.DotMultipleTargets, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="100" MinValue="1"
+                        Value="{Binding WhiteMageSettings.DotTargetLimit, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text=" Targets" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="Don't Dot if more than " IsChecked="{Binding WhiteMageSettings.DontDotIfMoreEnemies, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}"/>

--- a/Magitek/Views/UserControls/WhiteMage/Healing.xaml
+++ b/Magitek/Views/UserControls/WhiteMage/Healing.xaml
@@ -131,7 +131,7 @@
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
-            <CheckBox Content="Place asylum on the party member closest to the center of the whole party." IsChecked="{Binding WhiteMageSettings.AsylumCenterParty, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+            <CheckBox  Margin="5" Content="Place asylum on the party member closest to the center of the whole party." IsChecked="{Binding WhiteMageSettings.AsylumCenterParty, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
         </controls:SettingsBlock>
 
 


### PR DESCRIPTION
General

- Refactored rotation code so all rotations share common setup for openers/gambits and other checks
    like in sancturary.
- More null pointer exception fixes

Openers

- Openers are now checked/pulsed outside of combat as part of Heal(). This enables Openers & Gambits to properly have checks for Countdown Timer, OutOfCombat, etc.

FightLogic

- Fixed Tank Defensive response to TankBusters. Tanks should now properly cast rampart+etc in response to known tankbusters. (note: i only had time to actually test this for real on warrior, but should apply to all tanks.)

Jobs

- PCT: Fixed an issue with subtractive palette at low level.
- WAR: Fix not using primal ruination when moving
- WHM: Fix asylum being used instantly. Adjust window for Medica3/Confession Fightlogic response.
       Add dot up to x enemies option
- SCH: Add sacred soil to center of party.
       Adjust/(hopefully fix) some Succor fightlogic responses.
- SGE: Fix attempting to use EukrasianDyskrasia at low levels
       Add back in multi-dotting when low level, or out of range for EukrasianDyskrasia
       Add dot up to x enemies option (when multidotting at low-level or out of range)
- DRG: Fix true north
- MNK: Add true north
- SMN: Add aura checks for ifrit/garuda favor when summoning (hopefully to avoid casting a filler spell while waiting for the egi)
- MCH: Single-weave gauss/ricochet outside of wildfire as well.