### PR TITLE
Add Phantom Job Auto-Switching for Knowledge Crystal Buffs

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2822,6 +2822,9 @@ namespace Magitek.Logic.Roles
             if (!OccultCrescentSettings.Instance.UseRingingRespite)
                 return false;
 
+            if (!Core.Me.InCombat)
+                return false;
+
             if (!OCSpells.RingingRespite.CanCast())
                 return false;
 

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2493,7 +2493,7 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.HasAura(OCAuras.PredictionOfStarfall))
                 return false;
 
-            if (Core.Me.CurrentHealthPercent > OccultCrescentSettings.Instance.StarfallHealthPercent)
+            if (Core.Me.CurrentHealthPercent < OccultCrescentSettings.Instance.StarfallHealthPercent)
                 return false;
 
             // Cast on self - Starfall affects self and nearby enemies

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -155,7 +155,7 @@ namespace Magitek.Logic.Roles
 
         // Throttling for non-party resurrection checks
         private static DateTime _lastNonPartyResCheck = DateTime.MinValue;
-        private static readonly TimeSpan NonPartyResCheckInterval = TimeSpan.FromSeconds(2.0);
+        private static readonly TimeSpan NonPartyResCheckInterval = TimeSpan.FromSeconds(1.0);
 
         // Cannoneer alternating cannon tracking
         private static bool _lastUsedShockCannon = false;
@@ -205,7 +205,7 @@ namespace Magitek.Logic.Roles
         /// </summary>
         /// <param name="maxDistance">Maximum distance to consider "near" (default 5)</param>
         /// <returns>True if a Knowledge Crystal is found within range at a valid location</returns>
-        private static bool IsNearKnowledgeCrystal(float maxDistance = 5.0f)
+        public static bool IsNearKnowledgeCrystal(float maxDistance = 5.0f)
         {
             var now = DateTime.Now;
 
@@ -295,6 +295,10 @@ namespace Magitek.Logic.Roles
             if (phantomJob == PhantomJob.None)
                 return false;
 
+            // First, try automatic phantom job switching for knowledge crystal buffs
+            if (await PhantomJobSwitcher.AutoSwitchForKnowledgeCrystalBuffs())
+                return true;
+
             // Execute phantom job specific logic
             var phantomJobResult = phantomJob switch
             {
@@ -345,8 +349,12 @@ namespace Magitek.Logic.Roles
                 return false;
             _lastNonPartyResCheck = now;
 
-            // Only use excess mana for non-party resurrections
-            if (Core.Me.CurrentManaPercent < OccultCrescentSettings.Instance.ReviveNonPartyMinimumManaPercent)
+            // Check if we're Phantom Chemist (free resurrection) or need MP check for regular jobs
+            var phantomJob = GetCurrentPhantomJob();
+            bool isPhantomChemist = phantomJob == PhantomJob.Chemist;
+
+            // Only check MP for non-Chemist resurrections (Chemist Revive doesn't cost MP)
+            if (!isPhantomChemist && Core.Me.CurrentManaPercent < OccultCrescentSettings.Instance.ReviveNonPartyMinimumManaPercent)
                 return false;
 
             // Check combat preferences
@@ -478,7 +486,7 @@ namespace Magitek.Logic.Roles
         /// Determine the current phantom job based on player auras
         /// </summary>
         /// <returns>The current phantom job, or None if no phantom job is active</returns>
-        private static PhantomJob GetCurrentPhantomJob()
+        public static PhantomJob GetCurrentPhantomJob()
         {
             foreach (var kvp in PhantomJobAuras)
             {
@@ -1146,9 +1154,8 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
-        /// Cast Romeo's Ballad - interrupt ability
-        /// Out of combat: cast if NpcId 2007457 is in range
-        /// In combat: cast only if a monster is casting (to interrupt)
+        /// Cast Romeo's Ballad - interrupt ability (combat only)
+        /// Knowledge crystal casting is now handled by PhantomJobSwitcher
         /// </summary>
         /// <returns>True if spell was cast, false otherwise</returns>
         private static async Task<bool> RomeosBallad()
@@ -1156,32 +1163,23 @@ namespace Magitek.Logic.Roles
             if (!OccultCrescentSettings.Instance.UseRomeosBallad)
                 return false;
 
+            // Only used in combat for interrupts, knowledge crystal usage handled by PhantomJobSwitcher
+            if (!Core.Me.InCombat)
+                return false;
+
             if (!OCSpells.RomeosBallad.CanCast())
                 return false;
 
-            if (!Core.Me.InCombat)
-            {
-                if (!OccultCrescentSettings.Instance.RomeosBallad_KnowledgeCrystal)
-                    return false;
-
-                if (Core.Me.HasAura(OCAuras.RomeosBallad, msLeft: (int)(OccultCrescentSettings.Instance.PartyBuffRefreshMinutes * 60 * 1000)))
-                    return false;
-
-                if (IsNearKnowledgeCrystal())
-                    return await OCSpells.RomeosBallad.Cast(Core.Me);
-            }
-            // else if (OccultCrescentSettings.Instance.RomeosBallad_InterruptEnemies)
-            // {
-            //     // In combat: only cast if a monster is casting (to interrupt)
-            //     var castingEnemy = Combat.Enemies.FirstOrDefault(enemy =>
-            //         enemy.IsCasting &&
-            //         enemy.ValidAttackUnit() &&
-            //         enemy.InLineOfSight() &&
-            //         enemy.WithinSpellRange(OCSpells.RomeosBallad.Radius));
-
-            //     if (castingEnemy != null)
-            //         return await OCSpells.RomeosBallad.Cast(castingEnemy);
-            // }
+            // TODO: Implement interrupt logic if needed
+            // In combat: only cast if a monster is casting (to interrupt)
+            // var castingEnemy = Combat.Enemies.FirstOrDefault(enemy =>
+            //     enemy.IsCasting &&
+            //     enemy.ValidAttackUnit() &&
+            //     enemy.InLineOfSight() &&
+            //     enemy.WithinSpellRange(OCSpells.RomeosBallad.Radius));
+            //
+            // if (castingEnemy != null)
+            //     return await OCSpells.RomeosBallad.Cast(castingEnemy);
 
             return false;
         }
@@ -1210,8 +1208,8 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
-        /// Cast Pray - regen effect that lasts for a duration
-        /// When cast near Knowledge Crystal, provides party buff (Enduring Fortitude)
+        /// Cast Pray - regen effect (combat only)
+        /// Knowledge crystal party buff casting is now handled by PhantomJobSwitcher
         /// </summary>
         /// <returns>True if spell was cast, false otherwise</returns>
         private static async Task<bool> Pray()
@@ -1219,34 +1217,21 @@ namespace Magitek.Logic.Roles
             if (!OccultCrescentSettings.Instance.UsePray)
                 return false;
 
+            // Only used in combat for regen, knowledge crystal party buff handled by PhantomJobSwitcher
+            if (!Core.Me.InCombat)
+                return false;
+
             if (!OCSpells.Pray.CanCast())
                 return false;
 
-            if (!Core.Me.InCombat)
-            {
-                // Out of combat: only cast near Knowledge Crystal if enabled
-                if (!OccultCrescentSettings.Instance.PrayKnowledgeCrystal)
-                    return false;
+            // In combat: cast if we don't have the regen effect and HP is below threshold
+            if (Core.Me.HasAura(OCAuras.Pray))
+                return false;
 
-                if (Core.Me.HasAura(OCAuras.EnduringFortitude, msLeft: (int)(OccultCrescentSettings.Instance.PartyBuffRefreshMinutes * 60 * 1000)))
-                    return false;
+            if (Core.Me.CurrentHealthPercent > OccultCrescentSettings.Instance.PrayHealthPercent)
+                return false;
 
-                if (IsNearKnowledgeCrystal())
-                    return await OCSpells.Pray.Cast(Core.Me);
-            }
-            else
-            {
-                // In combat: cast if we don't have the regen effect and HP is below threshold
-                if (Core.Me.HasAura(OCAuras.Pray))
-                    return false;
-
-                if (Core.Me.CurrentHealthPercent > OccultCrescentSettings.Instance.PrayHealthPercent)
-                    return false;
-
-                return await OCSpells.Pray.Cast(Core.Me);
-            }
-
-            return false;
+            return await OCSpells.Pray.Cast(Core.Me);
         }
 
         /// <summary>
@@ -1403,8 +1388,8 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
-        /// Cast Counterstance - increases parry rate by 100% for 60s
-        /// When cast near Knowledge Crystal, provides movement speed buff
+        /// Cast Counterstance - increases parry rate by 100% for 60s (combat only)
+        /// Knowledge crystal movement speed buff casting is now handled by PhantomJobSwitcher
         /// </summary>
         /// <returns>True if spell was cast, false otherwise</returns>
         private static async Task<bool> Counterstance()
@@ -1412,35 +1397,19 @@ namespace Magitek.Logic.Roles
             if (!OccultCrescentSettings.Instance.UseCounterstance)
                 return false;
 
+            // Only used in combat for parry rate, knowledge crystal movement buff handled by PhantomJobSwitcher
+            if (!Core.Me.InCombat)
+                return false;
+
             if (!OCSpells.Counterstance.CanCast())
                 return false;
 
-            if (!Core.Me.InCombat)
-            {
-                // Out of combat: only cast near Knowledge Crystal if enabled
-                if (!OccultCrescentSettings.Instance.CounterstanceKnowledgeCrystal)
-                    return false;
+            // In combat: cast for parry rate buff
+            // Check if we already have the Counterstance parry buff
+            if (Core.Me.HasAura(OCAuras.Counterstance))
+                return false;
 
-                // Check if we already have the Fleetfooted buff from crystal casting
-                if (Core.Me.HasAura(OCAuras.Fleetfooted, msLeft: (int)(OccultCrescentSettings.Instance.PartyBuffRefreshMinutes * 60 * 1000)))
-                    return false;
-
-                if (IsNearKnowledgeCrystal())
-                {
-                    return await OCSpells.Counterstance.Cast(Core.Me);
-                }
-            }
-            else
-            {
-                // In combat: cast for parry rate buff
-                // Check if we already have the Counterstance parry buff
-                if (Core.Me.HasAura(OCAuras.Counterstance))
-                    return false;
-
-                return await OCSpells.Counterstance.Cast(Core.Me);
-            }
-
-            return false;
+            return await OCSpells.Counterstance.Cast(Core.Me);
         }
 
         /// <summary>
@@ -2653,12 +2622,12 @@ namespace Magitek.Logic.Roles
                 ally.IsValid &&
                 ally.IsAlive &&
                 ally.IsTank() &&
-                !ally.HasAura(OCAuras.BattleBell))
+                !ally.HasAura(OCAuras.BattleBell, msLeft: 1000))
                 .OrderBy(ally => ally.CurrentHealthPercent) // Prioritize tank taking more damage
                 .FirstOrDefault();
 
             // Second priority: Self if we don't have the buff
