### PR TITLE
PLD, MCH, PCT, RPR

### DIFF
--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -129,6 +129,13 @@ namespace Magitek.Logic.Machinist
             if (MachinistSettings.Instance.UseGaussRound && Spells.GaussRound.Masked().Charges > spell.Charges)
                 return false;
 
+            if (MachinistSettings.Instance.DoubleHyperchargedWildfire
+                && Combat.IsBoss()
+                && Core.Me.HasAura(Auras.WildfireBuff, true)
+                && !Core.Me.HasAura(Auras.Overheated)
+                && ActionResourceManager.Machinist.Heat > 50)
+                return false;
+
             return await spell.Cast(Core.Me.CurrentTarget);
         }
 
@@ -140,7 +147,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.ChainSaw.IsKnownAndReady())
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && !MachinistSettings.Instance.DoubleHyperchargedWildfire)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
@@ -172,7 +179,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.Excavator.IsKnownAndReady())
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && !MachinistSettings.Instance.DoubleHyperchargedWildfire)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
@@ -192,7 +199,13 @@ namespace Magitek.Logic.Machinist
             if (!Spells.FullMetalField.IsKnownAndReady())
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (!Core.Me.HasAura(Auras.FullMetalMachinist))
+                return false;
+
+            if (!Core.Me.HasAura(Auras.Overheated) && MachinistSettings.Instance.DoubleHyperchargedWildfire && Combat.IsBoss())
+                return false; 
+
+            if (Core.Me.HasAura(Auras.Overheated) && !MachinistSettings.Instance.DoubleHyperchargedWildfire)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))

--- a/Magitek/Logic/Machinist/SingleTarget.cs
+++ b/Magitek/Logic/Machinist/SingleTarget.cs
@@ -28,7 +28,7 @@ namespace Magitek.Logic.Machinist
             if (MachinistSettings.Instance.UseChainSaw && Spells.ChainSaw.IsKnownAndReady(200) && ActionResourceManager.Machinist.Battery <= 80)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && Spells.HeatBlast.IsKnown())
                 return false;
 
             if (Core.Me.HasAura(Auras.Reassembled) && Spells.Drill.IsKnown())
@@ -51,7 +51,7 @@ namespace Magitek.Logic.Machinist
             if (MachinistSettings.Instance.UseChainSaw && Spells.ChainSaw.IsKnownAndReady(200))
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && Spells.HeatBlast.IsKnown())
                 return false;
 
             if (Core.Me.HasAura(Auras.Reassembled) && Spells.Drill.IsKnown())
@@ -74,7 +74,7 @@ namespace Magitek.Logic.Machinist
             if (MachinistSettings.Instance.UseChainSaw && Spells.ChainSaw.IsKnownAndReady(200))
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && Spells.HeatBlast.IsKnown())
                 return false;
 
             if (Core.Me.HasAura(Auras.Reassembled) && Spells.Drill.IsKnown())
@@ -91,7 +91,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.Drill.IsKnownAndReady())
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && !MachinistSettings.Instance.DoubleHyperchargedWildfire)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
@@ -124,7 +124,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.AirAnchor.IsKnownAndReady() && !Spells.HotShot.IsKnownAndReady())
                 return false;
 
-            if (Core.Me.HasAura(Auras.Overheated))
+            if (Core.Me.HasAura(Auras.Overheated) && !MachinistSettings.Instance.DoubleHyperchargedWildfire)
                 return false;
 
             if (Core.Me.HasAura(Auras.WildfireBuff) && Core.Me.HasAura(Auras.Overheated))
@@ -157,6 +157,11 @@ namespace Magitek.Logic.Machinist
             if (ActionResourceManager.Machinist.OverheatRemaining == TimeSpan.Zero)
                 return false;
 
+            if (MachinistSettings.Instance.DoubleHyperchargedWildfire
+                && Spells.FullMetalField.IsKnown()
+                && Spells.Wildfire.IsReady())
+                return false;
+
             return await Spells.HeatBlast.Cast(Core.Me.CurrentTarget);
         }
 
@@ -187,6 +192,13 @@ namespace Magitek.Logic.Machinist
             }
 
             if (MachinistSettings.Instance.UseRicochet && Spells.Ricochet.Masked().Charges > spell.Charges)
