### PR TITLE
PCT, NIN, VPR, Openers

### DIFF
--- a/Magitek/Logic/CustomOpenerLogic.cs
+++ b/Magitek/Logic/CustomOpenerLogic.cs
@@ -25,7 +25,22 @@ namespace Magitek.Logic
         public static HashSet<OpenerGroup> _executedOpeners = new HashSet<OpenerGroup>();
         private static Gambit _executingGambit = null;
         private static Stopwatch GambitTimer { get; set; }
-        public static DateTime LastReset = DateTime.UtcNow;
+        public static DateTime LastOpenerStartedAt = DateTime.UtcNow;
+        public static DateTime LastOpenerResetAt = DateTime.UtcNow;
+
+        internal static bool ResetOpenerIfNeeded()
+        {
+            if (Combat.OutOfCombatTime.ElapsedMilliseconds >= 10500
+                && (_executedOpeners.Count > 0 || InOpener)
+                && (DateTime.UtcNow - LastOpenerStartedAt).TotalMilliseconds >= 10500
+                && (DateTime.UtcNow - LastOpenerResetAt).TotalMilliseconds >= 10500)
+            {
+                ResetOpener();
+                return true;
+            }
+
+            return false;
+        }
 
         internal static void ResetOpener()
         {
@@ -33,7 +48,8 @@ namespace Magitek.Logic
             _executingOpener = null;
             _executingGambit = null;
             _executedOpeners.Clear();
-            LastReset = DateTime.UtcNow;
+            LastOpenerStartedAt = DateTime.UtcNow;
+            LastOpenerResetAt = DateTime.UtcNow;
             BaseSettings.Instance.ResetOpeners = false;
         }
         
@@ -78,6 +94,7 @@ namespace Magitek.Logic
             }
 
             InOpener = true;
+            LastOpenerStartedAt = DateTime.UtcNow;
 
             // Check to see if we died in the middle of an opener
             if (Core.Me.IsDead)

--- a/Magitek/Logic/Ninja/Ninjutsu.cs
+++ b/Magitek/Logic/Ninja/Ninjutsu.cs
@@ -306,6 +306,9 @@ namespace Magitek.Logic.Ninja
             if (Core.Me.HasAura(Auras.Doton))
                 return false;
 
+            if (Combat.IsMoving(Core.Me.CurrentTarget))
+                return false;
+
             return await NinjaRoutine.PrepareNinjutsu(Spells.Doton, Core.Me);
 
         }

--- a/Magitek/Logic/Pictomancer/Palette.cs
+++ b/Magitek/Logic/Pictomancer/Palette.cs
@@ -164,7 +164,7 @@ namespace Magitek.Logic.Pictomancer
                 if (currentCharges > 0)
                     nextMogInMs -= (cooldownForCharge * (currentCharges - 1));
 
-                Logger.WriteInfo($"Next Mog in {nextMogInMs}ms. Starry Cooldown {PictomancerRoutine.StarryCooldownRemaining()}");
+                //Logger.WriteInfo($"Next Mog in {nextMogInMs}ms. Starry Cooldown {PictomancerRoutine.StarryCooldownRemaining()}");
 
                 if (nextMogInMs > PictomancerRoutine.StarryCooldownRemaining())
                     return false;
@@ -266,7 +266,7 @@ namespace Magitek.Logic.Pictomancer
                 && muse.Charges < 2)
                 return false;
 
-            if (muse.IsKnown/*AndReady*/() && muse.CanCast(Core.Me.CurrentTarget))
+            if (muse.IsKnown/*AndReady*/() && muse.CanCast(Core.Me))
                 return await muse.CastAura(Core.Me, Auras.HammerTime);
 
             return false;
@@ -357,7 +357,7 @@ namespace Magitek.Logic.Pictomancer
             if (PictomancerRoutine.CheckTTDIsEnemyDyingSoon())
                 return false;
 
-            if (!PictomancerRoutine.GlobalCooldown.CanWeave(1))
+            if (!PictomancerRoutine.GlobalCooldown.CanWeave())
                 return false;
 
             if (Core.Me.ClassLevel >= Spells.StarryMuse.LevelAcquired)

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -127,7 +127,8 @@ namespace Magitek
                 CombatMessageManager.RegisterMessageStrategiesForClass(Core.Me.CurrentJob);
             }
             #endregion