-            if (battleBellTarget == null && !Core.Me.HasAura(OCAuras.BattleBell))
+            if (battleBellTarget == null && !Core.Me.HasAura(OCAuras.BattleBell, msLeft: 1000))
                 battleBellTarget = Core.Me;
 
             // Third priority: Any other party member who doesn't have the buff
@@ -2668,7 +2637,7 @@ namespace Magitek.Logic.Roles
                     ally.IsValid &&
                     ally.IsAlive &&
                     !ally.IsTank() &&
-                    !ally.HasAura(OCAuras.BattleBell))
+                    !ally.HasAura(OCAuras.BattleBell, msLeft: 1000))
                     .OrderBy(ally => ally.IsHealer() ? 1 : 0) // Prefer DPS over healers
                     .FirstOrDefault();
             }
@@ -2838,12 +2807,12 @@ namespace Magitek.Logic.Roles
                     ally.IsValid &&
                     ally.IsAlive &&
                     ally.IsTank() &&
-                    !ally.HasAura(OCAuras.RingingRespite))
+                    !ally.HasAura(OCAuras.RingingRespite, msLeft: 1000))
                     .OrderBy(ally => ally.CurrentHealthPercent) // Prioritize tank taking more damage
                     .FirstOrDefault();
 
                 // Second priority: Self if we don't have the buff
-                if (ringingRespiteTarget == null && !Core.Me.HasAura(OCAuras.RingingRespite))
+                if (ringingRespiteTarget == null && !Core.Me.HasAura(OCAuras.RingingRespite, msLeft: 1000))
                     ringingRespiteTarget = Core.Me;
 
                 // Third priority: Any other party member who doesn't have the buff
@@ -2852,7 +2821,7 @@ namespace Magitek.Logic.Roles
                     ringingRespiteTarget = Group.CastableAlliesWithin30.Where(ally =>
                         ally.IsValid &&
                         ally.IsAlive &&
-                        !ally.HasAura(OCAuras.RingingRespite))
+                        !ally.HasAura(OCAuras.RingingRespite, msLeft: 1000))
                         .OrderBy(ally => ally.IsHealer() ? 1 : 0) // Prefer DPS over healers
                         .FirstOrDefault();
                 }
@@ -2894,17 +2863,17 @@ namespace Magitek.Logic.Roles
                 suspendTarget = Group.CastableAlliesWithin30.Where(ally =>
                     ally.IsValid &&
                     ally.IsAlive &&
-                    !ally.HasAura(OCAuras.Suspend))
+                    !ally.HasAura(OCAuras.Suspend, msLeft: 1000))
                     .FirstOrDefault();
 
                 // If no allies need suspend, check self
-                if (suspendTarget == null && !Core.Me.HasAura(OCAuras.Suspend))
+                if (suspendTarget == null && !Core.Me.HasAura(OCAuras.Suspend, msLeft: 1000))
                     suspendTarget = Core.Me;
             }
             else
             {
                 // Self-only mode: only check self
-                if (!Core.Me.HasAura(OCAuras.Suspend))
+                if (!Core.Me.HasAura(OCAuras.Suspend, msLeft: 1000))
                     suspendTarget = Core.Me;
             }
 

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2617,29 +2617,38 @@ namespace Magitek.Logic.Roles
 
             GameObject battleBellTarget = null;
 
-            // First priority: Find tank who doesn't have Battle Bell buff
-            battleBellTarget = Group.CastableAlliesWithin30.Where(ally =>
-                ally.IsValid &&
-                ally.IsAlive &&
-                ally.IsTank() &&
-                !ally.HasAura(OCAuras.BattleBell, msLeft: 1000))
-                .OrderBy(ally => ally.CurrentHealthPercent) // Prioritize tank taking more damage
-                .FirstOrDefault();
-
-            // Second priority: Self if we don't have the buff
-            if (battleBellTarget == null && !Core.Me.HasAura(OCAuras.BattleBell, msLeft: 1000))
-                battleBellTarget = Core.Me;
-
-            // Third priority: Any other party member who doesn't have the buff
-            if (battleBellTarget == null)
+            // Always include self option - if enabled and we don't have the buff, prioritize self
+            if (OccultCrescentSettings.Instance.BattleBellAlwaysIncludeSelf && !Core.Me.HasAura(OCAuras.BattleBell, msLeft: 1000))
             {
+                battleBellTarget = Core.Me;
+            }
+            else
+            {
+                // Normal priority system
+                // First priority: Find tank who doesn't have Battle Bell buff
                 battleBellTarget = Group.CastableAlliesWithin30.Where(ally =>
                     ally.IsValid &&
                     ally.IsAlive &&
-                    !ally.IsTank() &&
+                    ally.IsTank() &&
                     !ally.HasAura(OCAuras.BattleBell, msLeft: 1000))
-                    .OrderBy(ally => ally.IsHealer() ? 1 : 0) // Prefer DPS over healers
+                    .OrderBy(ally => ally.CurrentHealthPercent) // Prioritize tank taking more damage
                     .FirstOrDefault();
+
+                // Second priority: Self if we don't have the buff
+                if (battleBellTarget == null && !Core.Me.HasAura(OCAuras.BattleBell, msLeft: 1000))
+                    battleBellTarget = Core.Me;
+
+                // Third priority: Any other party member who doesn't have the buff
+                if (battleBellTarget == null)
+                {
+                    battleBellTarget = Group.CastableAlliesWithin30.Where(ally =>
+                        ally.IsValid &&
+                        ally.IsAlive &&
+                        !ally.IsTank() &&
+                        !ally.HasAura(OCAuras.BattleBell, msLeft: 1000))
+                        .OrderBy(ally => ally.IsHealer() ? 1 : 0) // Prefer DPS over healers
+                        .FirstOrDefault();
+                }
             }
 
             if (battleBellTarget == null)
@@ -2799,8 +2808,13 @@ namespace Magitek.Logic.Roles
 
             GameObject ringingRespiteTarget = null;
 
+            // Always include self option - if enabled and we don't have the buff, prioritize self
+            if (OccultCrescentSettings.Instance.RingingRespiteAlwaysIncludeSelf && !Core.Me.HasAura(OCAuras.RingingRespite, msLeft: 1000))
+            {
+                ringingRespiteTarget = Core.Me;
+            }
             // Check if we should cast on allies