+                return false;
+
+            if (MachinistSettings.Instance.DoubleHyperchargedWildfire
+                && Combat.IsBoss()
+                && Core.Me.HasAura(Auras.WildfireBuff, true)
+                && !Core.Me.HasAura(Auras.Overheated)
+                && ActionResourceManager.Machinist.Heat > 50)
                 return false;
 
             return await spell.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Ninja/Ninjutsu.cs
+++ b/Magitek/Logic/Ninja/Ninjutsu.cs
@@ -281,6 +281,35 @@ namespace Magitek.Logic.Ninja
 
         }
 
+        public static async Task<bool> Doton()
+        {
+            if (Core.Me.ClassLevel < Spells.Doton.LevelAcquired)
+                return false;
+
+            if (!Spells.Jin.IsKnown())
+                return false;
+
+            if (Core.Me.HasAura(Auras.TenChiJin) || Core.Me.HasAura(Auras.Kassatsu) && Core.Me.ClassLevel >= 76)
+                return false;
+
+            if (Spells.Chi.Charges < Spells.Chi.MaxCharges - (Spells.SpinningEdge.AdjustedCooldown.TotalMilliseconds / 20000)
+                && NinjaRoutine.UsedMudras.Count() == 0
+                && Spells.TrickAttack.Cooldown <= new TimeSpan(0, 0, 45))
+                return false;
+
+            if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < 3)
+                return false;
+
+            if (MovementManager.IsMoving)
+                return false;
+
+            if (Core.Me.HasAura(Auras.Doton))
+                return false;
+
+            return await NinjaRoutine.PrepareNinjutsu(Spells.Doton, Core.Me);
+
+        }
+
         public static async Task<bool> FumaShuriken()
         {
 

--- a/Magitek/Logic/Paladin/Aoe.cs
+++ b/Magitek/Logic/Paladin/Aoe.cs
@@ -50,6 +50,11 @@ namespace Magitek.Logic.Paladin
             if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= Spells.HolyCircle.Radius + x.CombatReach) < PaladinSettings.Instance.HolyCircleEnemies)
                 return false;
 
+            if (Core.Me.HasAura(Auras.Requiescat) && !Spells.BladeOfFaith.IsKnown())
+            {
+                return await Spells.HolyCircle.Cast(Core.Me);
+            }
+
             if (!Core.Me.HasAura(Auras.DivineMight))
                 return false;
 

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -81,7 +81,7 @@ namespace Magitek.Logic.Paladin
 
             if (PaladinSettings.Instance.UseHolySpiritToPull && !Core.Me.InCombat)
                 return await Spells.HolySpirit.Cast(Core.Me.CurrentTarget);
-
+    
             if (PaladinSettings.Instance.UseHolySpiritWhenOutOfMeleeRange)
             {
                 if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.FastBlade.Range))
@@ -100,6 +100,11 @@ namespace Magitek.Logic.Paladin
 
             if (!PaladinSettings.Instance.UseHolySpirit)
                 return false;
+
+            if (Core.Me.HasAura(Auras.Requiescat) && !Spells.BladeOfFaith.IsKnown())
+            {
+                return await Spells.HolySpirit.Cast(Core.Me.CurrentTarget);
+            }
 
             if (!Core.Me.HasAura(Auras.DivineMight))
                 return false;

--- a/Magitek/Logic/Pictomancer/Buff.cs
+++ b/Magitek/Logic/Pictomancer/Buff.cs
@@ -78,5 +78,13 @@ namespace Magitek.Logic.Pictomancer
             // intentionally don't wait for the grassa aura, it either happens or it doesn't. 
             return await Spells.TemperaGrassa.Cast(Core.Me);
         }
+
+        public static async Task<bool> UsePotion()
+        {
+            if (!Core.Me.HasAura(Auras.StarryMuse, true))
+                return false;
+
+            return await MagicDps.UsePotion(PictomancerSettings.Instance);
+        }
     }
 }

--- a/Magitek/Logic/Reaper/Normal/Utility.cs
+++ b/Magitek/Logic/Reaper/Normal/Utility.cs
@@ -1,6 +1,7 @@
 ﻿using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
+using Magitek.Logic.Roles;
 using Magitek.Models.Reaper;
 using Magitek.Utilities;
 using System.Threading.Tasks;
@@ -73,5 +74,12 @@ namespace Magitek.Logic.Reaper
 
         }
 
