### PR TITLE
7.1 pve updates

### DIFF
--- a/Magitek/Logic/Machinist/MultiTarget.cs
+++ b/Magitek/Logic/Machinist/MultiTarget.cs
@@ -91,7 +91,7 @@ namespace Magitek.Logic.Machinist
             if (Core.Me.HasAura(Auras.Overheated))
                 return false;
 
-            if (Core.Me.EnemiesInCone(8) < MachinistSettings.Instance.FlamethrowerEnemyCount)
+            if (Core.Me.EnemiesInCone(12) < MachinistSettings.Instance.FlamethrowerEnemyCount)
                 return false;
 
             if (Spells.FlameThrower.CanCast())

--- a/Magitek/Logic/Machinist/Pvp.cs
+++ b/Magitek/Logic/Machinist/Pvp.cs
@@ -27,12 +27,12 @@ namespace Magitek.Logic.Machinist
             return await Spells.BlastChargePvp.Cast(Core.Me.CurrentTarget);
         }
 
-        public static async Task<bool> HeatBlast()
+        public static async Task<bool> BlazingShot()
         {
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.HeatBlast.CanCast())
+            if (!Spells.BlazingShotPvp.CanCast())
                 return false;
 
             if (!Core.Me.HasAura(Auras.PvpOverheated))
@@ -44,7 +44,7 @@ namespace Magitek.Logic.Machinist
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            return await Spells.HeatBlastPvp.Cast(Core.Me.CurrentTarget);
+            return await Spells.BlazingShotPvp.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> WildFire()
@@ -65,6 +65,46 @@ namespace Magitek.Logic.Machinist
                 return false;
 
             return await Spells.WildfirePvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> Detonator()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!MachinistSettings.Instance.Pvp_Wildfire)
+                return false;
+
+            if (!Spells.DetonatorPvp.CanCast())
+                return false;
+
+            if (!Core.Me.CurrentTarget.HasAura(Auras.WildfirePvp))
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) < 27)
+                return false;
+
+            return await Spells.DetonatorPvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> FullMetalField()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!MachinistSettings.Instance.Pvp_FullMetalField)
+                return false;
+
+            if (!Spells.FullMetalFieldPvp.CanCast())
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 25)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            return await Spells.FullMetalFieldPvp.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> Scattergun()

