### PR TITLE
7.2 Fightlogic, PvP role actions, PLD PVP

### DIFF
--- a/Magitek/.editorconfig
+++ b/Magitek/.editorconfig
@@ -123,3 +123,5 @@ dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 #prefer properties not to be prefaced with this. or Me. in Visual Basic
 dotnet_style_qualification_for_property = false:suggestion
+
+dotnet_diagnostic.CA1416.severity = none

--- a/Magitek/Logic/Paladin/Pvp.cs
+++ b/Magitek/Logic/Paladin/Pvp.cs
@@ -48,6 +48,9 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
+            if (!Core.Me.HasAura(Auras.PvpConfiteorReady))
+                return false;
+
             if (!Spells.ConfiteorPvp.CanCast())
                 return false;
 
@@ -60,6 +63,9 @@ namespace Magitek.Logic.Paladin
         public static async Task<bool> AtonementPvp()
         {
             if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Core.Me.HasAura(Auras.PvpAtonementReady))
                 return false;
 
             if (!Spells.AtonementPvp.CanCast())
@@ -79,6 +85,9 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
+            if (!Core.Me.HasAura(Auras.PvpSupplicationReady))
+                return false;
+
             if (!Spells.SupplicationPvp.CanCast())
                 return false;
 
@@ -94,6 +103,9 @@ namespace Magitek.Logic.Paladin
         public static async Task<bool> SepulchrePvp()
         {
             if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Core.Me.HasAura(Auras.PvpSepulchreReady))
                 return false;
 
             if (!Spells.SepulchrePvp.CanCast())
@@ -113,7 +125,7 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.ShieldSmitePvp.CanCast())
+            if (!Spells.ShieldSmitePvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.ShieldSmitePvp.Range)

--- a/Magitek/Logic/Paladin/Pvp.cs
+++ b/Magitek/Logic/Paladin/Pvp.cs
@@ -71,27 +71,98 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.CurrentTarget.Distance(Core.Me) > 5)
                 return false;
 
-            if (!Core.Me.HasAura(Auras.PvpSwordOath))
-                return false;
-
             return await Spells.AtonementPvp.Cast(Core.Me.CurrentTarget);
         }
 
-        public static async Task<bool> ShieldBashPvp()
+        public static async Task<bool> SupplicationPvp()
         {
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.ShieldBashPvp.CanCast())
+            if (!Spells.SupplicationPvp.CanCast())
                 return false;
 
-            if (!PaladinSettings.Instance.Pvp_ShieldBash)
+            if (!PaladinSettings.Instance.Pvp_Supplication)
                 return false;
 
             if (Core.Me.CurrentTarget.Distance(Core.Me) > 5)
                 return false;
 
-            return await Spells.ShieldBashPvp.Cast(Core.Me.CurrentTarget);
+            return await Spells.SupplicationPvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> SepulchrePvp()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Spells.SepulchrePvp.CanCast())
+                return false;
+
+            if (!PaladinSettings.Instance.Pvp_Sepulchre)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 5)
+                return false;
+
+            return await Spells.SepulchrePvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> ShieldSmitePvp()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Spells.ShieldSmitePvp.CanCast())
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.ShieldSmitePvp.Range)
+                return false;
+
+            if (!PaladinSettings.Instance.Pvp_ShieldSmite)
+                return false;
+
+            if (PaladinSettings.Instance.Pvp_ShieldSmiteOnlyOnGuard && !Core.Me.CurrentTarget.HasAura(Auras.PvpGuard))
+                return false;
+
+            return await Spells.ShieldSmitePvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> HolySpiritPvp()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Spells.HolySpiritPvp.CanCast())
+                return false;
+
+            if (!PaladinSettings.Instance.Pvp_HolySpirit)
+                return false;
+
+            if (Core.Me.CurrentHealthPercent > PaladinSettings.Instance.Pvp_HolySpiritHpThreshold)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.HolySpiritPvp.Range)
+                return false;
+
+            return await Spells.HolySpiritPvp.Cast(Core.Me.CurrentTarget);
+        }
+
+        public static async Task<bool> ImperatorPvp()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Spells.ImperatorPvp.CanCast())
+                return false;
+
+            if (!PaladinSettings.Instance.Pvp_Imperator)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.ImperatorPvp.Range)
+                return false;
+
+            return await Spells.ImperatorPvp.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> HolySheltronPvp()

