### PR TITLE
Fix Phoenix enum spelling

### DIFF
--- a/Magitek/Logic/Summoner/Aoe.cs
+++ b/Magitek/Logic/Summoner/Aoe.cs
@@ -30,7 +30,7 @@ namespace Magitek.Logic.Summoner
             if (Core.Me.SummonedPet() == SmnPets.SolarBahamut) return await Sunflare();
             if (ArcResources.TranceTimer > 0 && Core.Me.SummonedPet() == SmnPets.Carbuncle) return await Deathflare();
 
-            if (Core.Me.SummonedPet() == SmnPets.Pheonix) return await Rekindle();
+            if (Core.Me.SummonedPet() == SmnPets.Phoenix) return await Rekindle();
 
             if (!Spells.MountainBuster.IsKnown()) return false;
 
@@ -274,7 +274,7 @@ namespace Magitek.Logic.Summoner
 
             BattleCharacter target;
 
-            if (Core.Me.SummonedPet() == SmnPets.Pheonix)
+            if (Core.Me.SummonedPet() == SmnPets.Phoenix)
             {
                 target = Combat.SmartAoeTarget(Spells.BrandofPurgatory, SummonerSettings.Instance.SmartAoe);
 
@@ -353,7 +353,7 @@ namespace Magitek.Logic.Summoner
 
             if (Core.Me.SummonedPet() == SmnPets.Bahamut
                 || Core.Me.SummonedPet() == SmnPets.SolarBahamut
-                || Core.Me.SummonedPet() == SmnPets.Pheonix)
+                || Core.Me.SummonedPet() == SmnPets.Phoenix)
                 return false;
 
             if ((SmnResources.ActivePet == SmnResources.ActivePetType.Garuda

--- a/Magitek/Logic/Summoner/SingleTarget.cs
+++ b/Magitek/Logic/Summoner/SingleTarget.cs
@@ -20,7 +20,7 @@ namespace Magitek.Logic.Summoner
             if (!SummonerSettings.Instance.Ruin)
                 return false;
 
-            if (Core.Me.SummonedPet() == SmnPets.Pheonix)
+            if (Core.Me.SummonedPet() == SmnPets.Phoenix)
                 return await Spells.FountainofFire.Cast(Core.Me.CurrentTarget);
 
             if (Core.Me.SummonedPet() == SmnPets.Bahamut)
@@ -131,7 +131,7 @@ namespace Magitek.Logic.Summoner
 
             if (Core.Me.SummonedPet() == SmnPets.Bahamut) return await EnkindleBahamut();
             if (Core.Me.SummonedPet() == SmnPets.SolarBahamut) return await EnkindleSolarBahamut();
-            if (Core.Me.SummonedPet() == SmnPets.Pheonix) return await EnkindlePhoenix();
+            if (Core.Me.SummonedPet() == SmnPets.Phoenix) return await EnkindlePhoenix();
 
             return false;
         }

--- a/Magitek/Utilities/Routines/Summoner.cs
+++ b/Magitek/Utilities/Routines/Summoner.cs
@@ -37,7 +37,7 @@ namespace Magitek.Utilities.Routines
             Garuda,
             Bahamut,
             SolarBahamut,
-            Pheonix
+            Phoenix
         }
 
 
@@ -47,7 +47,7 @@ namespace Magitek.Utilities.Routines
                 return SmnPets.Bahamut;
 
             if ((int)PetManager.ActivePetType == 14)
-                return SmnPets.Pheonix;
+                return SmnPets.Phoenix;
 
             if ((int)PetManager.ActivePetType == 23)
                 return SmnPets.Carbuncle;


### PR DESCRIPTION
## Summary
- Correct Summoner enum value `Phoenix`
- Update Summoner logic to use `SmnPets.Phoenix`

## Testing
- `dotnet build Magitek/Magitek.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68963990c3848330a9900c62ec5f18aa