### PR TITLE
StunTracker saves seen stuns locally. List of Boss names will also be pulled from configured FightLogic.

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -413,7 +413,8 @@ namespace Magitek.Extensions
             return unit != null && (unit.Name.Contains("Raven")
                                 || unit.Name.Contains("Falcon")
                                 || unit.Name.Contains("Striking Dummy")
-                                || unit.Name.Contains("Icebound Tomelith"));
+                                || unit.Name.Contains("Icebound Tomelith")
+                                || unit.Name.Contains("Interceptor"));
         }
 
         public static float GetResurrectionWeight(this GameObject c)

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -282,6 +282,7 @@ namespace Magitek
                 InterruptsAndStuns.Instance.Save();
                 BaseSettings.Instance.Save();
                 TogglesViewModel.Instance.SaveToggles();
+                StunTracker.Save();
                 _saveFormTime = time.AddSeconds(60);
             }
 
@@ -297,6 +298,7 @@ namespace Magitek
             BaseSettings.Instance.Save();
             InterruptsAndStuns.Instance.Save();
             TogglesViewModel.Instance.SaveToggles();
+            StunTracker.Save();
 
             var hotkeys = HotkeyManager.RegisteredHotkeys.Select(r => r.Name).Where(r => r.Contains("Magitek"));
 

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -334,7 +334,7 @@ namespace Magitek.Utilities
             }
         }
 
-        private static readonly List<Encounter> Encounters = new List<Encounter> {
+        internal static readonly List<Encounter> Encounters = new List<Encounter> {
             #region A Realm Reborn: Normal Raids
 
             new Encounter {
@@ -7083,7 +7083,7 @@ namespace Magitek.Utilities
             internal List<uint> AoeLockOns { get; set; }
         }
 
-        private class Encounter
+        internal class Encounter
         {
             internal ushort ZoneId { get; set; }
             internal string Name { get; set; }
@@ -7091,7 +7091,7 @@ namespace Magitek.Utilities
             internal List<Enemy> Enemies { get; set; }
         }
 
-        private static class ZoneId
+        internal static class ZoneId
         {
             public const ushort
                     ABloodyReunion = 560,

--- a/Magitek/Utilities/StunTracker.cs
+++ b/Magitek/Utilities/StunTracker.cs
@@ -40,8 +40,6 @@ namespace Magitek.Utilities
         private const LogLevel mLogLevelToShow = LogLevel.Useful;
 
         private const double MaxTimeForStunToTakeEffectMs = 1500;
-        private const int SaveIntervalMs = 300000; // Save every 5 minutes
-        private static DateTime mLastSaveTime = DateTime.MinValue;
         private static bool mListsModified = false;
 
         private static HashSet<uint> mUnstunnableEnemyIds = new HashSet<uint>();
@@ -63,11 +61,13 @@ namespace Magitek.Utilities
             Log(LogLevel.Useful, $"Loaded {mUnstunnableEnemyIds.Count} unstunnable and {mStunnableEnemyIds.Count} stunnable enemy IDs from persistence");
         }
 
-        private static void SavePersistedData()
+        public static void Save()
         {
-            StunTrackerPersistence.SaveData(mUnstunnableEnemyIds, mStunnableEnemyIds);
-            mLastSaveTime = DateTime.UtcNow;
-            mListsModified = false;
+            if (mListsModified)
+            {
+                StunTrackerPersistence.SaveData(mUnstunnableEnemyIds, mStunnableEnemyIds);
+                mListsModified = false;
+            }
         }
 
         //This must be called often to make sure we don't miss stuns
@@ -151,12 +151,6 @@ namespace Magitek.Utilities
                         mListsModified = true;
                     }
                 }
-            }
-
-            // Periodically save the data only if the lists have been modified
-            if (mListsModified && (DateTime.UtcNow - mLastSaveTime).TotalMilliseconds > SaveIntervalMs)
-            {
-                SavePersistedData();
             }
         }
 

--- a/Magitek/Utilities/StunTracker.cs
+++ b/Magitek/Utilities/StunTracker.cs
@@ -26,10 +26,8 @@ namespace Magitek.Utilities
         //
         //In order benefit from these services, combat routines can call IsStunnable() before attempting to stun an enemy.
         //
-        //Note that this code doesn't make use of permanent storage, so each time it's loaded, it will need to discover
-        //afresh what enemies can and cannot be stunned. This comes at the cost of a single stun attempt per enemy type,
-        //after which, if the enemy is unstunnable, it won't try again. Note also that this has no effect on interrupts,
-        //which will still work on interruptible spells cast by unstunnable enemies.
+        //Note that this code now uses persistent storage, so it will remember which enemies can and cannot be stunned
+        //between sessions. This eliminates the need to rediscover this information each time it's loaded.
 
         //TODO: Enable non-tank classes with stuns to use this. Maybe refactor Tank.Interrupt into a general routine.
 
@@ -42,11 +40,35 @@ namespace Magitek.Utilities
         private const LogLevel mLogLevelToShow = LogLevel.Useful;
 
         private const double MaxTimeForStunToTakeEffectMs = 1500;