--- a/Magitek/Logic/Paladin/Pvp.cs
+++ b/Magitek/Logic/Paladin/Pvp.cs
@@ -15,7 +15,16 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.FastBladePvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.FastBladePvp.Range)
+                return false;
+
+            if (!Spells.FastBladePvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.FastBladePvp.CastPvpCombo(Spells.RoyalAuthorityPvpCombo, Core.Me.CurrentTarget);
@@ -25,8 +34,14 @@ namespace Magitek.Logic.Paladin
         {
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
+                                
+            if (!Core.Me.HasTarget)
+                return false;
 
-            if (!Spells.RiotBladePvp.CanCast())
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.RiotBladePvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.RiotBladePvp.CastPvpCombo(Spells.RoyalAuthorityPvpCombo, Core.Me.CurrentTarget);
@@ -37,7 +52,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.RoyalAuthorityPvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.RoyalAuthorityPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.RoyalAuthorityPvp.CastPvpCombo(Spells.RoyalAuthorityPvpCombo, Core.Me.CurrentTarget);
@@ -51,7 +72,16 @@ namespace Magitek.Logic.Paladin
             if (!Core.Me.HasAura(Auras.PvpConfiteorReady))
                 return false;
 
-            if (!Spells.ConfiteorPvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+                
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.ConfiteorPvp.Range)
+                return false;
+
+            if (!Spells.ConfiteorPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_Confiteor)
@@ -68,7 +98,13 @@ namespace Magitek.Logic.Paladin
             if (!Core.Me.HasAura(Auras.PvpAtonementReady))
                 return false;
 
-            if (!Spells.AtonementPvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.AtonementPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_Atonement)
@@ -88,7 +124,13 @@ namespace Magitek.Logic.Paladin
             if (!Core.Me.HasAura(Auras.PvpSupplicationReady))
                 return false;
 
-            if (!Spells.SupplicationPvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.SupplicationPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_Supplication)
@@ -108,7 +150,13 @@ namespace Magitek.Logic.Paladin
             if (!Core.Me.HasAura(Auras.PvpSepulchreReady))
                 return false;
 
-            if (!Spells.SepulchrePvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.SepulchrePvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_Sepulchre)
@@ -125,7 +173,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.ShieldSmitePvp.CanCast(Core.Me.CurrentTarget))
+            if (!Spells.ShieldSmitePvp.CanCast())
+                return false;
+
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
             if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.ShieldSmitePvp.Range)
@@ -145,7 +199,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.HolySpiritPvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.HolySpiritPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_HolySpirit)
@@ -165,7 +225,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.ImperatorPvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.ImperatorPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_Imperator)
@@ -199,7 +265,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.IntervenePvp.CanCast())
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.IntervenePvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             if (!PaladinSettings.Instance.Pvp_Intervene)
@@ -242,6 +314,12 @@ namespace Magitek.Logic.Paladin
             if (!Spells.BladeofFaithPvp.CanCast())
                 return false;
 
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
             return await Spells.BladeofFaithPvp.Cast(Core.Me.CurrentTarget);
         }
 
@@ -253,6 +331,12 @@ namespace Magitek.Logic.Paladin
             if (!Spells.BladeofTruthPvp.CanCast())
                 return false;
 
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
             return await Spells.BladeofTruthPvp.Cast(Core.Me.CurrentTarget);
         }
 
@@ -262,6 +346,12 @@ namespace Magitek.Logic.Paladin
                 return false;
 
             if (!Spells.BladeofValorPvp.CanCast())
+                return false;
+
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
             return await Spells.BladeofValorPvp.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Pictomancer/Pvp.cs