--- a/Magitek/Logic/Paladin/Defensive.cs
+++ b/Magitek/Logic/Paladin/Defensive.cs
@@ -181,7 +181,7 @@ namespace Magitek.Logic.Paladin
 
             if (PaladinSettings.Instance.UseCoverHealer)
             {
-                GameObject coverTarget = Group.CastableAlliesWithin10.FirstOrDefault(r => r.IsHealer() && r.CurrentHealthPercent < PaladinSettings.Instance.UseCoverHealerHp);
+                GameObject coverTarget = Group.CastableAlliesWithin20.FirstOrDefault(r => r.IsHealer() && r.CurrentHealthPercent < PaladinSettings.Instance.UseCoverHealerHp);
 
                 if (coverTarget != null)
                 {
@@ -192,7 +192,7 @@ namespace Magitek.Logic.Paladin
             if (!PaladinSettings.Instance.UseCoverDps)
                 return false;
 
-            var coverDpsTarget = Group.CastableAlliesWithin10.FirstOrDefault(r => r.IsDps() && r.CurrentHealthPercent < PaladinSettings.Instance.UseCoverDpsHp);
+            var coverDpsTarget = Group.CastableAlliesWithin20.FirstOrDefault(r => r.IsDps() && r.CurrentHealthPercent < PaladinSettings.Instance.UseCoverDpsHp);
 
             if (coverDpsTarget == null)
                 return false;

--- a/Magitek/Logic/Summoner/Aoe.cs
+++ b/Magitek/Logic/Summoner/Aoe.cs
@@ -126,8 +126,9 @@ namespace Magitek.Logic.Summoner
 
             if (!Spells.CrimsonStrike.IsKnownAndReady()) return false;
 
-            if (Casting.LastSpell != Spells.CrimsonCyclone) return false;
-
+            if (!Core.Me.HasAura(Auras.CrimsonStrikeReady))
+                return false;
+            
             if (Core.Me.CurrentTarget == null)
                 return false;
 

--- a/Magitek/Models/Machinist/MachinistSettings.cs
+++ b/Magitek/Models/Machinist/MachinistSettings.cs
@@ -205,6 +205,10 @@ namespace Magitek.Models.Machinist
 
         [Setting]
         [DefaultValue(true)]
+        public bool Pvp_FullMetalField { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool Pvp_UsedAnalysisOnDrill { get; set; }
 
         [Setting]

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -155,7 +155,7 @@ namespace Magitek.Rotations
             {
                 //LB
                 if (await Pvp.MarksmansSpite()) return true;
-                if (await Pvp.HeatBlast()) return true;
+                if (await Pvp.BlazingShot()) return true;
                 if (await Pvp.Scattergun()) return true;
 
                 // Buff
@@ -168,6 +168,8 @@ namespace Magitek.Rotations
                 if (await Pvp.AirAnchor()) return true;
                 if (await Pvp.BioBlaster()) return true;
                 if (await Pvp.Drill()) return true;
+
+                if (await Pvp.FullMetalField()) return true;
             }
 
             // Main

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -392,7 +392,7 @@ namespace Magitek.Utilities
             ReadytoReawaken = 3671,
             HonedSteel = 3672,
             HonedReavers = 3772,
-            
+
             //PCT
             Aetherhues = 3675,
             Aetherhues2 = 3676,
@@ -422,6 +422,7 @@ namespace Magitek.Utilities
             Overheated = 2688,
             Dismantled = 860,
             Tactician = 1951,
+            WildfirePvp = 1323,
 
             //WHM
             Medica3 = 3880,
@@ -457,6 +458,9 @@ namespace Magitek.Utilities
 
             //WAR
             Wrathful = 3901,
+
+            //SMN
+            CrimsonStrikeReady = 4403,
 
             //To prevent conflict
             Placeholder = 9999;

--- a/Magitek/Utilities/Routines/Gunbreaker.cs
+++ b/Magitek/Utilities/Routines/Gunbreaker.cs
@@ -45,7 +45,7 @@ namespace Magitek.Utilities.Routines
         public static int MaxCartridge => Core.Me.ClassLevel < 88 ? 2 : 3;
         public static int AmountCartridgeFromBloodfest => Core.Me.ClassLevel < 88 ? 2 : 3;
         public static int RequiredCartridgeForGnashingFang => 1;
-        public static int RequiredCartridgeForDoubleDown => 2;
+        public static int RequiredCartridgeForDoubleDown => 1;
         public static int RequiredCartridgeForBurstStrike => 1;
         public static int RequiredCartridgeForFatedCircle => 1;
 

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -1291,6 +1291,9 @@ namespace Magitek.Utilities
         public static readonly SpellData BishopAutoturretPvp = DataManager.GetSpellData(29412);
         public static readonly SpellData AnalysisPvp = DataManager.GetSpellData(29414);
         public static readonly SpellData MarksmansSpitePvp = DataManager.GetSpellData(29415);
+        public static readonly SpellData BlazingShotPvp = DataManager.GetSpellData(41468);
+        public static readonly SpellData FullMetalFieldPvp = DataManager.GetSpellData(41469);
+        public static readonly SpellData DetonatorPvp = DataManager.GetSpellData(41470);
 
         //DNC
         public static readonly uint FountainPvpCombo = 54;

--- a/Magitek/Views/UserControls/Machinist/Pvp.xaml
+++ b/Magitek/Views/UserControls/Machinist/Pvp.xaml
@@ -67,6 +67,9 @@
                     <CheckBox Content="Wildfire" IsChecked="{Binding MachinistSettings.Pvp_Wildfire, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Full Metal Field" IsChecked="{Binding MachinistSettings.Pvp_FullMetalField, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="Scattergun" IsChecked="{Binding MachinistSettings.Pvp_Scattergun, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">


### PR DESCRIPTION
PLD: Updated cover range
GNB: Updated double down cartridge cost
SMN: Updated crimson strike
MCH: Updated flamethrower distance
MCH PVP: Added full metal field and blazing shot and detonator if target runs out of range