-            if (OccultCrescentSettings.Instance.RingingRespiteCastOnAllies)
+            else if (OccultCrescentSettings.Instance.RingingRespiteCastOnAllies)
             {
                 // First priority: Find tank who doesn't have Ringing Respite buff
                 ringingRespiteTarget = Group.CastableAlliesWithin30.Where(ally =>

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -36,6 +36,26 @@ namespace Magitek.Models.OccultCrescent
         [Setting]
         [DefaultValue(true)]
         public bool ReviveNonPartyInCombat { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool EnableAutomaticPhantomJobSwitching { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool AutoSwitchToKnightForEnduringFortitude { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool AutoSwitchToBardForRomeosBallad { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool AutoSwitchToMonkForFleetfooted { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool RestoreOriginalPhantomJobAfterAutoBuff { get; set; }
         #endregion
 
         #region Phantom Bard
@@ -47,9 +67,7 @@ namespace Magitek.Models.OccultCrescent
         [DefaultValue(true)]
         public bool UseRomeosBallad { get; set; }
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool RomeosBallad_KnowledgeCrystal { get; set; }
+
 
         [Setting]
         [DefaultValue(true)]
@@ -81,9 +99,7 @@ namespace Magitek.Models.OccultCrescent
         [DefaultValue(true)]
         public bool UsePray { get; set; }
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool PrayKnowledgeCrystal { get; set; }
+
 
         [Setting]
         [DefaultValue(75.0f)]
@@ -131,9 +147,7 @@ namespace Magitek.Models.OccultCrescent
         [DefaultValue(true)]
         public bool UseCounterstance { get; set; }
 
-        [Setting]
-        [DefaultValue(true)]
-        public bool CounterstanceKnowledgeCrystal { get; set; }
+
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -38,7 +38,7 @@ namespace Magitek.Models.OccultCrescent
         public bool ReviveNonPartyInCombat { get; set; }
 
         [Setting]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool EnableAutomaticPhantomJobSwitching { get; set; }
 
         [Setting]

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -408,12 +408,20 @@ namespace Magitek.Models.OccultCrescent
         public bool UseBattleBell { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool BattleBellAlwaysIncludeSelf { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool UseRingingRespite { get; set; }
 
         [Setting]
         [DefaultValue(true)]
         public bool RingingRespiteCastOnAllies { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool RingingRespiteAlwaysIncludeSelf { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
+++ b/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
@@ -1,0 +1,235 @@
+using System;
+using ff14bot;
+using ff14bot.Managers;
+using System;
+using GreyMagic;
+
+namespace Magitek.Utilities.Agents
+{
+    /// <summary>
+    /// Agent for MKD Support Job List functionality in Occult Crescent
+    /// Handles phantom job switching at knowledge crystals
+    /// 
+    /// Memory Structure Reference:
+    /// https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMKDSupportJobList.cs
+    /// 
+    /// Job ID Data Source (update PhantomJobId enum from this table):
+    /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/MKDSupportJob.csv
+    /// </summary>
+    internal static class AgentMKDSupportJobList
+    {
+        /// <summary>
+        /// Agent ID for MKDSupportJobList
+        /// </summary>
+        private const int AgentId = 468;
+
+        /// <summary>
+        /// Memory pattern for ChangeSupportJob function
+        /// </summary>
+        private const string ChangeSupportJobPattern = "Search 40 53 48 83 EC ? 0F B6 DA E8 ? ? ? ? 48 85 C0 74 ? 38 58";
+
+        // Cached values - initialized once and reused
+        private static IntPtr _changeSupportJobFunc = IntPtr.Zero;
+        private static IntPtr _agentPointer = IntPtr.Zero;
+        private static bool _initialized = false;
+        private static readonly object _initLock = new object();
+
+        /// <summary>
+        /// Initialize the cached function address and agent pointer
+        /// Uses proper disposal and caching as recommended by RB dev
+        /// </summary>
+        private static void Initialize()
+        {
+            if (_initialized) return;
+
+            lock (_initLock)
+            {
+                if (_initialized) return;
+
+                try
+                {
+                    // Get and cache the agent pointer
+                    var agent = AgentModule.GetAgentInterfaceById(AgentId);
+                    if (agent != null && agent.IsValid)
+                    {
+                        _agentPointer = agent.Pointer;
+                        Logger.WriteInfo($"[AgentMKDSupportJobList] Agent pointer cached: 0x{_agentPointer.ToInt64():X}");
+                    }
+                    else
+                    {
+                        Logger.WriteInfo($"[AgentMKDSupportJobList] Agent {AgentId} is not valid or available");
+                        return;
+                    }
+
+                    // Find and cache the ChangeSupportJob function with proper disposal
+                    using (var pf = new PatternFinder(Core.Memory))
+                    {
+                        // Use FindSingle as recommended by RB dev (has don't rebase option)
+                        _changeSupportJobFunc = pf.FindSingle(ChangeSupportJobPattern, true);
+
+                        if (_changeSupportJobFunc != IntPtr.Zero)
+                        {
+                            Logger.WriteInfo($"[AgentMKDSupportJobList] ChangeSupportJob function found and cached: 0x{_changeSupportJobFunc.ToInt64():X}");
+                        }
+                        else
+                        {
+                            Logger.WriteInfo($"[AgentMKDSupportJobList] ChangeSupportJob function not found");
+                            return;
+                        }
+                    } // PatternFinder automatically disposed here
+
+                    _initialized = true;
+                    Logger.WriteInfo($"[AgentMKDSupportJobList] Initialization completed successfully");
+                }
+                catch (Exception ex)
+                {
+                    Logger.WriteInfo($"[AgentMKDSupportJobList] Initialization failed: {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Switch to the specified phantom job using cached values and memory injection
+        /// Optimized with caching as recommended by RB dev
+        /// </summary>
+        /// <param name="jobId">The phantom job ID to switch to (1-12)</param>
+        /// <returns>True if the switch was successful, false otherwise</returns>
+        public static bool SwitchToPhantomJob(byte jobId)
+        {
+            try
+            {
+                // Initialize on first use
+                Initialize();
+
+                if (!_initialized || _agentPointer == IntPtr.Zero || _changeSupportJobFunc == IntPtr.Zero)
+                {
+                    Logger.WriteInfo($"[AgentMKDSupportJobList] Not properly initialized - Agent: 0x{_agentPointer.ToInt64():X}, Function: 0x{_changeSupportJobFunc.ToInt64():X}");
+                    return false;
+                }
+
+                // Validate address (replicate CallInjectedWraper validation)
+                if (_changeSupportJobFunc.ToInt64() < Core.Memory.ImageBase.ToInt64())
+                {
+                    Logger.WriteInfo($"[AgentMKDSupportJobList] Address is not in the game process");
+                    return false;
+                }
+
+                Logger.WriteInfo($"[AgentMKDSupportJobList] Switching to phantom job {jobId}");
+                Logger.WriteInfo($"[AgentMKDSupportJobList] Using cached Agent: 0x{_agentPointer.ToInt64():X}, Function: 0x{_changeSupportJobFunc.ToInt64():X}");
+
+                // Call the cached function with cached agent pointer
+                lock (Core.Memory.Executor.AssemblyLock)
+                {
+                    var result = Core.Memory.CallInjected64<IntPtr>(_changeSupportJobFunc, _agentPointer, jobId);
+
+                    // Return value 0x1 indicates success, anything else is failure
+                    bool success = result.ToInt64() == 0x1;
+                    if (success)
+                    {
+                        Logger.WriteInfo($"[AgentMKDSupportJobList] Phantom job switch to {jobId} succeeded");
+                    }
+                    else
+                    {
+                        Logger.WriteInfo($"[AgentMKDSupportJobList] Phantom job switch to {jobId} failed (likely job not unlocked)");
+                    }
+
+                    return success;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteInfo($"[AgentMKDSupportJobList] Error switching to phantom job {jobId}: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Alternative method: Open the interface using Toggle()
+        /// </summary>
+        /// <param name="jobId">The phantom job ID (currently unused, just opens interface)</param>
+        /// <returns>True if the interface was opened</returns>
+        public static bool OpenPhantomJobInterface(byte jobId)
+        {
+            try
+            {
+                var agent = AgentModule.GetAgentInterfaceById(AgentId);
+
+                if (agent == null || !agent.IsValid)
+                {
+                    Logger.WriteInfo($"[AgentMKDSupportJobList] Agent {AgentId} is not valid or available");
+                    return false;
+                }
+
+                Logger.WriteInfo($"[AgentMKDSupportJobList] Opening phantom job interface");
+                agent.Toggle();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteInfo($"[AgentMKDSupportJobList] Error opening interface: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Check if the agent and function are available
+        /// </summary>
+        public static bool IsAvailable
+        {
+            get
+            {
+                try
+                {
+                    Initialize();
+                    return _initialized && _agentPointer != IntPtr.Zero && _changeSupportJobFunc != IntPtr.Zero;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Force re-initialization (useful if game state changes)
+        /// </summary>
+        public static void Reset()
+        {
+            lock (_initLock)
+            {
+                _initialized = false;
+                _agentPointer = IntPtr.Zero;
+                _changeSupportJobFunc = IntPtr.Zero;
+                Logger.WriteInfo($"[AgentMKDSupportJobList] Reset completed - will re-initialize on next use");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Phantom job IDs based on MKDSupportJob.csv data
+    /// 
+    /// Data Source (MUST be kept in sync with this table):
+    /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/MKDSupportJob.csv
+    /// 
+    /// Correct job mapping from CSV (0-12):
+    /// 0=Freelancer, 1=Knight, 2=Berserker, 3=Monk, 4=Ranger, 5=Samurai,
+    /// 6=Bard, 7=Geomancer, 8=TimeMage, 9=Cannoneer, 10=Chemist, 11=Oracle, 12=Thief
+    /// </summary>
+    public enum PhantomJobId : byte
+    {
+        Freelancer = 0,
+        Knight = 1,
+        Berserker = 2,
+        Monk = 3,
+        Ranger = 4,
+        Samurai = 5,
+        Bard = 6,
+        Geomancer = 7,
+        TimeMage = 8,
+        Cannoneer = 9,
+        Chemist = 10,
+        Oracle = 11,
+        Thief = 12
+    }
+}

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -226,7 +226,7 @@ namespace Magitek.Utilities
             {
                 if (!AgentMKDSupportJobList.IsAvailable)
                 {
-                    Logger.WriteWarning("[PhantomJobSwitcher] AgentMKDSupportJobList is not available");
+                    Logger.WriteWarning("[PhantomJobSwitcher] Unable to automatically change phantom jobs");
                     return false;
                 }
 
@@ -241,7 +241,6 @@ namespace Magitek.Utilities
                 }
 
                 // Memory call succeeded (0x1), do a quick verification that aura actually applied
-                Logger.WriteInfo($"[PhantomJobSwitcher] Memory call succeeded for phantom job {jobId}, verifying aura...");
                 return await VerifyPhantomJobAura(jobId);
             }
             catch (Exception ex)
@@ -267,7 +266,6 @@ namespace Magitek.Utilities
             var currentJobId = GetCurrentPhantomJobId();
             if (currentJobId == jobId)
             {
-                Logger.WriteInfo($"[PhantomJobSwitcher] Phantom job {GetPhantomJobName(jobId)} verified immediately");
                 return true;
             }
 
@@ -280,7 +278,6 @@ namespace Magitek.Utilities
                 currentJobId = GetCurrentPhantomJobId();
                 if (currentJobId == jobId)
                 {
-                    Logger.WriteInfo($"[PhantomJobSwitcher] Phantom job {GetPhantomJobName(jobId)} verified after {elapsedMs}ms");
                     return true;
                 }
             }

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ff14bot;
+using ff14bot.Managers;
+using Buddy.Coroutines;
+using Magitek.Extensions;
+using Magitek.Models.OccultCrescent;
+using Magitek.Utilities.Agents;
+using Magitek.Logic.Roles;
+
+namespace Magitek.Utilities
+{
+    public static class PhantomJobSwitcher
+    {
+        /// <summary>
+        /// Throttling to prevent rapid repeated attempts when spells fail
+        /// </summary>
+        private static DateTime _lastAttemptTime = DateTime.MinValue;
+        private static readonly TimeSpan AttemptCooldown = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Maps phantom jobs to their corresponding knowledge crystal buff auras
+        /// </summary>
+        private static readonly Dictionary<PhantomJobId, KnowledgeCrystalBuff> KnowledgeCrystalBuffs = new()
+        {
+            // Bard (ID=6) -> Romeo's Ballad -> Romeo's Ballad aura
+            {
+                PhantomJobId.Bard,
+                new KnowledgeCrystalBuff
+                {
+                    AuraId = OCAuras.RomeosBallad, // 4244
+                    BuffName = "Romeo's Ballad",
+                    JobName = "Bard"
+                }
+            },
+            // Knight (ID=1) -> Pray -> Enduring Fortitude aura
+            {
+                PhantomJobId.Knight,
+                new KnowledgeCrystalBuff
+                {
+                    AuraId = OCAuras.EnduringFortitude, // 4233
+                    BuffName = "Enduring Fortitude",
+                    JobName = "Knight"
+                }
+            },
+            // Monk (ID=3) -> Counterstance -> Fleetfooted aura
+            {
+                PhantomJobId.Monk,
+                new KnowledgeCrystalBuff
+                {
+                    AuraId = OCAuras.Fleetfooted, // 4239
+                    BuffName = "Fleetfooted",
+                    JobName = "Monk"
+                }
+            }
+        };
+
+        /// <summary>
+        /// Automatically switch phantom jobs and cast knowledge crystal buffs when near a crystal
+        /// Restores the original phantom job after completing all buffs
+        /// </summary>
+        /// <returns>True if any action was taken</returns>
+        public static async Task<bool> AutoSwitchForKnowledgeCrystalBuffs()
+        {
+            // Check if automatic switching is enabled
+            if (!OccultCrescentSettings.Instance.EnableAutomaticPhantomJobSwitching)
+                return false;
+
+            // Must be in Occult Crescent
+            if (!Core.Me.OnOccultCrescent())
+                return false;
+
+            // Must be out of combat
+            if (Core.Me.InCombat)
+                return false;
+
+            // Throttle attempts to prevent rapid ping-ponging when spells fail
+            var now = DateTime.Now;
+            if (now - _lastAttemptTime < AttemptCooldown)
+                return false;
+
+            // Build list of needed buffs (cheap aura checks)
+            var neededBuffs = new List<(PhantomJobId jobId, KnowledgeCrystalBuff buffInfo)>();
+
+            foreach (var kvp in KnowledgeCrystalBuffs)
+            {
+                var phantomJobId = kvp.Key;
+                var buffInfo = kvp.Value;
+
+                // Check if this specific job switching is enabled
+                bool jobSwitchEnabled = phantomJobId switch
+                {
+                    PhantomJobId.Knight => OccultCrescentSettings.Instance.AutoSwitchToKnightForEnduringFortitude,
+                    PhantomJobId.Bard => OccultCrescentSettings.Instance.AutoSwitchToBardForRomeosBallad,
+                    PhantomJobId.Monk => OccultCrescentSettings.Instance.AutoSwitchToMonkForFleetfooted,
+                    _ => false
+                };
+
+                // Skip if this job switching is disabled
+                if (!jobSwitchEnabled)
+                    continue;
+
+                // Check if we need this buff
+                if (NeedsBuff(buffInfo))
+                {
+                    neededBuffs.Add((phantomJobId, buffInfo));
+                }
+            }
+
+            // If we don't need any buffs, no point checking crystal location
+            if (neededBuffs.Count == 0)
+                return false;
+
+            // Only now check if we're near a knowledge crystal (more expensive check)
+            if (!OccultCrescent.IsNearKnowledgeCrystal())
+                return false;
+
+            // Update attempt timestamp now that we're actually going to try
+            _lastAttemptTime = now;
+
+            // Get the current phantom job before switching
+            var originalPhantomJobId = GetCurrentPhantomJobId();
+
+            // Track successful buffs and if any action was taken
+            var successfulBuffs = new List<string>();
+            bool anyActionTaken = false;
+
+            // Try to cast all needed buffs
+            foreach (var (neededJobId, neededBuffInfo) in neededBuffs)
+            {
+                // Check if we're already in the needed phantom job
+                var currentJob = GetCurrentPhantomJobId();
+                bool alreadyInCorrectJob = currentJob == neededJobId;
+
+                if (alreadyInCorrectJob)
+                {
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Already in {neededBuffInfo.JobName}, casting {neededBuffInfo.BuffName}");
+                }
+                else
+                {
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Switching to {neededBuffInfo.JobName} for {neededBuffInfo.BuffName}");
+
+                    // Try to switch to the needed job
+                    if (!await SwitchToPhantomJob(neededJobId))
+                    {
+                        Logger.WriteInfo($"[PhantomJobSwitcher] Failed to switch to {neededBuffInfo.JobName} (likely not unlocked), trying next job");
+                        continue; // Try next job
+                    }
+
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Successfully switched to {neededBuffInfo.JobName}");
+                    anyActionTaken = true;
+                    await Coroutine.Wait(500, () => false); // Brief delay to ensure buffs are fully applied
+                }
+
+                // Try to cast the buff - if it fails, that's okay (user has job but not required level)
+                if (await CastKnowledgeCrystalBuff(neededJobId))
+                {
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Successfully cast {neededBuffInfo.BuffName}");
+                    successfulBuffs.Add(neededBuffInfo.BuffName);
+                    anyActionTaken = true;
+
+                    // Wait for the spell to actually finish casting before switching jobs
+                    await Casting.CheckForSuccessfulCast();
+                    await Coroutine.Wait(500, () => false); // Brief delay to ensure buffs are fully applied
+                }
+                else
+                {
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Failed to cast {neededBuffInfo.BuffName} (user may not have required level), continuing");
+                    // Continue to next buff - this is okay, user has job but not required level
+                }
+            }
+
+            // Restore original phantom job only once at the end if we took any action
+            if (anyActionTaken &&
+                OccultCrescentSettings.Instance.RestoreOriginalPhantomJobAfterAutoBuff &&
+                GetCurrentPhantomJobId() != originalPhantomJobId)
+            {
+                Logger.WriteInfo($"[PhantomJobSwitcher] Restoring to original phantom job: {GetPhantomJobName(originalPhantomJobId)}");
+                await Coroutine.Wait(500, () => false); // Brief delay to ensure buffs are fully applied
+
+                if (await SwitchToPhantomJob(originalPhantomJobId))
+                {
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Successfully restored to {GetPhantomJobName(originalPhantomJobId)}");
+                }
+                else
+                {
+                    Logger.WriteWarning($"[PhantomJobSwitcher] Failed to restore to {GetPhantomJobName(originalPhantomJobId)}");
+                }
+            }
+
+            // Log summary
+            if (successfulBuffs.Count > 0)
+            {
+                Logger.WriteInfo($"[PhantomJobSwitcher] Completed automatic buffing. Successfully cast: {string.Join(", ", successfulBuffs)}");
+            }
+            else if (anyActionTaken)
+            {
+                Logger.WriteInfo("[PhantomJobSwitcher] Attempted automatic buffing but no buffs were successfully cast");
+            }
+
+            return anyActionTaken;
+        }
+
+        /// <summary>
+        /// Check if we need a specific buff based on its remaining time
+        /// </summary>
+        /// <param name="buffInfo">The buff information to check</param>
+        /// <returns>True if the buff is needed</returns>
+        private static bool NeedsBuff(KnowledgeCrystalBuff buffInfo)
+        {
+            var refreshMinutes = OccultCrescentSettings.Instance.PartyBuffRefreshMinutes;
+            var msLeft = (int)(refreshMinutes * 60 * 1000);
+
+            return !Core.Me.HasAura(buffInfo.AuraId, msLeft: msLeft);
+        }
+
+        /// <summary>
+        /// Switch to the specified phantom job using memory injection result for immediate feedback
+        /// </summary>
+        /// <param name="jobId">The phantom job ID to switch to</param>
+        /// <returns>True if the switch was successful and aura was applied</returns>
+        private static async Task<bool> SwitchToPhantomJob(PhantomJobId jobId)
+        {
+            try
+            {
+                if (!AgentMKDSupportJobList.IsAvailable)
+                {
+                    Logger.WriteWarning("[PhantomJobSwitcher] AgentMKDSupportJobList is not available");
+                    return false;
+                }
+
+                // Call the memory injection and check immediate result (0x1 = success)
+                bool memoryCallSuccess = AgentMKDSupportJobList.SwitchToPhantomJob((byte)jobId);
+
+                if (!memoryCallSuccess)
+                {
+                    // Memory call failed immediately - job likely not unlocked, no need to wait
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Memory call failed for phantom job {jobId} (likely not unlocked)");
+                    return false;
+                }
+
+                // Memory call succeeded (0x1), do a quick verification that aura actually applied
+                Logger.WriteInfo($"[PhantomJobSwitcher] Memory call succeeded for phantom job {jobId}, verifying aura...");
+                return await VerifyPhantomJobAura(jobId);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteInfo($"[PhantomJobSwitcher] Error switching to phantom job {jobId}: {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Quick verification that the phantom job aura was applied after successful memory call
+        /// Since memory call succeeded (0x1), this should be nearly instant
+        /// </summary>
+        /// <param name="jobId">The phantom job ID we switched to</param>
+        /// <returns>True if the aura was applied within short timeout, false otherwise</returns>
+        private static async Task<bool> VerifyPhantomJobAura(PhantomJobId jobId)
+        {
+            const int timeoutMs = 300; // Very short timeout since memory call already succeeded
+            const int checkIntervalMs = 50; // Check every 50ms for quick response
+            int elapsedMs = 0;
+
+            // Check immediately first (often succeeds on first check)
+            var currentJobId = GetCurrentPhantomJobId();
+            if (currentJobId == jobId)
+            {
+                Logger.WriteInfo($"[PhantomJobSwitcher] Phantom job {GetPhantomJobName(jobId)} verified immediately");
+                return true;
+            }
+
+            // If not immediate, do a few quick checks
+            while (elapsedMs < timeoutMs)
+            {
+                await Coroutine.Wait(checkIntervalMs, () => false);
+                elapsedMs += checkIntervalMs;
+
+                currentJobId = GetCurrentPhantomJobId();
+                if (currentJobId == jobId)
+                {
+                    Logger.WriteInfo($"[PhantomJobSwitcher] Phantom job {GetPhantomJobName(jobId)} verified after {elapsedMs}ms");
+                    return true;
+                }
+            }
+
+            Logger.WriteWarning($"[PhantomJobSwitcher] Aura verification timeout for {GetPhantomJobName(jobId)} after {timeoutMs}ms");
+            return false;
+        }
+
+        /// <summary>
+        /// Cast the knowledge crystal buff for the specified phantom job
+        /// Reuses existing OccultCrescent spell casting logic
+        /// </summary>
+        /// <param name="jobId">The phantom job ID</param>
+        /// <returns>True if the spell was cast successfully</returns>
+        private static async Task<bool> CastKnowledgeCrystalBuff(PhantomJobId jobId)
+        {
+            try
+            {
+                return jobId switch
+                {
+                    PhantomJobId.Bard => await OCSpells.RomeosBallad.CastAura(Core.Me, OCAuras.RomeosBallad),
+                    PhantomJobId.Knight => await OCSpells.Pray.CastAura(Core.Me, OCAuras.EnduringFortitude),
+                    PhantomJobId.Monk => await OCSpells.Counterstance.CastAura(Core.Me, OCAuras.Fleetfooted),
+                    _ => false
+                };
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteInfo($"[PhantomJobSwitcher] Error casting buff for {jobId}: {ex.Message}");
+                return false;
+            }
+        }
+
+
+
+        /// <summary>
+        /// Get the current phantom job ID by reusing OccultCrescent logic
+        /// </summary>
+        /// <returns>The current phantom job ID, or None if no phantom job is active</returns>
+        private static PhantomJobId GetCurrentPhantomJobId()
+        {
+            // Reuse existing OccultCrescent logic instead of duplicating
+            var currentJob = OccultCrescent.GetCurrentPhantomJob();
+            return ConvertToPhantomJobId(currentJob);
+        }
+
+        /// <summary>
+        /// Convert OccultCrescent.PhantomJob enum to PhantomJobId enum
+        /// </summary>
+        /// <param name="phantomJob">The OccultCrescent phantom job</param>
+        /// <returns>The corresponding PhantomJobId</returns>
+        private static PhantomJobId ConvertToPhantomJobId(OccultCrescent.PhantomJob phantomJob)
+        {
+            return phantomJob switch
+            {
+                OccultCrescent.PhantomJob.None => PhantomJobId.Freelancer, // Default to Freelancer
+                OccultCrescent.PhantomJob.Knight => PhantomJobId.Knight,
+                OccultCrescent.PhantomJob.Berserker => PhantomJobId.Berserker,
+                OccultCrescent.PhantomJob.Monk => PhantomJobId.Monk,
+                OccultCrescent.PhantomJob.Ranger => PhantomJobId.Ranger,
+                OccultCrescent.PhantomJob.Samurai => PhantomJobId.Samurai,
+                OccultCrescent.PhantomJob.Bard => PhantomJobId.Bard,
+                OccultCrescent.PhantomJob.Geomancer => PhantomJobId.Geomancer,
+                OccultCrescent.PhantomJob.TimeMage => PhantomJobId.TimeMage,
+                OccultCrescent.PhantomJob.Cannoneer => PhantomJobId.Cannoneer,
+                OccultCrescent.PhantomJob.Chemist => PhantomJobId.Chemist,
+                OccultCrescent.PhantomJob.Oracle => PhantomJobId.Oracle,
+                OccultCrescent.PhantomJob.PhantomThief => PhantomJobId.Thief,
+                _ => PhantomJobId.Freelancer // Default to Freelancer
+            };
+        }
+
+        /// <summary>
+        /// Get the display name for a phantom job ID
+        /// </summary>
+        /// <param name="jobId">The phantom job ID</param>
+        /// <returns>The display name of the phantom job</returns>
+        private static string GetPhantomJobName(PhantomJobId jobId)
+        {
+            return jobId switch
+            {
+                PhantomJobId.Freelancer => "Freelancer",
+                PhantomJobId.Knight => "Knight",
+                PhantomJobId.Berserker => "Berserker",
+                PhantomJobId.Monk => "Monk",
+                PhantomJobId.Ranger => "Ranger",
+                PhantomJobId.Samurai => "Samurai",
+                PhantomJobId.Bard => "Bard",
+                PhantomJobId.Geomancer => "Geomancer",
+                PhantomJobId.TimeMage => "Time Mage",
+                PhantomJobId.Cannoneer => "Cannoneer",
+                PhantomJobId.Chemist => "Chemist",
+                PhantomJobId.Oracle => "Oracle",
+                PhantomJobId.Thief => "Phantom Thief",
+                _ => jobId.ToString()
+            };
+        }
+
+        /// <summary>
+        /// Information about a knowledge crystal buff
+        /// </summary>
+        private class KnowledgeCrystalBuff
+        {
+            public uint AuraId { get; set; }
+            public string BuffName { get; set; }
+            public string JobName { get; set; }
+        }
+    }
+}

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -731,7 +731,7 @@
                                                           IsChecked="{Binding UsePhantomJudgment, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>
                                                 <controls:Numeric MaxValue="100"
-                                                                  MinValue="1"
+                                                                  MinValue="0"
                                                                   Value="{Binding PhantomJudgmentHealthPercent, Mode=TwoWay}"
                                                                   Margin="5,0,0,0"/>
                                                 <TextBlock Style="{DynamicResource TextBlockDefault}"
@@ -744,7 +744,7 @@
                                                           IsChecked="{Binding UseBlessing, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>
                                                 <controls:Numeric MaxValue="100"
-                                                                  MinValue="1"
+                                                                  MinValue="0"
                                                                   Value="{Binding BlessingHealthPercent, Mode=TwoWay}"
                                                                   Margin="5,0,0,0"/>
                                                 <TextBlock Style="{DynamicResource TextBlockDefault}"
@@ -757,7 +757,7 @@
                                                           IsChecked="{Binding UseCleansing, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>
                                                 <controls:Numeric MaxValue="100"
-                                                                  MinValue="1"
+                                                                  MinValue="0"
                                                                   Value="{Binding CleansingHealthPercent, Mode=TwoWay}"
                                                                   Margin="5,0,0,0"/>
                                                 <TextBlock Style="{DynamicResource TextBlockDefault}"

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -6,894 +6,929 @@
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:enums="clr-namespace:Magitek.Enumerations">
 
-    <UserControl.DataContext>
-        <Binding Source="{x:Static occultCrescent:OccultCrescentSettings.Instance}"/>
-    </UserControl.DataContext>
+        <UserControl.DataContext>
+                <Binding Source="{x:Static occultCrescent:OccultCrescentSettings.Instance}"/>
+        </UserControl.DataContext>
 
-    <UserControl.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
-            <ObjectDataProvider x:Key="InterruptStrategy"
-                                MethodName="GetValues"
-                                ObjectType="{x:Type sys:Enum}">
-                <ObjectDataProvider.MethodParameters>
-                    <x:Type TypeName="enums:InterruptStrategy"/>
-                </ObjectDataProvider.MethodParameters>
-            </ObjectDataProvider>
-        </ResourceDictionary>
-    </UserControl.Resources>
+        <UserControl.Resources>
+                <ResourceDictionary>
+                        <ResourceDictionary.MergedDictionaries>
+                                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml"/>
+                        </ResourceDictionary.MergedDictionaries>
+                        <ObjectDataProvider x:Key="InterruptStrategy"
+                                            MethodName="GetValues"
+                                            ObjectType="{x:Type sys:Enum}">
+                                <ObjectDataProvider.MethodParameters>
+                                        <x:Type TypeName="enums:InterruptStrategy"/>
+                                </ObjectDataProvider.MethodParameters>
+                        </ObjectDataProvider>
+                </ResourceDictionary>
+        </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="10">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="10">
 
-            <!-- General Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="General Settings"/>
+                        <!-- General Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="General Settings"/>
 
-                    <!-- Enable OC System -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Enable Occult Crescent Phantom Job System"
-                                  IsChecked="{Binding Enable, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
+                                        <!-- Enable OC System -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Enable Occult Crescent Phantom Job System"
+                                                          IsChecked="{Binding Enable, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
 
-                    <!-- OC System Description -->
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic">
+                                        <!-- OC System Description -->
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic">
                         <Run Text="Occult Crescent content provides temporary Phantom Jobs with unique abilities."/>
                         <LineBreak/>
                         <Run Text="Magitek automatically detects your current Phantom Job and uses abilities accordingly."/>
-                    </TextBlock>
+                                        </TextBlock>
 
-                    <!-- Party Buff Refresh Time Setting -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text="Party buff refresh time:"/>
-                        <controls:Numeric MinValue="1"
-                                          MaxValue="30"
-                                          Value="{Binding PartyBuffRefreshMinutes, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" minutes"/>
-                    </StackPanel>
+                                        <!-- Party Buff Refresh Time Setting -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="Party buff refresh time:"/>
+                                                <controls:Numeric MinValue="1"
+                                                                  MaxValue="30"
+                                                                  Value="{Binding PartyBuffRefreshMinutes, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" minutes"/>
+                                        </StackPanel>
 
-                    <!-- Party Buff Refresh Description -->
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Party buff refresh time controls when to reapply long-duration buffs near Knowledge Crystals."/>
+                                        <!-- Party Buff Refresh Description -->
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Party buff refresh time controls when to reapply long-duration buffs near Knowledge Crystals."/>
 
-                    <!-- Non-Party Resurrection Settings -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Revive Non-Party Dead Players (excess mana only)"
-                                  IsChecked="{Binding ReviveNonPartyPlayers, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
+                                        <!-- Non-Party Resurrection Settings -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Revive Non-Party Dead Players (excess mana only)"
+                                                          IsChecked="{Binding ReviveNonPartyPlayers, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
 
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text="Min MP for Non-Party Revive: "/>
-                        <controls:Numeric MinValue="50"
-                                          MaxValue="100"
-                                          Value="{Binding ReviveNonPartyMinimumManaPercent, Mode=TwoWay}"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent"/>
-                    </StackPanel>
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="Min MP for Non-Party Revive: "/>
+                                                <controls:Numeric MinValue="0"
+                                                                  MaxValue="100"
+                                                                  Value="{Binding ReviveNonPartyMinimumManaPercent, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent"/>
+                                        </StackPanel>
 
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Out of Combat"
-                                  IsChecked="{Binding ReviveNonPartyOutOfCombat, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="In Combat"
-                                  IsChecked="{Binding ReviveNonPartyInCombat, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Out of Combat"
+                                                          IsChecked="{Binding ReviveNonPartyOutOfCombat, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="In Combat"
+                                                          IsChecked="{Binding ReviveNonPartyInCombat, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
 
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Foreground="Orange"
-                               Text="In combat: Uses Swiftcast/Dualcast only. Out of combat: Uses Swiftcast first, then slowcast if needed."/>
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Foreground="Orange"
+                                                   Text="In combat: Uses Swiftcast/Dualcast only. Out of combat: Uses Swiftcast first, then slowcast if needed."/>
+
+                                        <!-- Automatic Phantom Job Switching -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Automatically switch phantom jobs for Knowledge Crystal buffs"
+                                                          IsChecked="{Binding EnableAutomaticPhantomJobSwitching, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <!-- Granular Auto-Switch Settings -->
+                                        <StackPanel Margin="20,5,5,5">
+                                                <StackPanel Orientation="Horizontal"
+                                                            Margin="0,2">
+                                                        <CheckBox Content="Auto-switch to Knight for Enduring Fortitude"
+                                                                  IsChecked="{Binding AutoSwitchToKnightForEnduringFortitude, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"
+                                                                  IsEnabled="{Binding EnableAutomaticPhantomJobSwitching}"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal"
+                                                            Margin="0,2">
+                                                        <CheckBox Content="Auto-switch to Bard for Romeo's Ballad"
+                                                                  IsChecked="{Binding AutoSwitchToBardForRomeosBallad, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"
+                                                                  IsEnabled="{Binding EnableAutomaticPhantomJobSwitching}"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal"
+                                                            Margin="0,2">
+                                                        <CheckBox Content="Auto-switch to Monk for Fleetfooted"
+                                                                  IsChecked="{Binding AutoSwitchToMonkForFleetfooted, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"
+                                                                  IsEnabled="{Binding EnableAutomaticPhantomJobSwitching}"/>
+                                                </StackPanel>
+                                                <StackPanel Orientation="Horizontal"
+                                                            Margin="0,2">
+                                                        <CheckBox Content="Restore original phantom job after auto-buffing"
+                                                                  IsChecked="{Binding RestoreOriginalPhantomJobAfterAutoBuff, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"
+                                                                  IsEnabled="{Binding EnableAutomaticPhantomJobSwitching}"/>
+                                                </StackPanel>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Foreground="LightBlue"
+                                                   Text="When near Knowledge Crystals, automatically switches to enabled phantom jobs to cast party buffs if needed. Disable specific jobs you don't have access to."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Bard Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Bard"/>
+
+                                        <!-- Offensive Aria -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Offensive Aria (Damage buff - 70s duration)"
+                                                          IsChecked="{Binding UseOffensiveAria, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <!-- Hero's Rime -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Hero's Rime (Party damage/healing +10% - 120s cooldown)"
+                                                          IsChecked="{Binding UseHerosRime, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <!-- Mighty March -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Mighty March below"
+                                                          IsChecked="{Binding UseMightyMarch, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding MightyMarchHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding MightyMarchCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <!-- Romeo's Ballad -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Romeo's Ballad (Combat interrupts only - knowledge crystal usage is automatic)"
+                                                          IsChecked="{Binding UseRomeosBallad, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Knight Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Knight"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Phantom Guard"
+                                                          IsChecked="{Binding UsePhantomGuard, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="when HP below "
+                                                           Margin="20,0,0,0"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding PhantomGuardHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Pray (Combat regen only - knowledge crystal party buff is automatic)"
+                                                          IsChecked="{Binding UsePray, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="Regen when HP below "
+                                                           Margin="20,0,0,0"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding PrayHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent"/>
+                                        </StackPanel>
+
+                                        <!-- Occult Heal -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Heal below"
+                                                          IsChecked="{Binding UseOccultHeal, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultHealHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding OccultHealCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <!-- Pledge -->
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Pledge below"
+                                                          IsChecked="{Binding UsePledge, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding PledgeHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding PledgeCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Monk Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Monk"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Phantom Kick"
+                                                          IsChecked="{Binding UsePhantomKick, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="Only use in melee range"
+                                                          IsChecked="{Binding PhantomKickMeleeRangeOnly, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use OccultCounter (Attack after parry)"
+                                                          IsChecked="{Binding UseOccultCounter, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Counterstance (Combat parry buff only - knowledge crystal movement speed is automatic)"
+                                                          IsChecked="{Binding UseCounterstance, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use OccultChakra below"
+                                                          IsChecked="{Binding UseOccultChakra, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultChakraHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Berserker Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Berserker"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Deadly Blow (High damage based on missing HP)"
+                                                          IsChecked="{Binding UseDeadlyBlow, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Rage (Auto attack nearest enemy)"
+                                                          IsChecked="{Binding UseRage, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="Only use in melee range"
+                                                          IsChecked="{Binding RageMeleeRangeOnly, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Chemist Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Chemist"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Revive (Resurrect dead party members)"
+                                                          IsChecked="{Binding UseRevive, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="Revive Out of Combat"
+                                                          IsChecked="{Binding ReviveOutOfCombat, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="Resurrection Delay: "/>
+                                                <controls:Numeric MinValue="0"
+                                                                  MaxValue="10"
+                                                                  Value="{Binding ReviveDelay, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" seconds"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Potion below"
+                                                          IsChecked="{Binding UseOccultPotion, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultPotionHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding OccultPotionCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" (100k gil/cast)"
+                                                           Foreground="Red"
+                                                           Margin="10,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Ether below"
+                                                          IsChecked="{Binding UseOccultEther, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultEtherManaPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent MP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding OccultEtherCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Elixir when"
+                                                          IsChecked="{Binding UseOccultElixir, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultElixirPartyHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent+ party members need help"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" (300k gil/cast)"
+                                                           Foreground="Red"
+                                                           Margin="10,0,0,0"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Cannoneer Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Cannoneer"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Phantom Fire (Standard ranged attack)"
+                                                          IsChecked="{Binding UsePhantomFire, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Holy Cannon (More damage vs undead)"
+                                                          IsChecked="{Binding UseHolyCannon, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="Use Silver Cannon (Damage debuff) - Mutually exclusive"
+                                                          IsChecked="{Binding UseSilverCannon, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Dark Cannon (Inflicts blind)"
+                                                          IsChecked="{Binding UseDarkCannon, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="Use Shock Cannon (Inflicts paralysis) - Mutually exclusive"
+                                                          IsChecked="{Binding UseShockCannon, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Grouped abilities share restrictions as noted."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Time Mage Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Time Mage"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Quick (Speed buff for cast/recast/movement)"
+                                                          IsChecked="{Binding UseOccultQuick, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding OccultQuickCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Slowga (Inflicts Slow on enemies)"
+                                                          IsChecked="{Binding UseOccultSlowga, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Mage Masher (Reduces enemy magic attack power)"
+                                                          IsChecked="{Binding UseOccultMageMasher, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Dispel (Removes beneficial effects from enemies)"
+                                                          IsChecked="{Binding UseOccultDispel, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Comet (AoE damage - 8s cast time)"
+                                                          IsChecked="{Binding UseOccultComet, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Quick prioritizes casting party members. Comet has long cast time - use carefully."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Ranger Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Ranger"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Phantom Aim (Damage buff - 120s cooldown)"
+                                                          IsChecked="{Binding UsePhantomAim, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Falcon (Area attack)"
+                                                          IsChecked="{Binding UseOccultFalcon, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Unicorn below"
+                                                          IsChecked="{Binding UseOccultUnicorn, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultUnicornHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding OccultUnicornCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Unicorn creates 40k damage absorb barrier for entire party. Falcon triggers traps."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Thief Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Thief"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Occult Sprint (Greatly increases movement speed)"
+                                                          IsChecked="{Binding UseOccultSprint, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Steal when enemy below"
+                                                          IsChecked="{Binding UseSteal, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="50"
+                                                                  MinValue="1"
+                                                                  Value="{Binding StealHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP (increases item drop chance)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Vigilance within"
+                                                          IsChecked="{Binding UseVigilance, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="50"
+                                                                  MinValue="3"
+                                                                  Value="{Binding VigilanceTargetDistance, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" yalms of target (Vigilance → Foreseen Offense when entering combat)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Pilfer Weapon (Lowers target's physical attack power by 10%)"
+                                                          IsChecked="{Binding UsePilferWeapon, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Vigilance can only be cast out of combat with a valid target. Effect changes to Foreseen Offense (+60% crit rate) when entering combat."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Samurai Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Samurai"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Mineuchi stun with strategy:"
+                                                          IsChecked="{Binding UseMineuchi, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <ComboBox ItemsSource="{Binding Source={StaticResource InterruptStrategy}}"
+                                                          SelectedValue="{Binding MineuchiStrategy, Mode=TwoWay}"
+                                                          Margin="5,0,0,0"
+                                                          Width="120"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Shirahadori below"
+                                                          IsChecked="{Binding UseShirahadori, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding ShirahadoriHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP (physical damage immunity for one attack)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Iainuki (Cone attack with instant kill chance)"
+                                                          IsChecked="{Binding UseIainuki, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Zeninage (Consumes Occult Coffer for 1,500 potency)"
+                                                          IsChecked="{Binding UseZeninage, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Mineuchi avoids stunning immune enemies. Zeninage only works when you have an Occult Coffer. Iainuki is a cone AoE attack."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Oracle Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Oracle"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Predict (Grants random prediction)"
+                                                          IsChecked="{Binding UsePredict, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Foreground="Orange"
+                                                   Text="Predict cycles through 4 random predictions. Magitek will attempt to use the best prediction available as they cycle through. Only one can be used. Must cast something on 4th cycle to avoid False Prediction (deadly DoT)."/>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Foreground="Red"
+                                                   Text="⚠️ SAFETY: If Starfall is the 4rd prediction and you're below the Starfall threshold, the current prediction will be cast automatically to avoid being forced into deadly Starfall as the 4th prediction."/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Phantom Judgment when party below"
+                                                          IsChecked="{Binding UsePhantomJudgment, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding PhantomJudgmentHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP (Damage + Healing)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Blessing when party below"
+                                                          IsChecked="{Binding UseBlessing, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding BlessingHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP (Strong Healing + Regen)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Cleansing when party above"
+                                                          IsChecked="{Binding UseCleansing, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding CleansingHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP (Damage + Freeze Time)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Starfall when above"
+                                                          IsChecked="{Binding UseStarfall, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="90"
+                                                                  Value="{Binding StarfallHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP (90% max HP self damage!)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Phantom Rejuvenation below"
+                                                          IsChecked="{Binding UsePhantomRejuvenation, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding PhantomRejuvenationHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding PhantomRejuvenationCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" (Prioritizes tanks)"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Invulnerability below"
+                                                          IsChecked="{Binding UseInvulnerability, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="50"
+                                                                  MinValue="1"
+                                                                  Value="{Binding InvulnerabilityHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding InvulnerabilityCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" (Emergency protection)"/>
+                                        </StackPanel>
+
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <!-- Phantom Geomancer Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Geomancer"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Battle Bell (Damage boost that stacks when taking damage)"
+                                                          IsChecked="{Binding UseBattleBell, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Battle Bell prioritizes tanks first (who take most damage), then self, then other party members. Only cast in combat."/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Ringing Respite (Heals target when they take damage)"
+                                                          IsChecked="{Binding UseRingingRespite, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding RingingRespiteCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" (Prioritizes tanks)"
+                                                           Margin="5,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Suspend"
+                                                          IsChecked="{Binding UseSuspend, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="Suspend whole party"
+                                                          IsChecked="{Binding SuspendCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Sunbath below"
+                                                          IsChecked="{Binding UseSunbath, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding SunbathHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" percent HP"/>
+                                                <CheckBox Content="On Allies"
+                                                          IsChecked="{Binding SunbathCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text=" (Restores HP)"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockSection}"
+                                                   Text="Weather Effects (Combat Only)"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Cloudy Caress (Increases healing potency by 30%)"
+                                                          IsChecked="{Binding UseCloudyCaress, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Blessed Rain (Erects magical barrier which nullifies damage)"
+                                                          IsChecked="{Binding UseBlessedRain, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Misty Mirage (Increases evasion by 40%)"
+                                                          IsChecked="{Binding UseMistyMirage, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Hasty Mirage (Increases movement speed by 20%)"
+                                                          IsChecked="{Binding UseHastyMirage, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Use Aetherial Gain (Increases damage dealt by 10%)"
+                                                          IsChecked="{Binding UseAetherialGain, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <TextBlock Margin="5"
+                                                   Style="{DynamicResource TextBlockDefault}"
+                                                   TextWrapping="Wrap"
+                                                   FontStyle="Italic"
+                                                   Text="Weather effects are beneficial buffs that can only be cast in combat when available. All effects are applied to self and nearby party members."/>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
                 </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Bard Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Bard"/>
-
-                    <!-- Offensive Aria -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Offensive Aria (Damage buff - 70s duration)"
-                                  IsChecked="{Binding UseOffensiveAria, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <!-- Hero's Rime -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Hero's Rime (Party damage/healing +10% - 120s cooldown)"
-                                  IsChecked="{Binding UseHerosRime, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <!-- Mighty March -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Mighty March below"
-                                  IsChecked="{Binding UseMightyMarch, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding MightyMarchHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding MightyMarchCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <!-- Romeo's Ballad -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Romeo's Ballad"
-                                  IsChecked="{Binding UseRomeosBallad, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Use on Knowledge Crystal (Out of Combat)"
-                                  IsChecked="{Binding RomeosBallad_KnowledgeCrystal, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Knight Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Knight"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Phantom Guard"
-                                  IsChecked="{Binding UsePhantomGuard, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text="when HP below "
-                                   Margin="20,0,0,0"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding PhantomGuardHealthPercent, Mode=TwoWay}"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Pray (Regen effect)"
-                                  IsChecked="{Binding UsePray, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Use on Knowledge Crystal (Party buff)"
-                                  IsChecked="{Binding PrayKnowledgeCrystal, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text="Regen when HP below "
-                                   Margin="20,0,0,0"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding PrayHealthPercent, Mode=TwoWay}"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent"/>
-                    </StackPanel>
-
-                    <!-- Occult Heal -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Heal below"
-                                  IsChecked="{Binding UseOccultHeal, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding OccultHealHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding OccultHealCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <!-- Pledge -->
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Pledge below"
-                                  IsChecked="{Binding UsePledge, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding PledgeHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding PledgeCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Monk Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Monk"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Phantom Kick"
-                                  IsChecked="{Binding UsePhantomKick, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Only use in melee range"
-                                  IsChecked="{Binding PhantomKickMeleeRangeOnly, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use OccultCounter (Attack after parry)"
-                                  IsChecked="{Binding UseOccultCounter, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Counterstance (Parry rate buff)"
-                                  IsChecked="{Binding UseCounterstance, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Use on Knowledge Crystal (Movement speed)"
-                                  IsChecked="{Binding CounterstanceKnowledgeCrystal, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use OccultChakra below"
-                                  IsChecked="{Binding UseOccultChakra, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding OccultChakraHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                    </StackPanel>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Berserker Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Berserker"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Deadly Blow (High damage based on missing HP)"
-                                  IsChecked="{Binding UseDeadlyBlow, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Rage (Auto attack nearest enemy)"
-                                  IsChecked="{Binding UseRage, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Only use in melee range"
-                                  IsChecked="{Binding RageMeleeRangeOnly, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Chemist Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Chemist"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Revive (Resurrect dead party members)"
-                                  IsChecked="{Binding UseRevive, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Revive Out of Combat"
-                                  IsChecked="{Binding ReviveOutOfCombat, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text="Resurrection Delay: "/>
-                        <controls:Numeric MinValue="0"
-                                          MaxValue="10"
-                                          Value="{Binding ReviveDelay, Mode=TwoWay}"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" seconds"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Potion below"
-                                  IsChecked="{Binding UseOccultPotion, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding OccultPotionHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding OccultPotionCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" (100k gil/cast)"
-                                   Foreground="Red"
-                                   Margin="10,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Ether below"
-                                  IsChecked="{Binding UseOccultEther, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding OccultEtherManaPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent MP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding OccultEtherCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Elixir when"
-                                  IsChecked="{Binding UseOccultElixir, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding OccultElixirPartyHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent+ party members need help"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" (300k gil/cast)"
-                                   Foreground="Red"
-                                   Margin="10,0,0,0"/>
-                    </StackPanel>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Cannoneer Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Cannoneer"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Phantom Fire (Standard ranged attack)"
-                                  IsChecked="{Binding UsePhantomFire, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Holy Cannon (More damage vs undead)"
-                                  IsChecked="{Binding UseHolyCannon, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Use Silver Cannon (Damage debuff) - Mutually exclusive"
-                                  IsChecked="{Binding UseSilverCannon, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Dark Cannon (Inflicts blind)"
-                                  IsChecked="{Binding UseDarkCannon, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Use Shock Cannon (Inflicts paralysis) - Mutually exclusive"
-                                  IsChecked="{Binding UseShockCannon, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Grouped abilities share restrictions as noted."/>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Time Mage Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Time Mage"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Quick (Speed buff for cast/recast/movement)"
-                                  IsChecked="{Binding UseOccultQuick, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding OccultQuickCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Slowga (Inflicts Slow on enemies)"
-                                  IsChecked="{Binding UseOccultSlowga, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Mage Masher (Reduces enemy magic attack power)"
-                                  IsChecked="{Binding UseOccultMageMasher, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Dispel (Removes beneficial effects from enemies)"
-                                  IsChecked="{Binding UseOccultDispel, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Comet (AoE damage - 8s cast time)"
-                                  IsChecked="{Binding UseOccultComet, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Quick prioritizes casting party members. Comet has long cast time - use carefully."/>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Ranger Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Ranger"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Phantom Aim (Damage buff - 120s cooldown)"
-                                  IsChecked="{Binding UsePhantomAim, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Falcon (Area attack)"
-                                  IsChecked="{Binding UseOccultFalcon, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Unicorn below"
-                                  IsChecked="{Binding UseOccultUnicorn, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding OccultUnicornHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding OccultUnicornCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Unicorn creates 40k damage absorb barrier for entire party. Falcon triggers traps."/>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Thief Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Thief"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Occult Sprint (Greatly increases movement speed)"
-                                  IsChecked="{Binding UseOccultSprint, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Steal when enemy below"
-                                  IsChecked="{Binding UseSteal, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="50"
-                                          MinValue="1"
-                                          Value="{Binding StealHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP (increases item drop chance)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Vigilance within"
-                                  IsChecked="{Binding UseVigilance, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="50"
-                                          MinValue="3"
-                                          Value="{Binding VigilanceTargetDistance, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" yalms of target (Vigilance → Foreseen Offense when entering combat)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Pilfer Weapon (Lowers target's physical attack power by 10%)"
-                                  IsChecked="{Binding UsePilferWeapon, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Vigilance can only be cast out of combat with a valid target. Effect changes to Foreseen Offense (+60% crit rate) when entering combat."/>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Samurai Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Samurai"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Mineuchi stun with strategy:"
-                                  IsChecked="{Binding UseMineuchi, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <ComboBox ItemsSource="{Binding Source={StaticResource InterruptStrategy}}"
-                                  SelectedValue="{Binding MineuchiStrategy, Mode=TwoWay}"
-                                  Margin="5,0,0,0"
-                                  Width="120"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Shirahadori below"
-                                  IsChecked="{Binding UseShirahadori, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding ShirahadoriHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP (physical damage immunity for one attack)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Iainuki (Cone attack with instant kill chance)"
-                                  IsChecked="{Binding UseIainuki, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Zeninage (Consumes Occult Coffer for 1,500 potency)"
-                                  IsChecked="{Binding UseZeninage, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Mineuchi avoids stunning immune enemies. Zeninage only works when you have an Occult Coffer. Iainuki is a cone AoE attack."/>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Oracle Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Oracle"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Predict (Grants random prediction)"
-                                  IsChecked="{Binding UsePredict, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Foreground="Orange"
-                               Text="Predict cycles through 4 random predictions. Magitek will attempt to use the best prediction available as they cycle through. Only one can be used. Must cast something on 4th cycle to avoid False Prediction (deadly DoT)."/>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Foreground="Red"
-                               Text="⚠️ SAFETY: If Starfall is the 4rd prediction and you're below the Starfall threshold, the current prediction will be cast automatically to avoid being forced into deadly Starfall as the 4th prediction."/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Phantom Judgment when party below"
-                                  IsChecked="{Binding UsePhantomJudgment, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding PhantomJudgmentHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP (Damage + Healing)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Blessing when party below"
-                                  IsChecked="{Binding UseBlessing, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding BlessingHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP (Strong Healing + Regen)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Cleansing when party above"
-                                  IsChecked="{Binding UseCleansing, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding CleansingHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP (Damage + Freeze Time)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Starfall when above"
-                                  IsChecked="{Binding UseStarfall, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="90"
-                                          Value="{Binding StarfallHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP (90% max HP self damage!)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Phantom Rejuvenation below"
-                                  IsChecked="{Binding UsePhantomRejuvenation, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding PhantomRejuvenationHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding PhantomRejuvenationCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" (Prioritizes tanks)"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Invulnerability below"
-                                  IsChecked="{Binding UseInvulnerability, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="50"
-                                          MinValue="1"
-                                          Value="{Binding InvulnerabilityHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding InvulnerabilityCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" (Emergency protection)"/>
-                    </StackPanel>
-
-                </StackPanel>
-            </controls:SettingsBlock>
-
-            <!-- Phantom Geomancer Settings -->
-            <controls:SettingsBlock Margin="0,5"
-                                    Background="{DynamicResource ClassSelectorBackground}">
-                <StackPanel Margin="5">
-                    <TextBlock Style="{DynamicResource TextBlockSection}"
-                               Text="Phantom Geomancer"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Battle Bell (Damage boost that stacks when taking damage)"
-                                  IsChecked="{Binding UseBattleBell, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Battle Bell prioritizes tanks first (who take most damage), then self, then other party members. Only cast in combat."/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Ringing Respite (Heals target when they take damage)"
-                                  IsChecked="{Binding UseRingingRespite, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding RingingRespiteCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" (Prioritizes tanks)"
-                                   Margin="5,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Suspend"
-                                  IsChecked="{Binding UseSuspend, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <CheckBox Content="Suspend whole party"
-                                  IsChecked="{Binding SuspendCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Sunbath below"
-                                  IsChecked="{Binding UseSunbath, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                        <controls:Numeric MaxValue="100"
-                                          MinValue="1"
-                                          Value="{Binding SunbathHealthPercent, Mode=TwoWay}"
-                                          Margin="5,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" percent HP"/>
-                        <CheckBox Content="On Allies"
-                                  IsChecked="{Binding SunbathCastOnAllies, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"
-                                  Margin="20,0,0,0"/>
-                        <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                   Text=" (Restores HP)"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockSection}"
-                               Text="Weather Effects (Combat Only)"/>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Cloudy Caress (Increases healing potency by 30%)"
-                                  IsChecked="{Binding UseCloudyCaress, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Blessed Rain (Erects magical barrier which nullifies damage)"
-                                  IsChecked="{Binding UseBlessedRain, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Misty Mirage (Increases evasion by 40%)"
-                                  IsChecked="{Binding UseMistyMirage, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Hasty Mirage (Increases movement speed by 20%)"
-                                  IsChecked="{Binding UseHastyMirage, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <StackPanel Margin="5"
-                                Orientation="Horizontal">
-                        <CheckBox Content="Use Aetherial Gain (Increases damage dealt by 10%)"
-                                  IsChecked="{Binding UseAetherialGain, Mode=TwoWay}"
-                                  Style="{DynamicResource CheckBoxFlat}"/>
-                    </StackPanel>
-
-                    <TextBlock Margin="5"
-                               Style="{DynamicResource TextBlockDefault}"
-                               TextWrapping="Wrap"
-                               FontStyle="Italic"
-                               Text="Weather effects are beneficial buffs that can only be cast in combat when available. All effects are applied to self and nearby party members."/>
-                </StackPanel>
-            </controls:SettingsBlock>
-
-        </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
 </UserControl> 


### PR DESCRIPTION
Adds automatic knowledge crystal buff support. When you're near a knowledge crystal, Magitek will automatically switch to the right phantom job and cast powerful party buffs: Romeo's Ballad (xp buff), Enduring Fortitude (damage reduction), and Fleetfooted (movement speed). After casting buffs, it switches back to your original phantom job so you can continue playing normally. Includes smart cooldowns to prevent issues if you don't have the required spell levels yet.