+++ b/Magitek/Logic/Pictomancer/Pvp.cs
@@ -146,7 +146,9 @@ namespace Magitek.Logic.Pictomancer
             if (!spell.CanCast())
                 return false;
 
-            if (Spells.LivingMusePvp.Masked().Charges < 1 && Core.Me.HasTarget)
+            if (Spells.LivingMusePvp.Masked().Charges < 1 
+                && Core.Me.HasTarget 
+                && !Core.Me.HasAura(Auras.PvpQuickSketch))
                 return false;
 
             if (WorldManager.ZoneId == 250 && !Core.Me.HasTarget)

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -48,8 +48,11 @@ namespace Magitek.Logic.Roles
             if (await Sprint(settings))
                 return true;
 
+            if (await RoleAction(settings))
+                return true;
+
             return false;
-        }
+        }        
 
         public static async Task<bool> Sprint<T>(T settings) where T : JobSettings
         {
@@ -157,7 +160,302 @@ namespace Magitek.Logic.Roles
                 return false;
 
             return await Spells.Recuperate.Cast(Core.Me);
+        }        
+
+        public static async Task<bool> RoleAction<T>(T settings) where T : JobSettings
+        {
+            if (!settings.Pvp_UseRoleActions)
+                return false;
+
+            if (!Spells.PvPRoleAction.CanCast())
+                return false;
+
+            var selectedAction = Spells.PvPRoleAction.Masked();
+
+            // However ideally, most role actions would be better integrated into
+            // the rotation logic, such as bravery being combined with chain saw.
+            // This is just a quick and easy way to get role actions working.
+            
+            if (selectedAction == Spells.RoleDervishPvp)
+                return await CastDervish(settings);
+                
+            if (selectedAction == Spells.RoleBraveryPvp)
+                return await CastBravery(settings);
+                
+            if (selectedAction == Spells.RoleEageEyeShot)
+                return await CastEagleEyeShot(settings);
+
+            if (selectedAction == Spells.RoleRampage)
+                return await CastRampage(settings);
+
+            if (selectedAction == Spells.RoleRampart)
+                return await CastRampart(settings);
+
+            if (selectedAction == Spells.RoleFullSwing)
+                return await CastFullSwing(settings);
+
+            if (selectedAction == Spells.RoleHaelan)
+                return await CastHaelan(settings);
+
+            if (selectedAction == Spells.RoleStoneskinII)
+                return await CastStoneskinII(settings);
+
+            if (selectedAction == Spells.RoleDiabrosis)
+                return await CastDiabrosis(settings);
+
+            if (selectedAction == Spells.RoleBloodbath)
+                return await CastBloodbath(settings);
+
+            if (selectedAction == Spells.RoleSwift)
+                return await CastSwift(settings);
+
+            if (selectedAction == Spells.RoleSmite)
+                return await CastSmite(settings);
+
+            if (selectedAction == Spells.RoleComet)
+                return await CastComet(settings);
+
+            if (selectedAction == Spells.RolePhantomDart)
+                return await CastPhantomDart(settings);
+
+            if (selectedAction == Spells.RoleRust)
+                return await CastRust(settings);
+
+            return false;
+        }
+        
+        private static async Task<bool> CastDervish<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 25)
+                return false;
+
+            if (Core.Me.CurrentTarget.CurrentHealthPercent > 60)
+                return false;
+
+            return await Spells.RoleDervishPvp.Cast(Core.Me);
+        }
+        
+        private static async Task<bool> CastBravery<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 25)
+                return false;
+
+            if (Core.Me.CurrentTarget.CurrentHealthPercent > 60)
+                return false;
+
+            return await Spells.RoleBraveryPvp.Cast(Core.Me);
+        }
+        
+        private static async Task<bool> CastEagleEyeShot<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (!Spells.PvPRoleAction.CanCast(Core.Me.CurrentTarget))
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 40)
+                return false;
+
+            return await Spells.PvPRoleAction.Cast(Core.Me.CurrentTarget);
+        }    
+
+        private static async Task<bool> CastRampage<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RoleRampage.Radius)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Combat.Enemies.Count(x => x.Distance(Core.Me.CurrentTarget) < Spells.RoleRampage.Radius) < 3)
+                return false;
+
+            return await Spells.RoleRampage.Cast(Core.Me);
         }
 
