### PR TITLE
Reprisal update, settings window position reset

### DIFF
--- a/Magitek/Extensions/PlayerExtensions.cs
+++ b/Magitek/Extensions/PlayerExtensions.cs
@@ -38,6 +38,20 @@ namespace Magitek.Extensions
             return WorldManager.ZoneId == 1252;
         }
 
+        /// <summary>
+        /// Checks if the player is in a sanctuary (game's sanctuary status) or in a zone that should be treated as a sanctuary
+        /// to prevent instant casting of buffs and other actions.
+        /// </summary>
+        public static bool InSanctuaryOrSafeZone(this LocalPlayer player)
+        {
+            // Check the game's built-in sanctuary status first
+            if (WorldManager.InSanctuary)
+                return true;
+
+            // Check additional zones that should be treated as sanctuaries
+            return CustomSanctuaryZones.Contains(WorldManager.ZoneId);
+        }
+
         private static readonly HashSet<ushort> PvpMaps = new HashSet<ushort>()
         {
             149,
@@ -75,6 +89,17 @@ namespace Magitek.Extensions
             551,
             552,
             554
+        };
+
+        /// <summary>
+        /// Zone IDs that should be treated as sanctuaries even if the game doesn't mark them as such.
+        /// Add zone IDs here to prevent instant casting of buffs and other actions.
+        /// </summary>
+        private static readonly HashSet<ushort> CustomSanctuaryZones = new HashSet<ushort>()
+        {
+            // Add zone IDs here that should be treated as sanctuaries
+            1269, // Phantom Village
+            1237, // Sinus Adorum
         };
 
         public static int EnemiesInCone(this LocalPlayer player, float maxdistance)

--- a/Magitek/Logic/DarkKnight/Defensive.cs
+++ b/Magitek/Logic/DarkKnight/Defensive.cs
@@ -170,6 +170,9 @@ namespace Magitek.Logic.DarkKnight
             if (!DarkKnightSettings.Instance.UseReprisal)
                 return false;
 
+            if (Core.Me.CurrentHealthPercent > DarkKnightSettings.Instance.ReprisalHealthPercent)
+                return false;
+
             return await Spells.Reprisal.Cast(Core.Me.CurrentTarget);
         }
 

--- a/Magitek/Logic/Gunbreaker/Defensive.cs
+++ b/Magitek/Logic/Gunbreaker/Defensive.cs
@@ -61,7 +61,7 @@ namespace Magitek.Logic.Gunbreaker
             if (!GunbreakerSettings.Instance.UseReprisal)
                 return false;
 
-            if (!UseDefensives())
+            if (!UseDefensives() && Combat.Enemies.Count < 3)
                 return false;
 
             if (Core.Me.CurrentHealthPercent > GunbreakerSettings.Instance.ReprisalHealthPercent)

--- a/Magitek/Logic/Paladin/Defensive.cs
+++ b/Magitek/Logic/Paladin/Defensive.cs
@@ -72,7 +72,7 @@ namespace Magitek.Logic.Paladin
             if (!PaladinSettings.Instance.UseReprisal)
                 return false;
 
-            if (!UseDefensives())
+            if (!UseDefensives() && Combat.Enemies.Count < 3)
                 return false;
 
             if (Core.Me.CurrentHealthPercent > PaladinSettings.Instance.ReprisalHealthPercent)

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -107,7 +107,6 @@ namespace Magitek.Logic.Roles
 
     internal class OccultCrescent
     {
-        // 1500000 25 minutes
         private static readonly uint KnowledgeCrystal = 2007457;
 
         // Known Knowledge Crystal locations that never change

--- a/Magitek/Logic/Warrior/Defensive.cs
+++ b/Magitek/Logic/Warrior/Defensive.cs
@@ -1,5 +1,6 @@
 ﻿using ff14bot;
 using Magitek.Extensions;
+using Magitek.Gambits.Conditions;
 using Magitek.Logic.Roles;
 using Magitek.Models.Warrior;
 using Magitek.Utilities;
@@ -49,7 +50,7 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UseReprisal)
                 return false;
 
-            if (!UseDefensives())
+            if (!UseDefensives() && Combat.Enemies.Count < 3)
                 return false;
 
             if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.ReprisalHealthPercent)

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -352,6 +352,9 @@ namespace Magitek
             if (Form.IsVisible)
                 return;
 
+            // Validate window position before showing
+            Models.Account.BaseSettings.ValidateSettingsWindowPosition(1000, 700);
+
             Form.Show();
 
             OverlayManager.StartMainOverlay();

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -17,7 +17,7 @@ namespace Magitek.Rotations
             if (Core.Me.CurrentHealthPercent > 70 || Core.Me.ClassLevel < 4)
                 return false;
 
-            if (WorldManager.InSanctuary)
+            if (Globals.InSanctuaryOrSafeZone)
                 return false;
 
             return false;

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -16,7 +16,7 @@ namespace Magitek.Rotations
             if (Core.Me.CurrentHealthPercent > 70 || Core.Me.ClassLevel < 4)
                 return false;
 
