### PR TITLE
Phantom Thief sprint & steal update. Ninja Dokumori on multi targets only option.

### DIFF
--- a/Magitek/Logic/Ninja/Cooldown.cs
+++ b/Magitek/Logic/Ninja/Cooldown.cs
@@ -26,7 +26,7 @@ namespace Magitek.Logic.Ninja
             if (Core.Me.OnOccultCrescent() && OccultCrescentSettings.Instance.UseDokumori)
             {
                 var nearbyEnemies = Combat.Enemies.Count();
-                if (nearbyEnemies >= 2)
+                if (nearbyEnemies >= 2 || !OccultCrescentSettings.Instance.DokumoriOnlyMultipleTargets)
                     return false;
             }
 

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -295,6 +295,10 @@ namespace Magitek.Models.OccultCrescent
 
         [Setting]
         [DefaultValue(true)]
+        public bool OccultSprintOnlyInCombat { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool UseSteal { get; set; }
 
         [Setting]
@@ -472,6 +476,10 @@ namespace Magitek.Models.OccultCrescent
         [Setting]
         [DefaultValue(7.0f)]
         public float DokumoriHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool DokumoriOnlyMultipleTargets { get; set; }
         #endregion
     }
 }

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -605,6 +605,14 @@
 
                                         <StackPanel Margin="5"
                                                     Orientation="Horizontal">
+                                                <CheckBox Content="Only use Occult Sprint in combat"
+                                                          IsChecked="{Binding OccultSprintOnlyInCombat, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
                                                 <CheckBox Content="Use Steal when enemy below"
                                                           IsChecked="{Binding UseSteal, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>
@@ -965,12 +973,20 @@
                                                            Text=" percent HP (AoE steal - increases item drop chance)"/>
                                         </StackPanel>
 
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="Only use Dokumori on multiple targets (2+ enemies)"
+                                                          IsChecked="{Binding DokumoriOnlyMultipleTargets, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
                                         <TextBlock Margin="5"
                                                    Style="{DynamicResource TextBlockDefault}"
                                                    TextWrapping="Wrap"
                                                    FontStyle="Italic"
                                                    Foreground="Gold"
-                                                   Text="Dokumori is an AoE steal ability for gold farming. Only uses gold farming mode with 2+ enemies - single target scenarios use normal rotation for ninki gauge benefits. Only works when playing as Ninja job."/>
+                                                   Text="Dokumori is an AoE steal ability for gold farming. Only uses gold farming mode with 2+ enemies - single target scenarios use normal rotation for ninki gauge benefits. Only works when playing as Ninja job. Enable 'multiple targets only' to save Dokumori cooldown for big AoE pulls."/>
                                 </StackPanel>
                         </controls:SettingsBlock>
 


### PR DESCRIPTION
Phantom Thief - Added setting to only use Occult Sprint in combat, now only casts when moving
Phantom Thief - Steal now automatically targets lowest HP enemy in range instead of requiring manual targeting
Ninja - Added setting to only use Dokumori on 2+ enemies for gold farming (preserves cooldown for big pulls) 