+        private static async Task<bool> CastRampart<T>(T settings) where T : JobSettings
+        {
+            if (Core.Me.CurrentHealthPercent > 70)
+                return false;
+
+            return await Spells.RoleRampart.Cast(Core.Me);
+        }
+
+        private static async Task<bool> CastFullSwing<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RoleFullSwing.Range)
+                return false;
+
+            if (!Core.Me.CurrentTarget.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            return await Spells.RoleFullSwing.Cast(Core.Me.CurrentTarget);
+        }
+
+        private static async Task<bool> CastHaelan<T>(T settings) where T : JobSettings
+        {
+            if (!Spells.RoleHaelan.CanCast())
+                return false;
+
+            // Save mana for self-recuperate
+            if (Core.Me.CurrentMana <= 4500)
+                return false;
+
+            var healTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.CurrentHealth > 0 && r.CurrentHealthPercent <= 65);
+
+            if (healTarget == null)
+                return false;
+
+            return await Spells.RoleHaelan.Cast(healTarget);
+        }
+
+        private static async Task<bool> CastStoneskinII<T>(T settings) where T : JobSettings
+        {
+            var target = Group.CastableAlliesWithin15.FirstOrDefault(r => r.CurrentHealth > 0 && r.CurrentHealthPercent <= 80);
+
+            if (target == null)
+            {
+                if (Core.Me.CurrentHealthPercent <= 80)
+                    return await Spells.RoleStoneskinII.Cast(Core.Me);
+                return false;
+            }
+
+            return await Spells.RoleStoneskinII.Cast(Core.Me);
+        }
+
+        private static async Task<bool> CastDiabrosis<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RoleDiabrosis.Range)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Core.Me.CurrentTarget.CurrentHealthPercent <= 35)
+                return await Spells.RoleDiabrosis.Cast(Core.Me.CurrentTarget);
+
+            if (Combat.Enemies.Count(x => x.Distance(Core.Me.CurrentTarget) < Spells.RoleDiabrosis.Radius) < 3)
+                return false;
+
+            return await Spells.RoleDiabrosis.Cast(Core.Me.CurrentTarget);
+        }
+
+        private static async Task<bool> CastBloodbath<T>(T settings) where T : JobSettings
+        {
+            if (Core.Me.CurrentHealthPercent > 85)
+                return false;
+                
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 15)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            return await Spells.RoleBloodbath.Cast(Core.Me);
+        }
+
+        private static async Task<bool> CastSwift<T>(T settings) where T : JobSettings
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > 10)
+                return false;
+
+            if (Core.Me.HasAura(Auras.PvpSprint))
+                return false;
+
+            return await Spells.RoleSwift.Cast(Core.Me);
+        }
+
+        private static async Task<bool> CastSmite<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RoleSmite.Range)
+                return false;
+
+            if (Core.Me.CurrentTarget.CurrentHealthPercent > 30)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            return await Spells.RoleSmite.Cast(Core.Me.CurrentTarget);
+        }
+
+        private static async Task<bool> CastComet<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RoleComet.Range)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Combat.Enemies.Count(x => x.Distance(Core.Me.CurrentTarget) < Spells.RoleComet.Radius) < 4)
+                return false;
+
+            return await Spells.RoleComet.Cast(Core.Me.CurrentTarget);
+        }
+
+        private static async Task<bool> CastPhantomDart<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RolePhantomDart.Range)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            return await Spells.RolePhantomDart.Cast(Core.Me.CurrentTarget);
+        }
+
+        private static async Task<bool> CastRust<T>(T settings) where T : JobSettings
+        {
+            if (!Core.Me.HasTarget)
+                return false;
+
+            if (Core.Me.CurrentTarget.Distance(Core.Me) > Spells.RoleRust.Range)
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (Combat.Enemies.Count(x => x.Distance(Core.Me.CurrentTarget) < Spells.RoleRust.Radius) < 3)
+                return false;
+
+            return await Spells.RoleRust.Cast(Core.Me.CurrentTarget);
+        }
     }
 }