-            if (WorldManager.InSanctuary)
+            if (Globals.InSanctuaryOrSafeZone)
                 return false;
 
             return SummonerSettings.Instance.Physick ? await Spells.SmnPhysick.Heal(Core.Me) : false;

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -2545,41 +2545,39 @@ namespace Magitek.Utilities
                 Expansion = FfxivExpansion.Shadowbringers,
                 Enemies = new List<Enemy> {
                     new Enemy {
-                        Id = 8445,
-                        Name = "Forgiven Dissonance",
-                        TankBusters = new List<uint>() {
-                            15812 //Pillory
-                        },
-                        SharedTankBusters = null,
-                        Aoes = new List<uint>() {
-                            15813 //Path of Light
-                        },
-                        BigAoes = null
-                    },
-                    new Enemy {
                         Id = 8300,
-                        Name = "Tesleen, The Forgiven",
-                        TankBusters = new List<uint>() {
-                            15823 //Tickler
+                        Name = "Tesleen, the Forgiven",
+                        TankBusters = new List<uint> {
+                            15823, // the Tickler
                         },
+                        Aoes = new List<uint> {
+                            15824, // Scold's Bridle
+                        },
+                        AoeLockOns = new List<uint> {
+                            79,
+                            62,
+                        },
+                        Knockbacks = null,
                         SharedTankBusters = null,
-                        Aoes = new List<uint>() {
-                            15824 //Bridle
-                        },
                         BigAoes = null
                     },
                     new Enemy {
                         Id = 8301,
                         Name = "Philia",
-                        TankBusters = new List<uint>() {
-                            15831 //Head Crusher
+                        TankBusters = new List<uint> {
+                            15831, // Head Crusher
                         },
+                        Aoes = new List<uint> {
+                            15832, // Scavenger's Daughter
+                            15842, // Taphephobia
+                            17232, // Into the Light
+                            16777, // Pendulum
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
                         SharedTankBusters = null,
-                        Aoes = new List<uint>() {
-                            15832 //Scavenger
-                        },
                         BigAoes = null
-                    }
+                    },
                 }
             },
             new Encounter {

--- a/Magitek/Utilities/Globals.cs
+++ b/Magitek/Utilities/Globals.cs
@@ -18,6 +18,7 @@ namespace Magitek.Utilities
         public static bool InGcInstance => RaptureAtkUnitManager.Controls.Any(r => r.Name == "GcArmyOrder");
         public static bool OnPvpMap => Core.Me.OnPvpMap();
         public static bool InActiveDuty => DutyManager.InInstance && Duty.State() == Duty.States.InProgress;
+        public static bool InSanctuaryOrSafeZone => Core.Me.InSanctuaryOrSafeZone();
         public static GameObject HealTarget;
         // the game has a base animation lock of 610ms for most weaponskills & spells.
         // Some weaved abilities that are instant have a shorter animation lock of ~360-410ms

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -151,7 +151,7 @@ namespace Magitek.Utilities.Managers
             await Casting.CheckForSuccessfulCast();
             SpellQueueLogic.SpellQueue.Clear();
 
-            if (WorldManager.InSanctuary)
+            if (Globals.InSanctuaryOrSafeZone)
                 return false;
 
             if (Globals.OnPvpMap)
@@ -174,7 +174,7 @@ namespace Magitek.Utilities.Managers
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, (Core.Me.IsRanged() ? 20 : 0) + Core.Me.CurrentTarget.CombatReach);
             }
 
-            if (WorldManager.InSanctuary)
+            if (Globals.InSanctuaryOrSafeZone)
                 return false;
 
             if (Globals.OnPvpMap)
@@ -230,7 +230,7 @@ namespace Magitek.Utilities.Managers
             if (await OccultCrescent.Execute())
                 return true;
 
-            if (WorldManager.InSanctuary)
+            if (Globals.InSanctuaryOrSafeZone)
                 return false;
 
             return await ExecuteRotationMethod(RotationManager.CurrentRotation, "Heal");

--- a/Magitek/Utilities/Overlays/MainOverlayUiComponent.cs
+++ b/Magitek/Utilities/Overlays/MainOverlayUiComponent.cs
@@ -25,6 +25,9 @@ namespace Magitek.Utilities.Overlays
                 {
                     Application.Current.Dispatcher.Invoke(delegate
                     {
+                        // Validate window position before showing
+                        Models.Account.BaseSettings.ValidateSettingsWindowPosition(1000, 700);
+
                         if (!Magitek.Form.IsVisible)
                             Magitek.Form.Show();
 

--- a/Magitek/ViewModels/MainOverlayViewModel.cs
+++ b/Magitek/ViewModels/MainOverlayViewModel.cs
@@ -20,7 +20,12 @@ namespace Magitek.ViewModels
 
         public ICommand OpenMainSettingsForm => new DelegateCommand(() =>
         {
-            Application.Current.Dispatcher.Invoke(delegate { Magitek.Form.Show(); });
+            Application.Current.Dispatcher.Invoke(delegate
+            {
+                // Validate window position before showing
+                Models.Account.BaseSettings.ValidateSettingsWindowPosition(1000, 700);
+                Magitek.Form.Show();
+            });
         });
 
         public ICommand EnablePvpOverlay => new DelegateCommand(() =>

--- a/Magitek/Views/SettingsWindow.xaml.cs
+++ b/Magitek/Views/SettingsWindow.xaml.cs
@@ -138,7 +138,8 @@ namespace Magitek.Views
 
         private void SettingsWindow_OnLoaded(object sender, RoutedEventArgs e)
         {
-
+            // Removed validation from here to prevent binding feedback loops
+            // Validation is handled before showing the window instead
         }
 
         private void Close(object sender, RoutedEventArgs e)


### PR DESCRIPTION
* Use repisal when more than 3 enemies
* Consider phantom village and cosmic moon base as sanctuaries
* Update holminster switch fightlogic
* Reset window positions if the settings window is off the screen for some reason. 