### PR TITLE
Use IAddonProxy<CombatRoutine> to asyncly load magitek

### DIFF
--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -178,7 +178,7 @@ namespace Magitek
 
 
         public override string Name => "Magitek";
-
+        public override bool WantButton => true;
         public override float PullRange { get; } = 25;
 
         public override ClassJobType[] Class

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -177,6 +177,7 @@ namespace Magitek
         }
 
 
+        public override CapabilityFlags SupportedCapabilities => CapabilityFlags.All;
         public override string Name => "Magitek";
         public override bool WantButton => true;
         public override float PullRange { get; } = 25;

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -177,7 +177,8 @@ namespace Magitek
         }
 
 
-        public override string Name { get; }
+        public override string Name => "Magitek";
+
         public override float PullRange { get; } = 25;
 
         public override ClassJobType[] Class

--- a/MagitekLoader/MagitekLoader.cs
+++ b/MagitekLoader/MagitekLoader.cs
@@ -35,7 +35,7 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
     
     private static string? _latestVersion;
 
-
+    private readonly HttpClient _client = new HttpClient();
     public async Task<CombatRoutine> Load(string directory)
     {
         currentDirectory = directory;
@@ -249,25 +249,15 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
         LoadProduct();
     }
 
-    private static async Task<string?> GetLatestVersion()
+    private  async Task<string?> GetLatestVersion()
     {
-        using var client = new HttpClient();
-        HttpResponseMessage response;
         try
         {
-            response = await client.GetAsync(VersionUrl);
-        }
-        catch (Exception e)
-        {
-            Log(e.Message);
-            return null;
-        }
+            var response = await _client.GetAsync(VersionUrl);
 
-        if (!response.IsSuccessStatusCode)
-            return null;
+            if (!response.IsSuccessStatusCode)
+                return null;
 
-        try
-        {
             return (await response.Content.ReadAsStringAsync()).Trim();
         }
         catch (Exception e)
@@ -350,34 +340,21 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
         return true;
     }
 
-    private static async Task<byte[]?> DownloadLatestVersion()
+    private async Task<byte[]?> DownloadLatestVersion()
     {
-        using var client = new HttpClient();
-        HttpResponseMessage response;
         try
         {
-            response = await client.GetAsync(ZipUrl);
+            var response = await _client.GetAsync(ZipUrl);
+
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            return await response.Content.ReadAsByteArrayAsync();
         }
         catch (Exception e)
         {
             Log(e.Message);
             return null;
         }
-
-        if (!response.IsSuccessStatusCode)
-            return null;
-
-        byte[] responseMessageBytes;
-        try
-        {
-            responseMessageBytes = await response.Content.ReadAsByteArrayAsync();
-        }
-        catch (Exception e)
-        {
-            Log(e.Message);
-            return null;
-        }
-
-        return responseMessageBytes;
     }
 }

--- a/MagitekLoader/MagitekLoader.cs
+++ b/MagitekLoader/MagitekLoader.cs
@@ -50,9 +50,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
         return Load();
     }
 
-
-    private static CombatRoutine? Product { get; set; }
-
     private void RedirectAssembly()
     {
         AppDomain.CurrentDomain.AssemblyResolve += Handler;
@@ -116,18 +113,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
         }
     }
 
-    private void LoadProduct()
-    {
-        if (Product != null) return;
-
-        Product = Load();
-
-        if (Product == null)
-        {
-            Log("Failed to load Magitek .");
-        }
-
-    }
 
     private static void Log(string message)
     {
@@ -159,7 +144,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
 
         if (local == _latestVersion || _latestVersion == null || (local != null && (local.StartsWith("pre-") || local.StartsWith("test-"))))
         {
-            LoadProduct();
             return;
         }
 
@@ -195,7 +179,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
 
         stopwatch.Stop();
         Log($"Update complete in {stopwatch.ElapsedMilliseconds} ms.");
-        LoadProduct();
     }
 
     private  async Task<string?> GetLatestVersion()


### PR DESCRIPTION
This changes the loader to use the IAddonProxy interface which allows a dll to be downloaded/loaded asyncly and then accept a CombatRoutine as a return. 

This has three benefits
1) It removes a layer of abstraction from RB and the executing code
2) The download/update can use await
3) the initial install can be any directory, the directory is passed into the loader function so we know where to load/download files

This was an extremely quick conversion and needs some more testing.

This will require the main assembly to be recompiled, as it currently does not define Name 