--- a/Magitek/Models/Paladin/PaladinSettings.cs
+++ b/Magitek/Models/Paladin/PaladinSettings.cs
@@ -278,7 +278,31 @@ namespace Magitek.Models.Paladin
 
         [Setting]
         [DefaultValue(true)]
-        public bool Pvp_ShieldBash { get; set; }
+        public bool Pvp_Supplication { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_Sepulchre { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_HolySpirit { get; set; }
+
+        [Setting]
+        [DefaultValue(85.0f)]
+        public float Pvp_HolySpiritHpThreshold { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_Imperator { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_ShieldSmite { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool Pvp_ShieldSmiteOnlyOnGuard { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/Roles/JobSettings.cs
+++ b/Magitek/Models/Roles/JobSettings.cs
@@ -55,6 +55,10 @@ namespace Magitek.Models.Roles
         [Setting]
         [DefaultValue(true)]
         public bool Pvp_SprintWithoutTarget { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_UseRoleActions { get; set; }
         #endregion
     }
 }

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -127,17 +127,22 @@ namespace Magitek.Rotations
             if (await Pvp.BladeofFaithPvp()) return true;
             if (await Pvp.HolySheltronPvp()) return true;
 
+            if (await Pvp.ShieldSmitePvp()) return true;
+            if (await Pvp.HolySpiritPvp()) return true;
+
             if (!CommonPvp.GuardCheck(PaladinSettings.Instance))
             {
+                if (await Pvp.ImperatorPvp()) return true;
                 if (await Pvp.IntervenePvp()) return true;
-                if (await Pvp.AtonementPvp()) return true;
-                if (await Pvp.ShieldBashPvp()) return true;
-                if (await Pvp.ConfiteorPvp()) return true;
             }
+            
+            if (await Pvp.AtonementPvp()) return true;
+            if (await Pvp.SupplicationPvp()) return true;
+            if (await Pvp.SepulchrePvp()) return true;
+            if (await Pvp.ConfiteorPvp()) return true;
 
             if (await Pvp.RoyalAuthorityPvp()) return true;
             if (await Pvp.RiotBladePvp()) return true;
-
             return (await Pvp.FastBladePvp());
         }
     }

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -547,6 +547,7 @@ namespace Magitek.Utilities
             PvpOrogeny = 3256,
             PvpSubtractivePalette = 4102,
             PvpStarstruck = 4118,
+            PvpQuickSketch = 4324,
             PvpPomSketch = 4124,
             PvpWingSketch = 4125,
             PvpClawSketch = 4126,

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -564,8 +564,11 @@ namespace Magitek.Utilities
             PvpWildfire = 1323,
             PvpWildfireBuff = 2018,
             PvpChainSaw = 3154,
-            PvpSacredSight = 4326
-            ;
+            PvpSacredSight = 4326,
+            PvpAtonementReady = 2015,
+            PvpSupplicationReady = 4281,
+            PvpSepulchreReady = 4282,
+            PvpConfiteorReady = 3028;
 
 
         #endregion

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -135,6 +135,14 @@ namespace Magitek.Utilities
             if (output && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo($"[AOE Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name}");
 
+            if (!output && enemyLogic.AoeLockOns != null)
+            {
+                output = Core.Me.VfxContainer.LockOns.Any(lockOn => enemyLogic.AoeLockOns.Contains(lockOn.Id));
+
+                if (output && DebugSettings.Instance.DebugFightLogic)
+                    Logger.WriteInfo($"[AOE Lock On Detected] {encounter.Name} {enemy.Name} lockon {Core.Me.VfxContainer.LockOns.FirstOrDefault(l => enemyLogic.AoeLockOns.Contains(l.Id))}");
+            }
+
             return output;
         }
 
@@ -196,7 +204,7 @@ namespace Magitek.Utilities
             {
                 var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
-                return (enemyLogic?.Aoes != null || enemyLogic?.BigAoes != null);
+                return (enemyLogic?.Aoes != null || enemyLogic?.BigAoes != null || enemyLogic?.AoeLockOns != null);
             }
 
             return false;
@@ -308,6 +316,10 @@ namespace Magitek.Utilities
                             if (element.BigAoes != null)
                                 Debug.Instance.FightLogicData +=
                                     $"\tBig Aoes:\n{string.Join("", element.BigAoes.Select(baoe => $"\t\t{DataManager.GetSpellData(baoe).Name} ({baoe})\n"))}";
+
+                            if (element.AoeLockOns != null)
+                                Debug.Instance.FightLogicData +=
+                                    $"\tAoe Lock Ons:\n{string.Join("", element.AoeLockOns.Select(aoeLockOn => $"\t\t({aoeLockOn})\n"))}";
 
                             Debug.Instance.FightLogicData += $"\n";
                         });
@@ -6617,6 +6629,53 @@ namespace Magitek.Utilities
                 }
             },
 