+        private const int SaveIntervalMs = 300000; // Save every 5 minutes
+        private static DateTime mLastSaveTime = DateTime.MinValue;
+        private static bool mListsModified = false;
 
         private static HashSet<uint> mUnstunnableEnemyIds = new HashSet<uint>();
         private static HashSet<uint> mStunnableEnemyIds = new HashSet<uint>();
         private static Dictionary<BattleCharacter, StunData> mAttemptedStunEnemies = new Dictionary<BattleCharacter, StunData>();
         private static Dictionary<BattleCharacter, StunData> mStunnableEnemies = new Dictionary<BattleCharacter, StunData>();
+
+        // Static constructor to load persisted data when the class is first accessed
+        static StunTracker()
+        {
+            LoadPersistedData();
+        }
+
+        private static void LoadPersistedData()
+        {
+            var data = StunTrackerPersistence.LoadData();
+            mUnstunnableEnemyIds = data.UnstunnableEnemyIds;
+            mStunnableEnemyIds = data.StunnableEnemyIds;
+            Log(LogLevel.Useful, $"Loaded {mUnstunnableEnemyIds.Count} unstunnable and {mStunnableEnemyIds.Count} stunnable enemy IDs from persistence");
+        }
+
+        private static void SavePersistedData()
+        {
+            StunTrackerPersistence.SaveData(mUnstunnableEnemyIds, mStunnableEnemyIds);
+            mLastSaveTime = DateTime.UtcNow;
+            mListsModified = false;
+        }
 
         //This must be called often to make sure we don't miss stuns
         public static void Update(List<BattleCharacter> enemies)
@@ -74,6 +96,7 @@ namespace Magitek.Utilities
                     mUnstunnableEnemyIds.Remove(bc.NpcId);
                     mStunnableEnemies.Add(bc, new StunData(stun.TimespanLeft, bc));
                     Log(LogLevel.Debug, $"Added to stun list: {bc.EnglishName}");
+                    mListsModified = true;
                 }
             }
 
@@ -125,8 +148,15 @@ namespace Magitek.Utilities
                     {
                         Log(LogLevel.Useful, $"{bc.EnglishName.ToUpper()} NOT STUNNABLE");
                         mUnstunnableEnemyIds.Add(bc.NpcId);
+                        mListsModified = true;
                     }
                 }
+            }
+
+            // Periodically save the data only if the lists have been modified
+            if (mListsModified && (DateTime.UtcNow - mLastSaveTime).TotalMilliseconds > SaveIntervalMs)
+            {
+                SavePersistedData();
             }
         }
 

--- a/Magitek/Utilities/StunTrackerPersistence.cs
+++ b/Magitek/Utilities/StunTrackerPersistence.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using ff14bot.Helpers;
+
+namespace Magitek.Utilities
+{
+    public class StunTrackerPersistence
+    {
+        private static readonly string PersistenceFilePath = Path.Combine(JsonSettings.CharacterSettingsDirectory, "Magitek", "StunTrackerData.json");
+
+        public class StunTrackerData
+        {
+            public HashSet<uint> UnstunnableEnemyIds { get; set; } = new HashSet<uint>();
+            public HashSet<uint> StunnableEnemyIds { get; set; } = new HashSet<uint>();
+        }
+
+        public static void SaveData(HashSet<uint> unstunnableEnemyIds, HashSet<uint> stunnableEnemyIds)
+        {
+            try
+            {
+                var data = new StunTrackerData
+                {
+                    UnstunnableEnemyIds = unstunnableEnemyIds,
+                    StunnableEnemyIds = stunnableEnemyIds
+                };
+
+                string directoryPath = Path.GetDirectoryName(PersistenceFilePath);
+                if (!Directory.Exists(directoryPath))
+                {
+                    Directory.CreateDirectory(directoryPath);
+                }
+
+                string json = JsonConvert.SerializeObject(data, Formatting.Indented);
+                File.WriteAllText(PersistenceFilePath, json);
+
+                Logger.WriteInfo("[StunTracker] Persistence data saved successfully");
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteInfo($"[StunTracker] Failed to save persistence data: {ex.Message}");
+            }
+        }
+
+        public static StunTrackerData LoadData()
+        {
+            try
+            {
+                if (!File.Exists(PersistenceFilePath))
+                {
+                    Logger.WriteInfo("[StunTracker] No persistence data found, starting fresh");
+                    return new StunTrackerData();
+                }
+
+                string json = File.ReadAllText(PersistenceFilePath);
+                var data = JsonConvert.DeserializeObject<StunTrackerData>(json);
+
+                Logger.WriteInfo($"[StunTracker] Loaded {data.UnstunnableEnemyIds.Count} unstunnable and {data.StunnableEnemyIds.Count} stunnable enemy IDs");
+                return data;
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteInfo($"[StunTracker] Failed to load persistence data: {ex.Message}");
+                return new StunTrackerData();
+            }
+        }
+    }
+}

--- a/Magitek/Utilities/XivDataHelper.cs
+++ b/Magitek/Utilities/XivDataHelper.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Linq;
 
 namespace Magitek.Utilities
 {
@@ -63,6 +64,11 @@ namespace Magitek.Utilities
 
             BossNames = new HashSet<string>(BossDictionary.Values);
             BossNames.UnionWith(JsonConvert.DeserializeObject<List<string>>(bossesNames));
+
+            FightLogic.Encounters.SelectMany(encounter => encounter.Enemies)
+                .Where(enemy => enemy.Name != null)
+                .ToList()
+                .ForEach(enemy => BossNames.Add(enemy.Name));
         }
 
 


### PR DESCRIPTION
Update StunTracker to persist the stuns locally.
List of Boss names will also be pulled from configured FightLogic.