### PR TITLE
Fix healer alliance filters

### DIFF
--- a/Magitek/Utilities/Group.cs
+++ b/Magitek/Utilities/Group.cs
@@ -154,7 +154,7 @@ namespace Magitek.Utilities
                     var allianceToHeal = AllianceMembers.Where(a => !a.CanAttack && !a.HasAura(Auras.MountedPvp) && (
                                                                           HealAllianceDps && a.IsDps() ||
                                                                           HealAllianceTanks && a.IsTank() ||
-                                                                          HealAllianceHealers && a.IsDps()));
+                                                                          HealAllianceHealers && a.IsHealer()));
 
                     foreach (var ally in allianceToHeal)
                     {
@@ -168,7 +168,7 @@ namespace Magitek.Utilities
                     var allianceToRes = AllianceMembers.Where(a => a.CurrentHealth <= 0 &&
                                                                    (ResAllianceDps && a.IsDps() ||
                                                                     ResAllianceTanks && a.IsTank() ||
-                                                                    ResAllianceHealers && a.IsDps()));
+                                                                    ResAllianceHealers && a.IsHealer()));
                     foreach (var ally in allianceToRes)
                     {
                         CastableAlliance.Add(ally);


### PR DESCRIPTION
## Summary
- Fix alliance update logic that misidentified healers as DPS

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689635492a0c8330b82685469489314f