+            new Encounter {
+                ZoneId = 1266,
+                Name = "The Underkeep",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 13753,
+                        Name = "Gargant",
+                        TankBusters = new List<uint> {
+                            42548, // Trap Jaws
+                        },
+                        Aoes = new List<uint> {
+                            42547, // Chilling Chirp
+                        },
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 13757,
+                        Name = "Soldier S0",
+                        TankBusters = new List<uint> {
+                            43136, // Thunderous Slash
+                        },
+                        Aoes = new List<uint> {
+                            42579, // Field of Scorn
+                            42574, // Static Force
+                            42570, // Electric Excess
+                        },
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 13749,
+                        Name = "Valia Pira",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            42525, // Entropic Sphere
+                            42519, // Electric Field
+                            42738, // Neutralize Front Lines
+                            42540, // Deterrent Pulse
+                        },
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                }
+            },
+
             #endregion           
 
             #region Dawntrail: Extreme Trials
@@ -6692,6 +6751,30 @@ namespace Magitek.Utilities
                     }
                 }
             },
+
+            new Encounter {
+                ZoneId = 1270,
+                Name = "Recollection",
+                Expansion = FfxivExpansion.Dawntrail,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 13861,
+                        Name = "Zelenia",
+                        TankBusters = new List<uint> {
+                            43128, // Specter of the Lost
+                        },
+                        Aoes = new List<uint> {
+                            43056, // Shock
+                            43086, // Stock Break
+                            43070, // Valorous Ascension
+                            43127, // Thorned Catharsis
+                        },
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                }
+            },
+
             #endregion
 
             #region Dawntrail: Normal Raids
@@ -6901,6 +6984,7 @@ namespace Magitek.Utilities
             internal List<uint> Aoes { get; set; }
             internal List<uint> BigAoes { get; set; }
             internal List<uint> Knockbacks { get; set; }
+            internal List<uint> AoeLockOns { get; set; }
         }
 
         private class Encounter

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -1181,6 +1181,22 @@ namespace Magitek.Utilities
         public static readonly SpellData Purify = DataManager.GetSpellData(29056);
         public static readonly SpellData Guard = DataManager.GetSpellData(29054);
         public static readonly SpellData SprintPvp = DataManager.GetSpellData(29057);