-            BaseSettings.Instance.ResetOpeners = true;
+
+            CustomOpenerLogic.ResetOpener();
         }
 
         private void GameEventsOnOnMapChanged(object sender, EventArgs e)
@@ -144,7 +145,8 @@ namespace Magitek
                     TogglesManager.LoadTogglesForCurrentJob();
                 });
             }
-            BaseSettings.Instance.ResetOpeners = true;
+
+            CustomOpenerLogic.ResetOpener();
         }
 
         public void OnStart(BotBase bot)
@@ -155,7 +157,7 @@ namespace Magitek
             OpenerLogic.InOpener = false;
             OpenerLogic.OpenerQueue.Clear();
             SpellQueueLogic.SpellQueue.Clear();
-            BaseSettings.Instance.ResetOpeners = true;
+            CustomOpenerLogic.ResetOpener();
 
             // Apply the gambits we have
             GambitsViewModel.Instance.ApplyGambits();
@@ -262,12 +264,9 @@ namespace Magitek
                 }
             }
 
-            if (Combat.OutOfCombatTime.ElapsedMilliseconds >= 10500
-                && (CustomOpenerLogic._executedOpeners.Count > 0 || CustomOpenerLogic.InOpener)
-                && (DateTime.UtcNow - CustomOpenerLogic.LastReset).TotalMilliseconds >= 10500)
+            if (CustomOpenerLogic.ResetOpenerIfNeeded())
             {
-                Logger.WriteInfo(@"Resetting Openers Because We're Out Of Combat");
-                CustomOpenerLogic.ResetOpener();
+                Logger.WriteInfo(@"Reset Openers Because We're Out Of Combat");
             }
 
             if (WorldManager.InPvP && !BaseSettings.Instance.ActivePvpCombatRoutine)
@@ -396,23 +395,23 @@ namespace Magitek
                 new ActionRunCoroutine(_ => RotationManager.Rotation.Rest())));
 
         public override Composite PreCombatBuffBehavior =>
-            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
+            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP || BaseSettings.Instance.ActivePvpCombatRoutine, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
                 new ActionRunCoroutine(_ => RotationManager.Rotation.PreCombatBuff())));
 
         public override Composite PullBehavior =>
-            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
+            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP || BaseSettings.Instance.ActivePvpCombatRoutine, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
                 new ActionRunCoroutine(_ => RotationManager.Rotation.Pull())));
 
         public override Composite HealBehavior =>
-            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
+            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP || BaseSettings.Instance.ActivePvpCombatRoutine, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
                 new ActionRunCoroutine(_ => RotationManager.Rotation.Heal())));
 
         public override Composite CombatBuffBehavior =>
-            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
+            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP || BaseSettings.Instance.ActivePvpCombatRoutine, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
                 new ActionRunCoroutine(_ => RotationManager.Rotation.CombatBuff())));
 
         public override Composite CombatBehavior =>
-            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
+            new Decorator(new PrioritySelector(new Decorator(_ => WorldManager.InPvP || BaseSettings.Instance.ActivePvpCombatRoutine, new ActionRunCoroutine(_ => RotationManager.Rotation.PvP())),
                 new ActionRunCoroutine(_ => RotationManager.Rotation.Combat())));
 
         #endregion Behavior Composites

--- a/Magitek/Models/Debugging/EnemySpellCastInfo.cs
+++ b/Magitek/Models/Debugging/EnemySpellCastInfo.cs
@@ -5,6 +5,8 @@ using Magitek.Models.WebResources;
 using Magitek.ViewModels;
 using PropertyChanged;
 using System;
+using System.ComponentModel;
+using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
@@ -24,6 +26,8 @@ namespace Magitek.Models.Debugging
             ZoneId = zoneId;
             ZoneName = zoneName;
             Icon = this.GetIcon();
+            InFightLogicBuilderAOE = "[+] FightLogic AOE";
+            InFightLogicBuilderTB = "[+] FightLogic TB";
         }
 
         public string Name { get; set; }
@@ -44,12 +48,24 @@ namespace Magitek.Models.Debugging
             }
         }
 
