### PR TITLE
Use global CanWeave timing in Dark Knight rotation

### DIFF
--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -43,7 +43,7 @@ namespace Magitek.Rotations
             if (await Buff.Grit()) return true;
             if (await Tank.Interrupt(DarkKnightSettings.Instance)) return true;
 
-            if (DarkKnightRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.HardSlash.Cooldown.TotalMilliseconds > 650 + BaseSettings.Instance.UserLatencyOffset)
+            if (DarkKnightRoutine.GlobalCooldown.CanWeave())
             {
                 //Potion
                 if (await Buff.UsePotion()) return true;


### PR DESCRIPTION
## Summary
- replace hard-coded OGCD delay with GlobalCooldown.CanWeave in Dark Knight rotation

## Testing
- `dotnet build Magitek/Magitek.sln` (fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)


------
https://chatgpt.com/codex/tasks/task_e_689636721a4883308812b5db22eadb15