+        public static readonly SpellData PvPRoleAction = DataManager.GetSpellData(43259);
+        public static readonly SpellData RoleDervishPvp = DataManager.GetSpellData(43249);
+        public static readonly SpellData RoleBraveryPvp = DataManager.GetSpellData(43250);
+        public static readonly SpellData RoleEageEyeShot = DataManager.GetSpellData(43251);
+        public static readonly SpellData RoleRampage = DataManager.GetSpellData(43243);
+        public static readonly SpellData RoleRampart = DataManager.GetSpellData(43244);
+        public static readonly SpellData RoleFullSwing = DataManager.GetSpellData(43245);
+        public static readonly SpellData RoleHaelan = DataManager.GetSpellData(43255);
+        public static readonly SpellData RoleStoneskinII = DataManager.GetSpellData(43256);
+        public static readonly SpellData RoleDiabrosis = DataManager.GetSpellData(43257);
+        public static readonly SpellData RoleBloodbath = DataManager.GetSpellData(43246);
+        public static readonly SpellData RoleSwift = DataManager.GetSpellData(43247);
+        public static readonly SpellData RoleSmite = DataManager.GetSpellData(43248);
+        public static readonly SpellData RoleComet = DataManager.GetSpellData(43252);
+        public static readonly SpellData RolePhantomDart = DataManager.GetSpellData(43291);
+        public static readonly SpellData RoleRust = DataManager.GetSpellData(43254);
 
         //PCT
         public static readonly SpellData PaintRGBPvp = DataManager.GetSpellData(39191); // fire in red base
@@ -1499,15 +1515,19 @@ namespace Magitek.Utilities
         public static readonly SpellData RiotBladePvp = DataManager.GetSpellData(29059);
         public static readonly SpellData RoyalAuthorityPvp = DataManager.GetSpellData(29060);
         public static readonly SpellData AtonementPvp = DataManager.GetSpellData(29061);
-        public static readonly SpellData ShieldBashPvp = DataManager.GetSpellData(29064);
+        public static readonly SpellData HolySpiritPvp = DataManager.GetSpellData(29062);
+        public static readonly SpellData ShieldSmitePvp = DataManager.GetSpellData(41430);
         public static readonly SpellData IntervenePvp = DataManager.GetSpellData(29065);
         public static readonly SpellData GuardianPvp = DataManager.GetSpellData(29066);
         public static readonly SpellData HolySheltronPvp = DataManager.GetSpellData(29067);
         public static readonly SpellData PhalanxPvp = DataManager.GetSpellData(29069);
-        public static readonly SpellData ConfiteorPvp = DataManager.GetSpellData(29070);
+        public static readonly SpellData ConfiteorPvp = DataManager.GetSpellData(42194);
         public static readonly SpellData BladeofFaithPvp = DataManager.GetSpellData(29071);
         public static readonly SpellData BladeofTruthPvp = DataManager.GetSpellData(29072);
         public static readonly SpellData BladeofValorPvp = DataManager.GetSpellData(29073);
+        public static readonly SpellData SupplicationPvp = DataManager.GetSpellData(41428);
+        public static readonly SpellData SepulchrePvp = DataManager.GetSpellData(41429);
+        public static readonly SpellData ImperatorPvp = DataManager.GetSpellData(41431);
 
         #endregion
 

--- a/Magitek/Views/UserControls/Paladin/Pvp.xaml
+++ b/Magitek/Views/UserControls/Paladin/Pvp.xaml
@@ -68,7 +68,23 @@
                     <CheckBox Content="Confiteor" IsChecked="{Binding PaladinSettings.Pvp_Confiteor, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="Shield Bash                      " IsChecked="{Binding PaladinSettings.Pvp_ShieldBash, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Supplication                      " IsChecked="{Binding PaladinSettings.Pvp_Supplication, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Sepulchre" IsChecked="{Binding PaladinSettings.Pvp_Sepulchre, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Imperator                      " IsChecked="{Binding PaladinSettings.Pvp_Imperator, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Holy Spirit                      " IsChecked="{Binding PaladinSettings.Pvp_HolySpirit, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="Below" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding PaladinSettings.Pvp_HolySpiritHpThreshold, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="% HP" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="Shield Smite                      " IsChecked="{Binding PaladinSettings.Pvp_ShieldSmite, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Content="Only on Guard" IsChecked="{Binding PaladinSettings.Pvp_ShieldSmiteOnlyOnGuard, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="Intervene" IsChecked="{Binding PaladinSettings.Pvp_Intervene, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">


### PR DESCRIPTION
FightLogic - Added Recollection and The Underkeep dungeons

PVP ALL - All Role Actions are now supported. You can change role action at any time and routine will use the selected action. PCT PVP - Added QuickSketch
PLD PVP - Updated to 7.2