+        public string InFightLogicBuilderAOE { get; set; }
+        public string InFightLogicBuilderTB { get; set; }
+
         public ICommand AddToFightLogicBuilderAOE => new DelegateCommand<EnemySpellCastInfo>(info =>
         {
             if (info == null)
                 return;
 
-            Debug.Instance.FightLogicBuilderAOE.Add(info);
+            if (Debug.Instance.FightLogicBuilderAOE.Any(r => r.Id == info.Id))
+            {
+                Debug.Instance.FightLogicBuilderAOE.Remove(info);
+                InFightLogicBuilderAOE = "[+] FightLogic AOE";
+            }
+            else
+            {
+                Debug.Instance.FightLogicBuilderAOE.Add(info);
+                InFightLogicBuilderAOE = "[-] FightLogic AOE";
+            }
         });
 
         public ICommand AddToFightLogicBuilderTB => new DelegateCommand<EnemySpellCastInfo>(info =>
@@ -57,7 +73,16 @@ namespace Magitek.Models.Debugging
             if (info == null)
                 return;
 
-            Debug.Instance.FightLogicBuilderTB.Add(info);
+            if (Debug.Instance.FightLogicBuilderTB.Any(r => r.Id == info.Id))
+            { 
+                Debug.Instance.FightLogicBuilderTB.Remove(info);
+                InFightLogicBuilderTB = "[+] FightLogic TB";
+            }
+            else
+            { 
+                Debug.Instance.FightLogicBuilderTB.Add(info);
+                InFightLogicBuilderTB = "[-] FightLogic TB";
+            }
         });
 
         public ICommand AddToInterruptsAndStuns => new DelegateCommand<EnemySpellCastInfo>(info =>
@@ -91,6 +116,6 @@ namespace Magitek.Models.Debugging
             {
                 InterruptsAndStuns.Instance.ActionList.Add(newXivItem);
             });
-        }); 
+        });
     }
 }

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -89,11 +89,11 @@ namespace Magitek.Rotations
             if (await Ninjutsu.TenChiJin_Raiton()) return true;
             if (await Ninjutsu.TenChiJin_Suiton()) return true;
 
+            if (await Ninjutsu.Doton()) return true;
             if (await Ninjutsu.GokaMekkyaku()) return true;
             if (await Ninjutsu.HyoshoRanryu()) return true;
             if (await Ninjutsu.Huton()) return true;
             if (await Ninjutsu.Suiton()) return true;
-            if (await Ninjutsu.Doton()) return true;
             if (await Ninjutsu.Katon()) return true;
             if (await Ninjutsu.Raiton()) return true;
             if (await Ninjutsu.FumaShuriken()) return true;

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -69,9 +69,12 @@ namespace Magitek.Rotations
 
             PictomancerRoutine.DetectSmudge();
 
-            if (await Buff.FightLogic_TemperaGrassa()) return true;
-            if (await Buff.FightLogic_TemperaCoat()) return true;
-            if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
+            if (!Core.Me.HasAura(Auras.StarryMuse, true))
+            {
+                if (await Buff.FightLogic_TemperaGrassa()) return true;
+                if (await Buff.FightLogic_TemperaCoat()) return true;
+                if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
+            }
 
             if (PictomancerRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -80,11 +80,12 @@ namespace Magitek.Rotations
                 if (await Buff.UsePotion()) return true;
             }
 
-            if (PictomancerRoutine.GlobalCooldown.CanWeave(1) || MovementManager.IsMoving)
+            if (PictomancerRoutine.GlobalCooldown.CanWeave() || MovementManager.IsMoving)
             {
-                if (await Palette.MogoftheAges()) return true;
+                if (await Palette.ScenicMuse()) return true;
                 if (await Palette.CreatureMuse()) return true;
                 if (await Palette.StrikingMuse()) return true;
+                if (await Palette.MogoftheAges()) return true;
             }
 
             // palettes
@@ -92,9 +93,7 @@ namespace Magitek.Rotations
             if (await Buff.SubtractivePalette()) return true;
 
             if (await Palette.StarPrism()) return true;