+        public static async Task<bool> UsePotion()
+        {
+            if (!Core.Me.HasAura(Auras.ArcaneCircle, true))
+                return false;
+
+            return await PhysicalDps.UsePotion(ReaperSettings.Instance);
+        }
     }
 }

--- a/Magitek/Models/Machinist/MachinistSettings.cs
+++ b/Magitek/Models/Machinist/MachinistSettings.cs
@@ -134,6 +134,14 @@ namespace Magitek.Models.Machinist
         public float DelayWildfireSeconds { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool LateWeaveWildfire { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool DoubleHyperchargedWildfire { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool UseReassemble { get; set; }
 

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -67,6 +67,12 @@ namespace Magitek.Rotations
 
             if (ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero)
             {
+                if (MachinistRoutine.GlobalCooldown.CanWeave())
+                {
+                    if (await Cooldowns.Wildfire()) return true;
+                    if (await Cooldowns.Hypercharge()) return true; // for 10xHB
+                }
+
                 if (MachinistRoutine.GlobalCooldown.CanWeave(1))
                 {
                     //Utility
@@ -105,20 +111,23 @@ namespace Magitek.Rotations
                     if (await Cooldowns.Wildfire()) return true;
                     if (await Cooldowns.Hypercharge()) return true;
                     if (await Cooldowns.BarrelStabilizer()) return true;
+                }
 
+                if (MachinistRoutine.GlobalCooldown.CanWeave(1))
+                {
                     //oGCDs
                     if (await SingleTarget.GaussRound()) return true;
                     if (await MultiTarget.Ricochet()) return true;
                 }
             }
 
+            if (await MultiTarget.FullMetalField()) return true;
+
             //GCDs - Top Hypercharge Priority
             if (await MultiTarget.AutoCrossbow()) return true;
             if (await SingleTarget.HeatBlast()) return true;
 
             //Use On CD
-            if (await MultiTarget.FullMetalField()) return true;
-
             if (await MultiTarget.Excavator()) return true;
             if (await MultiTarget.ChainSaw()) return true;
 

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -93,6 +93,7 @@ namespace Magitek.Rotations
             if (await Ninjutsu.HyoshoRanryu()) return true;
             if (await Ninjutsu.Huton()) return true;
             if (await Ninjutsu.Suiton()) return true;
+            if (await Ninjutsu.Doton()) return true;
             if (await Ninjutsu.Katon()) return true;
             if (await Ninjutsu.Raiton()) return true;
             if (await Ninjutsu.FumaShuriken()) return true;

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -76,6 +76,8 @@ namespace Magitek.Rotations
             if (PictomancerRoutine.GlobalCooldown.CanWeave())
             {
                 if (await Healer.LucidDreaming(PictomancerSettings.Instance.UseLucidDreaming, PictomancerSettings.Instance.LucidDreamingMinimumManaPercent)) return true;
+
+                if (await Buff.UsePotion()) return true;
             }
 
             if (PictomancerRoutine.GlobalCooldown.CanWeave(1) || MovementManager.IsMoving)

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -80,6 +80,7 @@ namespace Magitek.Rotations
             {
                 if (ReaperRoutine.GlobalCooldown.CanWeave())
                 {
+                    if (await Utility.UsePotion()) return true;
                     if (await PhysicalDps.Interrupt(ReaperSettings.Instance)) return true;
                     if (await PhysicalDps.SecondWind(ReaperSettings.Instance)) return true;
                     if (await PhysicalDps.Bloodbath(ReaperSettings.Instance)) return true;

--- a/Magitek/Utilities/Combat.cs
+++ b/Magitek/Utilities/Combat.cs
@@ -20,6 +20,11 @@ namespace Magitek.Utilities
         public static readonly Stopwatch DutyTime = new Stopwatch();
         public static double CurrentTargetCombatTimeLeft;
 
+        public static bool IsBoss()
+        {
+            return Core.Me.CurrentTarget.IsBoss() || (Globals.InActiveDuty && Enemies.Count == 1);
+        }
+
         public static bool IsMoving(GameObject target)
         {
             //if (!Tracking.EnemyInfos.Any(r => r.Unit == target && r.IsMoving)) return false;

--- a/Magitek/Utilities/WeaveWindow.cs
+++ b/Magitek/Utilities/WeaveWindow.cs
@@ -96,23 +96,9 @@ namespace Magitek.Utilities
             return true;
         }
 
-        public bool CanWeaveLate(int ogcdPlacement = 1)
+        public bool IsLateWeaveWindow()
         {
-            if (!CanWeave(ogcdPlacement))
-                return false;
-
-            switch (ogcdPlacement)
-            {
-                case 1:
-                    return (Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset) * 2 >
-                           _gcd.Cooldown.TotalMilliseconds;
-                case 2:
-                    return (Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset) >
-                           _gcd.Cooldown.TotalMilliseconds;
-                default:
-                    return false;
-            }
-
+            return (_gcd.Cooldown.TotalMilliseconds <= (Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset + 100));
         }
 
         public bool IsWeaveWindow(int targetWindow = 1, bool timeBased = false)

--- a/Magitek/Views/UserControls/Machinist/Buffs.xaml
+++ b/Magitek/Views/UserControls/Machinist/Buffs.xaml
@@ -49,10 +49,18 @@
         </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5" Orientation="Horizontal">
-                <CheckBox Content="Hypercharge          " IsChecked="{Binding MachinistSettings.UseHypercharge, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Content="Wildfire                     " IsChecked="{Binding MachinistSettings.UseWildfire, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Content="Barrel Stabilizer " IsChecked="{Binding MachinistSettings.UseBarrelStabilizer, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+            <StackPanel Orientation="Vertical">
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Hypercharge          " IsChecked="{Binding MachinistSettings.UseHypercharge, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Wildfire                     " IsChecked="{Binding MachinistSettings.UseWildfire, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Barrel Stabilizer " IsChecked="{Binding MachinistSettings.UseBarrelStabilizer, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Late Weave Wildfire (better alignment for 6GCD wildfire)" IsChecked="{Binding MachinistSettings.LateWeaveWildfire, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Save for Double Hypercharged Wildfires (requires late weave wildfire)" IsChecked="{Binding MachinistSettings.DoubleHyperchargedWildfire, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Pictomancer/Utility.xaml
+++ b/Magitek/Views/UserControls/Pictomancer/Utility.xaml
@@ -16,10 +16,35 @@
     </UserControl.DataContext>
 
     <UserControl.Resources>
-        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <ObjectDataProvider x:Key="PotionEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:PotionEnum" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <StackPanel Margin="10">
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <Grid Margin="5">
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <CheckBox Grid.Row="0" Grid.Column="0" Content="Use Potion " IsChecked="{Binding PictomancerSettings.UsePotion, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <ComboBox Grid.Row="0" Grid.Column="1" Width="120" ItemsSource="{Binding Source={StaticResource PotionEnum}}" SelectedValue="{Binding PictomancerSettings.PotionTypeAndGradeLevel, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" (Item Potion selected should be in your hotkey bar)" />
+            </Grid>
+        </controls:SettingsBlock>
+
         <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">
                 <StackPanel Orientation="Vertical">

--- a/Magitek/Views/UserControls/Reaper/Utility.xaml
+++ b/Magitek/Views/UserControls/Reaper/Utility.xaml
@@ -16,10 +16,34 @@
     </UserControl.DataContext>
 
     <UserControl.Resources>
-        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <ObjectDataProvider x:Key="PotionEnum" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="enums:PotionEnum" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+        </ResourceDictionary>
     </UserControl.Resources>
 
     <StackPanel Margin="10">
+        <controls:SettingsBlock Margin="0,5,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <Grid Margin="5">
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <CheckBox Grid.Row="0" Grid.Column="0" Content="Use Potion " IsChecked="{Binding ReaperSettings.UsePotion, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <ComboBox Grid.Row="0" Grid.Column="1" Width="120" ItemsSource="{Binding Source={StaticResource PotionEnum}}" SelectedValue="{Binding ReaperSettings.PotionTypeAndGradeLevel, Mode=TwoWay}" Style="{DynamicResource ComboBox}" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Style="{DynamicResource TextBlockDefault}" Text=" (Item Potion selected should be in your hotkey bar)" />
+            </Grid>
+        </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="5">


### PR DESCRIPTION
PLD: Casts Requiscat Holy/Cirlce when under level 90.
MCH: Fix routine getting stuck in low level with hypercharge & no heat blast.
     Add option to late weave wildfire. Better alignment for 6GCD wildfires without NoClippy.
     Add option for 10xHB 120s burst windows.
PCT: Add potion toggle for starry muse.
RPR: Add potion toggle for arcane circle.