-            if (await Palette.RainbowDrip()) return true;
-            if (await Palette.ScenicMuse()) return true;            
-
+            if (await Palette.RainbowDrip()) return true;    
             if (await Palette.HammerStamp()) return true;
 
             // inspiration is on a timer, need to consume those stacks first.

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -52,15 +52,15 @@ namespace Magitek.Rotations
 
             if (SingleTarget.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_Debuff(ViperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-
             if (ViperRoutine.GlobalCooldown.CanWeave())
             {
+                if (await CommonFightLogic.FightLogic_Debuff(ViperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
                 if (await PhysicalDps.Interrupt(ViperSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(ViperSettings.Instance)) return true;
                 if (await PhysicalDps.Bloodbath(ViperSettings.Instance)) return true;
 
                 if (await Utility.TrueNorth()) return true;
+                if (await Utility.UsePotion()) return true;
                 if (await SingleTarget.Slither()) return true;
 
                 if (await Cooldown.FourthLegacy()) return true;

--- a/Magitek/Styles/Buttons.xaml
+++ b/Magitek/Styles/Buttons.xaml
@@ -694,10 +694,11 @@
         <Setter Property="FontFamily" Value="Segoe UI Symbol" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="Foreground" Value="{DynamicResource FlatControlBackground}" />
+        <Setter Property="Background" Value="Transparent" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Background="Transparent">
+                    <Grid Background="{TemplateBinding Background}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition />

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -124,9 +124,6 @@ namespace Magitek.Utilities.Managers
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
 
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
             await Chocobo.HandleChocobo();
 
             return await ExecuteRotationMethod(RotationManager.CurrentRotation, "Rest");            
@@ -136,9 +133,6 @@ namespace Magitek.Utilities.Managers
         {
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
 
             await Chocobo.HandleChocobo();
 
@@ -174,14 +168,20 @@ namespace Magitek.Utilities.Managers
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
 
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, (Core.Me.IsRanged() ? 20 : 0) + Core.Me.CurrentTarget.CombatReach);
             }
+
+            if (WorldManager.InSanctuary)
+                return false;
+
+            if (Globals.OnPvpMap)
+                return false;
+
+            if (DutyManager.InInstance && !Globals.InActiveDuty)
+                return false;
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
@@ -203,9 +203,6 @@ namespace Magitek.Utilities.Managers
         {
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
 
             if (Core.Me.IsMounted)
                 return true;
@@ -237,9 +234,6 @@ namespace Magitek.Utilities.Managers
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
 
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
-
             return await ExecuteRotationMethod(RotationManager.CurrentRotation, "CombatBuff");
         }
 
@@ -247,9 +241,6 @@ namespace Magitek.Utilities.Managers
         {
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
-
-            if (BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await PvP();
 
             Group.UpdateAllies(GetGroupExtensionForJob(RotationManager.CurrentRotation));
             Globals.HealTarget = Group.CastableAlliesWithin30.FirstOrDefault();
@@ -290,9 +281,6 @@ namespace Magitek.Utilities.Managers
         {
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
-
-            if (!BaseSettings.Instance.ActivePvpCombatRoutine)
-                return await Combat();
 
             Group.UpdateAllies(GetGroupExtensionForJob(RotationManager.CurrentRotation));
             Globals.HealTarget = Group.CastableAlliesWithin30.FirstOrDefault();

--- a/Magitek/ViewModels/Debug.cs
+++ b/Magitek/ViewModels/Debug.cs
@@ -135,7 +135,12 @@ namespace Magitek.ViewModels
             sb.AppendLine("    }");
             sb.AppendLine("},");
 
-            Clipboard.SetText(sb.ToString());
+            try
+            {
+                Clipboard.SetDataObject(sb.ToString());
+            } catch {
+                Logger.Error("Failed to copy to clipboard");
+            }
         }
 
 
@@ -145,6 +150,15 @@ namespace Magitek.ViewModels
         {
             var instance = Instance;
             if (instance == null) return;
+
+            foreach (var x in instance.FightLogicBuilderTB) 
+            {
+                x.InFightLogicBuilderTB = "[+] FightLogic TB";
+            }
+            foreach (var x in instance.FightLogicBuilderAOE)
+            {
+                x.InFightLogicBuilderAOE = "[+] FightLogic AOE";
+            }
 
             instance.FightLogicBuilderTB.Clear();
             instance.FightLogicBuilderAOE.Clear();

--- a/Magitek/Views/UserControls/Bugs/EnemySpellCasts.xaml
+++ b/Magitek/Views/UserControls/Bugs/EnemySpellCasts.xaml
@@ -1,4 +1,7 @@
-﻿<UserControl x:Class="Magitek.Views.UserControls.Bugs.EnemySpellCasts" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:viewModels="clr-namespace:Magitek.ViewModels">
+﻿<UserControl x:Class="Magitek.Views.UserControls.Bugs.EnemySpellCasts" 
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+             xmlns:viewModels="clr-namespace:Magitek.ViewModels">
 
     <UserControl.DataContext>
         <Binding Source="{x:Static viewModels:Debug.Instance}" />
@@ -38,8 +41,7 @@
                             <ColumnDefinition Width="30" />
                             <ColumnDefinition Width="80" />
                             <ColumnDefinition Width="100" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
 
                         <Border Grid.Column="0" Background="{DynamicResource Black20}" CornerRadius="5">
@@ -47,32 +49,40 @@
                         </Border>
 
                         <TextBlock Grid.Column="1"
-                                   Margin="2,0"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   Foreground="White"
-                                   Text="{Binding Value.Id}" />
-                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Foreground="White" Text="{Binding Value.Name}" />
-                        <TextBlock Grid.Column="3" Margin="5,0" VerticalAlignment="Center" Foreground="White" Text="{Binding Value.CastedBy}" />
-                        <Button Grid.Column="4"
-                                HorizontalAlignment="Left"
-                                Command="{Binding Value.AddToInterruptsAndStuns}"
-                                CommandParameter="{Binding Value}"
-                                Content="Add Interrupt/Stun"
-                                Style="{DynamicResource ButtonLists}" />
-                        <Button Grid.Column="5"
-                            HorizontalAlignment="Left"
-                            Command="{Binding Value.AddToFightLogicBuilderTB}"
-                            CommandParameter="{Binding Value}"
-                            Content="FightLogic TankBuster"
-                            Style="{DynamicResource ButtonLists}" />
-                        <Button Grid.Column="6"
-                            HorizontalAlignment="Left"
-                            Command="{Binding Value.AddToFightLogicBuilderAOE}"
-                            CommandParameter="{Binding Value}"
-                            Content="FightLogic AOE"
-                            Style="{DynamicResource ButtonLists}" />
-                    </Grid>
+                           Margin="2,0"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Foreground="White"
+                           Text="{Binding Value.Id}" />
+                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Foreground="White" Text="{Binding Value.Name}" />
+                                    <TextBlock Grid.Column="3" Margin="5,0" VerticalAlignment="Center" Foreground="White" Text="{Binding Value.CastedBy}" />
+
+                                    <StackPanel Grid.Column="4" Orientation="Horizontal" HorizontalAlignment="Left">
+                                        <Button 
+                                            Command="{Binding Value.AddToInterruptsAndStuns}"
+                                            CommandParameter="{Binding Value}"
+                                            Content="Add Interrupt/Stun"
+                                            Style="{DynamicResource ButtonLists}" 
+                                            MinWidth="120" />
+
+                                        <Button 
+                                            Command="{Binding Value.AddToFightLogicBuilderTB}"
+                                            CommandParameter="{Binding Value}"
+                                            Content="{Binding Value.InFightLogicBuilderTB}"
+                                            Style="{DynamicResource ButtonLists}" 
+                                            MinWidth="120" 
+                                            />
+
+                                        <Button 
+                                            Command="{Binding Value.AddToFightLogicBuilderAOE}"
+                                            CommandParameter="{Binding Value}"
+                                            Content="{Binding Value.InFightLogicBuilderAOE}"
+                                            Style="{DynamicResource ButtonLists}" 
+                                            MinWidth="120" 
+                                            />
+                                    </StackPanel>
+                                </Grid>
+
 
                 </DataTemplate>
             </ListBox.ItemTemplate>

--- a/MagitekLoader/MagitekLoader.csproj
+++ b/MagitekLoader/MagitekLoader.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
-    <SccProjectName>SAK</SccProjectName>
-    <SccLocalPath>SAK</SccLocalPath>
-    <SccAuxPath>SAK</SccAuxPath>
-    <SccProvider>SAK</SccProvider>
+    <SccProjectName></SccProjectName>
+    <SccLocalPath></SccLocalPath>
+    <SccAuxPath></SccAuxPath>
+    <SccProvider></SccProvider>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
Openers: Don't reset opener due to out of combat if it was started within the last 10 seconds.
NIN: Doton - added a second check for movement of the enemy as well
PCT: Adjust priority of starry muse and striking muse. No fightlogic during burst window.
VPR: Actually use potions. Weave faint.
Dev: Improved fightlogic builder buttons on spell cast history. 