### PR TITLE
Implement PvP Hold Burst System for all jobs & UI PVP updates & PVP MCH improvments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ __pycache__/
 VsCodeWorkspace.code-workspace
 
 .vscode/
+.cursor/
+.claude/
+AGENTS.md

--- a/Magitek/Controls/CurrentNews.xaml.cs
+++ b/Magitek/Controls/CurrentNews.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Controls;
+using Magitek.ViewModels;
 
 namespace Magitek.Controls
 {
@@ -7,6 +8,12 @@ namespace Magitek.Controls
         public CurrentNews()
         {
             InitializeComponent();
+            Loaded += CurrentNews_Loaded;
+        }
+
+        private void CurrentNews_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            MagitekApi.Instance.RefreshIfNeeded();
         }
     }
 }

--- a/Magitek/Converters/InvertedBooleanToVisibilityConverter.cs
+++ b/Magitek/Converters/InvertedBooleanToVisibilityConverter.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Magitek.Converters
+{
+    public sealed class InvertedBooleanToVisibilityConverter : BooleanConverter<Visibility>
+    {
+        public InvertedBooleanToVisibilityConverter() :
+            base(Visibility.Collapsed, Visibility.Visible)
+        { }
+    }
+}
+

--- a/Magitek/Logic/Machinist/Pvp.cs
+++ b/Magitek/Logic/Machinist/Pvp.cs
@@ -230,40 +230,41 @@ namespace Magitek.Logic.Machinist
                 return false;
 
             // Only cast Analysis right before using the primed abilities it buffs
-            // Check if each ability is ready to cast (using spell CanCast and basic range checks)
+            // Since Analysis is an oGCD, we can prep it even if the primed ability can't be cast this instant
+            // Check if ability is ready within one GCD window (similar to PvE Reassemble logic)
             bool shouldCast = false;
 
-            // Drill - check if primed, enabled, and ready to use
+            // Drill - check if primed, enabled, ready within GCD window, and target in range
             if (MachinistSettings.Instance.Pvp_UsedAnalysisOnDrill &&
                 Core.Me.HasAura(Auras.PvpDrillPrimed) &&
-                Spells.DrillPvp.CanCast() &&
+                Spells.DrillPvp.IsKnownAndReady((int)Spells.BlastChargePvp.Cooldown.TotalMilliseconds - 100) &&
                 Core.Me.CurrentTarget.WithinSpellRange(Spells.DrillPvp.Range))
             {
                 shouldCast = true;
             }
 
-            // Bio Blaster - check if primed, enabled, and ready to use
+            // Bio Blaster - check if primed, enabled, ready within GCD window, and target in range
             if (MachinistSettings.Instance.Pvp_UsedAnalysisOnBio &&
                 Core.Me.HasAura(Auras.PvpBioPrimed) &&
-                Spells.BioblasterPvp.CanCast() &&
+                Spells.BioblasterPvp.IsKnownAndReady((int)Spells.BlastChargePvp.Cooldown.TotalMilliseconds - 100) &&
                 Core.Me.CurrentTarget.WithinSpellRange(Spells.BioblasterPvp.Range))
             {
                 shouldCast = true;
             }
 
-            // Air Anchor - check if primed, enabled, and ready to use
+            // Air Anchor - check if primed, enabled, ready within GCD window, and target in range
             if (MachinistSettings.Instance.Pvp_UsedAnalysisOnAA &&
                 Core.Me.HasAura(Auras.PvpAirAnchorPrimed) &&
-                Spells.AirAnchorPvp.CanCast() &&
+                Spells.AirAnchorPvp.IsKnownAndReady((int)Spells.BlastChargePvp.Cooldown.TotalMilliseconds - 100) &&
                 Core.Me.CurrentTarget.WithinSpellRange(Spells.AirAnchorPvp.Range))
             {
                 shouldCast = true;
             }
 
-            // Chain Saw - check if primed, enabled, and ready to use
+            // Chain Saw - check if primed, enabled, ready within GCD window, and target in range
             if (MachinistSettings.Instance.Pvp_UsedAnalysisOnChainSaw &&
                 Core.Me.HasAura(Auras.PvpChainSawPrimed) &&
-                Spells.ChainSawPvp.CanCast() &&
+                Spells.ChainSawPvp.IsKnownAndReady((int)Spells.BlastChargePvp.Cooldown.TotalMilliseconds - 100) &&
                 Core.Me.CurrentTarget.WithinSpellRange(Spells.ChainSawPvp.Range))
             {
                 shouldCast = true;

--- a/Magitek/Logic/Paladin/Pvp.cs
+++ b/Magitek/Logic/Paladin/Pvp.cs
@@ -1,5 +1,6 @@
 using ff14bot;
 using Magitek.Extensions;
+using Magitek.Models.Account;
 using Magitek.Models.Paladin;
 using Magitek.Utilities;
 using System.Linq;
@@ -9,7 +10,6 @@ namespace Magitek.Logic.Paladin
 {
     internal static class Pvp
     {
-
         public static async Task<bool> FastBladePvp()
         {
             if (Core.Me.HasAura(Auras.PvpGuard))

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -340,6 +340,21 @@ namespace Magitek.Logic.Roles
                 || (checkInvuln && settings.Pvp_InvulnCheck && target.HasAnyAura(new uint[] { Auras.PvpHallowedGround, Auras.PvpUndeadRedemption }));
         }
 
+        public static bool ShouldUseBurst()
+        {
+            // Check global "Hold Burst" toggle
+            if (Models.Account.BaseSettings.Instance.HoldPvpBurst)
+                return false;
+
+            // Check if target is Warmachina and global setting says don't burst on them
+            if (Core.Me.CurrentTarget != null &&
+                Core.Me.CurrentTarget.IsWarMachina() &&
+                !Models.Account.BaseSettings.Instance.PvpUseBurstOnWarmachina)
+                return false;
+
+            return true;
+        }
+
         public static async Task<bool> Purify<T>(T settings) where T : JobSettings
         {
             if (!settings.Pvp_UsePurify)

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -156,7 +156,7 @@ namespace Magitek.Logic.Roles
 
         public static async Task<bool> Sprint<T>(T settings) where T : JobSettings
         {
-            if (!settings.Pvp_SprintWithoutTarget)
+            if (!Models.Account.BaseSettings.Instance.Pvp_SprintWithoutTarget)
                 return false;
 
             if (!MovementManager.IsMoving)
@@ -189,7 +189,7 @@ namespace Magitek.Logic.Roles
 
         public static async Task<bool> Mount<T>(T settings) where T : JobSettings
         {
-            if (!settings.Pvp_UseMount)
+            if (!Models.Account.BaseSettings.Instance.Pvp_UseMount)
                 return false;
 
             if (Core.Me.HasAnyAura(Auras.Invincibility) && !MovementManager.IsMoving)
@@ -336,20 +336,20 @@ namespace Magitek.Logic.Roles
                 return true;
 
             return !Attackable(target)
-                || (checkGuard && settings.Pvp_GuardCheck && target.HasAura(Auras.PvpGuard))
-                || (checkInvuln && settings.Pvp_InvulnCheck && target.HasAnyAura(new uint[] { Auras.PvpHallowedGround, Auras.PvpUndeadRedemption }));
+                || (checkGuard && Models.Account.BaseSettings.Instance.Pvp_GuardCheck && target.HasAura(Auras.PvpGuard))
+                || (checkInvuln && Models.Account.BaseSettings.Instance.Pvp_InvulnCheck && target.HasAnyAura(new uint[] { Auras.PvpHallowedGround, Auras.PvpUndeadRedemption }));
         }
 
         public static bool ShouldUseBurst()
         {
             // Check global "Hold Burst" toggle
-            if (Models.Account.BaseSettings.Instance.HoldPvpBurst)
+            if (Models.Account.BaseSettings.Instance.Pvp_HoldBurst)
                 return false;
 
             // Check if target is Warmachina and global setting says don't burst on them
             if (Core.Me.CurrentTarget != null &&
                 Core.Me.CurrentTarget.IsWarMachina() &&
-                !Models.Account.BaseSettings.Instance.PvpUseBurstOnWarmachina)
+                !Models.Account.BaseSettings.Instance.Pvp_UseBurstOnWarmachina)
                 return false;
 
             return true;

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -475,22 +475,22 @@ namespace Magitek
             HotkeyManager.Unregister("MagitekHoldPvpBurst");
 
             // Check if we have a key set
-            if (Models.Account.BaseSettings.Instance.HoldPvpBurstKey == Keys.None &&
-                Models.Account.BaseSettings.Instance.HoldPvpBurstModkey == ModifierKeys.None)
+            if (Models.Account.BaseSettings.Instance.Pvp_HoldBurstKey == Keys.None &&
+                Models.Account.BaseSettings.Instance.Pvp_HoldBurstModkey == ModifierKeys.None)
                 return;
 
             // Register the hotkey
             HotkeyManager.Register("MagitekHoldPvpBurst",
-                Models.Account.BaseSettings.Instance.HoldPvpBurstKey,
-                Models.Account.BaseSettings.Instance.HoldPvpBurstModkey,
+                Models.Account.BaseSettings.Instance.Pvp_HoldBurstKey,
+                Models.Account.BaseSettings.Instance.Pvp_HoldBurstModkey,
                 r =>
                 {
-                    // Toggle the HoldPvpBurst boolean
-                    Models.Account.BaseSettings.Instance.HoldPvpBurst = !Models.Account.BaseSettings.Instance.HoldPvpBurst;
-                    Logger.WriteInfo($@"[Hotkey] Hold PvP Burst: {Models.Account.BaseSettings.Instance.HoldPvpBurst}");
+                    // Toggle the Pvp_HoldBurst boolean
+                    Models.Account.BaseSettings.Instance.Pvp_HoldBurst = !Models.Account.BaseSettings.Instance.Pvp_HoldBurst;
+                    Logger.WriteInfo($@"[Hotkey] Hold PvP Burst: {Models.Account.BaseSettings.Instance.Pvp_HoldBurst}");
                 });
 
-            Logger.WriteInfo($@"[Hotkeys] Registered Hold PvP Burst hotkey: {Models.Account.BaseSettings.Instance.HoldPvpBurstModkey} + {Models.Account.BaseSettings.Instance.HoldPvpBurstKey}");
+            Logger.WriteInfo($@"[Hotkeys] Registered Hold PvP Burst hotkey: {Models.Account.BaseSettings.Instance.Pvp_HoldBurstModkey} + {Models.Account.BaseSettings.Instance.Pvp_HoldBurstKey}");
         }
 
         private void UnregisterAllMagitekHotkeys()

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -67,6 +67,7 @@ namespace Magitek
             TogglesManager.LoadTogglesForCurrentJob();
             RegisterOpenerHotkey();
             RegisterResetOpenerHotkey();
+            RegisterHoldPvpBurstHotkey();
             CombatMessageManager.RegisterMessageStrategiesForClass(Core.Me.CurrentJob);
             Logger.WriteInfo("Initialized");
         }
@@ -110,6 +111,8 @@ namespace Magitek
                     RegisterOpenerHotkey();
                     // Register reset opener hotkey
                     RegisterResetOpenerHotkey();
+                    // Register hold PvP burst hotkey
+                    RegisterHoldPvpBurstHotkey();
                 });
 
                 HookBehaviors();
@@ -141,6 +144,8 @@ namespace Magitek
                     RegisterOpenerHotkey();
                     // Register reset opener hotkey
                     RegisterResetOpenerHotkey();
+                    // Register hold PvP burst hotkey
+                    RegisterHoldPvpBurstHotkey();
                 });
             }
 
@@ -462,6 +467,30 @@ namespace Magitek
                 });
 
             Logger.WriteInfo($@"[Hotkeys] Registered reset opener hotkey: {Models.Account.BaseSettings.Instance.ResetOpenersModkey} + {Models.Account.BaseSettings.Instance.ResetOpenersKey}");
+        }
+
+        public static void RegisterHoldPvpBurstHotkey()
+        {
+            // Unregister first to prevent duplicates
+            HotkeyManager.Unregister("MagitekHoldPvpBurst");
+
+            // Check if we have a key set
+            if (Models.Account.BaseSettings.Instance.HoldPvpBurstKey == Keys.None &&
+                Models.Account.BaseSettings.Instance.HoldPvpBurstModkey == ModifierKeys.None)
+                return;
+
+            // Register the hotkey
+            HotkeyManager.Register("MagitekHoldPvpBurst",
+                Models.Account.BaseSettings.Instance.HoldPvpBurstKey,
+                Models.Account.BaseSettings.Instance.HoldPvpBurstModkey,
+                r =>
+                {
+                    // Toggle the HoldPvpBurst boolean
+                    Models.Account.BaseSettings.Instance.HoldPvpBurst = !Models.Account.BaseSettings.Instance.HoldPvpBurst;
+                    Logger.WriteInfo($@"[Hotkey] Hold PvP Burst: {Models.Account.BaseSettings.Instance.HoldPvpBurst}");
+                });
+
+            Logger.WriteInfo($@"[Hotkeys] Registered Hold PvP Burst hotkey: {Models.Account.BaseSettings.Instance.HoldPvpBurstModkey} + {Models.Account.BaseSettings.Instance.HoldPvpBurstKey}");
         }
 
         private void UnregisterAllMagitekHotkeys()

--- a/Magitek/Models/Account/BaseSettings.cs
+++ b/Magitek/Models/Account/BaseSettings.cs
@@ -344,19 +344,36 @@ namespace Magitek.Models.Account
         #region PvP
         [Setting]
         [DefaultValue(false)]
-        public bool HoldPvpBurst { get; set; }
+        public bool Pvp_HoldBurst { get; set; }
 
         [Setting]
         [DefaultValue(Keys.None)]
-        public Keys HoldPvpBurstKey { get; set; }
+        public Keys Pvp_HoldBurstKey { get; set; }
 
         [Setting]
         [DefaultValue(ModifierKeys.None)]
-        public ModifierKeys HoldPvpBurstModkey { get; set; }
+        public ModifierKeys Pvp_HoldBurstModkey { get; set; }
 
         [Setting]
         [DefaultValue(false)]
-        public bool PvpUseBurstOnWarmachina { get; set; }
+        public bool Pvp_UseBurstOnWarmachina { get; set; }
+
+        // Global Utilities (will be displayed in Global PVP section)
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_GuardCheck { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_InvulnCheck { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_SprintWithoutTarget { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_UseMount { get; set; }
         #endregion
 
         [Setting]

--- a/Magitek/Models/Account/BaseSettings.cs
+++ b/Magitek/Models/Account/BaseSettings.cs
@@ -341,6 +341,24 @@ namespace Magitek.Models.Account
         public bool ForceLimitBreak { get; set; }
         #endregion
 
+        #region PvP
+        [Setting]
+        [DefaultValue(false)]
+        public bool HoldPvpBurst { get; set; }
+
+        [Setting]
+        [DefaultValue(Keys.None)]
+        public Keys HoldPvpBurstKey { get; set; }
+
+        [Setting]
+        [DefaultValue(ModifierKeys.None)]
+        public ModifierKeys HoldPvpBurstModkey { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool PvpUseBurstOnWarmachina { get; set; }
+        #endregion
+
         [Setting]
         [DefaultValue(false)]
         public bool AssumeFaceTargetOnAction { get; set; }

--- a/Magitek/Models/Machinist/MachinistSettings.cs
+++ b/Magitek/Models/Machinist/MachinistSettings.cs
@@ -193,6 +193,10 @@ namespace Magitek.Models.Machinist
 
         [Setting]
         [DefaultValue(true)]
+        public bool Pvp_ScattergunTargetClosest { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool Pvp_BishopAutoturret { get; set; }
 
         [Setting]

--- a/Magitek/Models/Roles/JobSettings.cs
+++ b/Magitek/Models/Roles/JobSettings.cs
@@ -24,6 +24,19 @@ namespace Magitek.Models.Roles
         #endregion
 
         #region pvp
+        // Per-job Utilities (displayed in each job's PVP Utilities section)
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_UsePurify { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_AutoGuardMarksmanSpite { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool Pvp_UseRoleActions { get; set; }
+
         [Setting]
         [DefaultValue(true)]
         public bool Pvp_UseRecuperate { get; set; }
@@ -34,43 +47,11 @@ namespace Magitek.Models.Roles
 
         [Setting]
         [DefaultValue(true)]
-        public bool Pvp_UsePurify { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
         public bool Pvp_UseGuard { get; set; }
 
         [Setting]
         [DefaultValue(40.0f)]
         public float Pvp_GuardHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_AutoGuardMarksmanSpite { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_GuardCheck { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_InvulnCheck { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_SprintWithoutTarget { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_UseMount { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_AutoDismount { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_UseRoleActions { get; set; }
 
         [Setting]
         [DefaultValue(7)]

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -5344,7 +5344,7 @@ namespace Magitek.Properties
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Dont Attack Guard.
+        ///   Looks up a localized string similar to Don't Attack Guard.
         /// </summary>
         public static string Generic_Dont_Attack_Guard
         {
@@ -7280,7 +7280,7 @@ namespace Magitek.Properties
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Sprint Without Target.
+        ///   Looks up a localized string similar to Auto Sprint (Will sprint without target / running away).
         /// </summary>
         public static string Generic_Sprint_Without_Target
         {
@@ -7566,7 +7566,7 @@ namespace Magitek.Properties
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Use Mount.
+        ///   Looks up a localized string similar to Auto Mount (Will attempt to mount / dismount when safe).
         /// </summary>
         public static string Generic_Use_Mount
         {
@@ -7617,6 +7617,17 @@ namespace Magitek.Properties
             get
             {
                 return ResourceManager.GetString("Generic_Use_Potion", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use Role Actions.
+        /// </summary>
+        public static string Generic_Use_Role_Actions
+        {
+            get
+            {
+                return ResourceManager.GetString("Generic_Use_Role_Actions", resourceCulture);
             }
         }
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -8577,6 +8577,14 @@ namespace Magitek.Properties
             }
         }
 
+        public static string Machinist_Content_Scattergun_Target_Closest
+        {
+            get
+            {
+                return ResourceManager.GetString("Machinist_Content_Scattergun_Target_Closest", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Split Shot Combo.
         /// </summary>
@@ -8728,6 +8736,14 @@ namespace Magitek.Properties
             get
             {
                 return ResourceManager.GetString("Machinist_ToolTip_If_enabled_will_save_Full_Metal_", resourceCulture);
+            }
+        }
+
+        public static string Machinist_ToolTip_Scattergun_Will_target_closest
+        {
+            get
+            {
+                return ResourceManager.GetString("Machinist_ToolTip_Scattergun_Will_target_closest", resourceCulture);
             }
         }
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -6884,6 +6884,17 @@ namespace Magitek.Properties
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Use Burst on Warmachina.
+        /// </summary>
+        public static string Generic_PvpUseBurstOnWarmachina
+        {
+            get
+            {
+                return ResourceManager.GetString("Generic_PvpUseBurstOnWarmachina", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Rdm.
         /// </summary>
         public static string Generic_Rdm
@@ -7749,6 +7760,72 @@ namespace Magitek.Properties
             get
             {
                 return ResourceManager.GetString("Generic_Yalms_Away", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Configure a hotkey to manually hold burst abilities in PvP. When active, burst cooldowns are saved and only basic attacks will be used.
+        /// </summary>
+        public static string GlobalPvp_Text_Hold_Burst_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("GlobalPvp_Text_Hold_Burst_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hold Burst Settings.
+        /// </summary>
+        public static string GlobalPvp_Text_Hold_Burst_Settings
+        {
+            get
+            {
+                return ResourceManager.GetString("GlobalPvp_Text_Hold_Burst_Settings", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Note: The 'Hold PVP Burst' toggle also appears in the main settings overlay when PVP mode is active, and can be toggled manually there as well.
+        /// </summary>
+        public static string GlobalPvp_Text_Hold_Burst_Overlay_Note
+        {
+            get
+            {
+                return ResourceManager.GetString("GlobalPvp_Text_Hold_Burst_Overlay_Note", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hold Burst Hotkey.
+        /// </summary>
+        public static string GlobalPvp_Text_Hold_Burst_Hotkey_Label
+        {
+            get
+            {
+                return ResourceManager.GetString("GlobalPvp_Text_Hold_Burst_Hotkey_Label", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hotkey:.
+        /// </summary>
+        public static string GlobalPvp_Text_Hotkey
+        {
+            get
+            {
+                return ResourceManager.GetString("GlobalPvp_Text_Hotkey", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Warmachina are NPCs in PvP (Ravens, Falcons, Striking Dummies, Icebound Tomeliths, etc.). By default, burst abilities are saved when targeting them. Enable the checkbox above to allow burst on Warmachina.
+        /// </summary>
+        public static string GlobalPvp_Text_Warmachina_Description
+        {
+            get
+            {
+                return ResourceManager.GetString("GlobalPvp_Text_Warmachina_Description", resourceCulture);
             }
         }
 
@@ -16117,6 +16194,17 @@ namespace Magitek.Properties
             get
             {
                 return ResourceManager.GetString("UserControls_Content_Execute_LimitBreak", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hold PVP Burst.
+        /// </summary>
+        public static string UserControls_Content_Hold_PVP_Burst
+        {
+            get
+            {
+                return ResourceManager.GetString("UserControls_Content_Hold_PVP_Burst", resourceCulture);
             }
         }
 

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -1574,6 +1574,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Machinist_ToolTip_If_enabled_will_save_Full_Metal_" xml:space="preserve">
     <value>If enabled, will save Full Metal Field when Wildfire is about to come off cooldown</value>
   </data>
+  <data name="Machinist_ToolTip_Scattergun_Will_target_closest" xml:space="preserve">
+    <value>If enabled, Scattergun will target the closest enemy within range instead of current target (defensive use)</value>
+  </data>
   <data name="Machinist_Content_Split_Shot_Combo" xml:space="preserve">
     <value>Split Shot Combo</value>
   </data>
@@ -4619,6 +4622,9 @@ Does not work if Lightspeed is disabled.</value>
   </data>
   <data name="Machinist_Content_Scattergun" xml:space="preserve">
     <value>Scattergun</value>
+  </data>
+  <data name="Machinist_Content_Scattergun_Target_Closest" xml:space="preserve">
+    <value>Target Closest Enemy</value>
   </data>
   <data name="Machinist_Content_BioBlaster" xml:space="preserve">
     <value>BioBlaster</value>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -3921,10 +3921,13 @@ Does not work if Lightspeed is disabled.</value>
     <value>Allies Need Healing</value>
   </data>
   <data name="Generic_Sprint_Without_Target" xml:space="preserve">
-    <value>Sprint Without Target</value>
+    <value>Auto Sprint (Will sprint without target / running away)</value>
   </data>
   <data name="Generic_Use_Mount" xml:space="preserve">
-    <value>Use Mount</value>
+    <value>Auto Mount (Will attempt to mount / dismount when safe)</value>
+  </data>
+  <data name="Generic_Use_Role_Actions" xml:space="preserve">
+    <value>Use Role Actions</value>
   </data>
   <data name="Generic_When_There_Are" xml:space="preserve">
     <value>When There Are</value>
@@ -4023,7 +4026,7 @@ Does not work if Lightspeed is disabled.</value>
     <value>Out Of Combat</value>
   </data>
   <data name="Generic_Dont_Attack_Guard" xml:space="preserve">
-    <value>Dont Attack Guard</value>
+    <value>Don't Attack Guard</value>
   </data>
   <data name="Generic_Dont_Attack_Invuln_Hallowed_Groundund" xml:space="preserve">
     <value>Dont Attack Invuln Hallowed Groundund</value>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -423,6 +423,24 @@
   <data name="Views_Text_NoClippyXivAlexander_simulate_a_10ms_pi" xml:space="preserve">
     <value>NoClippy/XivAlexander simulate a 10ms ping</value>
   </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Settings" xml:space="preserve">
+    <value>Hold Burst Settings</value>
+  </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Hotkey_Label" xml:space="preserve">
+    <value>Hold Burst Hotkey</value>
+  </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Description" xml:space="preserve">
+    <value>Configure a hotkey to manually hold burst abilities in PvP. When active, burst cooldowns are saved and only basic attacks will be used.</value>
+  </data>
+  <data name="GlobalPvp_Text_Hotkey" xml:space="preserve">
+    <value>Hotkey:</value>
+  </data>
+  <data name="GlobalPvp_Text_Warmachina_Description" xml:space="preserve">
+    <value>Warmachina are NPCs in PvP (Ravens, Falcons, Striking Dummies, Icebound Tomeliths, etc.). By default, burst abilities are saved when targeting them. Enable the checkbox above to allow burst on Warmachina.</value>
+  </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Overlay_Note" xml:space="preserve">
+    <value>Note: The 'Hold PVP Burst' toggle also appears in the main settings overlay when PVP mode is active, and can be toggled manually there as well.</value>
+  </data>
   <data name="Views_Text_Overlay_Settings" xml:space="preserve">
     <value>Overlay Settings</value>
   </data>
@@ -518,6 +536,9 @@
   </data>
   <data name="UserControls_Content_Execute_LimitBreak" xml:space="preserve">
     <value>Execute LimitBreak</value>
+  </data>
+  <data name="UserControls_Content_Hold_PVP_Burst" xml:space="preserve">
+    <value>Hold PVP Burst</value>
   </data>
   <data name="Astrologian_Content_Heal_Alliance_DPS" xml:space="preserve">
     <value>Heal Alliance DPS</value>
@@ -4229,6 +4250,9 @@ Does not work if Lightspeed is disabled.</value>
   </data>
   <data name="Generic_Pvp" xml:space="preserve">
     <value>Pvp</value>
+  </data>
+  <data name="Generic_PvpUseBurstOnWarmachina" xml:space="preserve">
+    <value>Use Burst on Warmachina</value>
   </data>
   <data name="Generic_Toggles" xml:space="preserve">
     <value>Toggles</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -1569,6 +1569,9 @@
   <data name="Machinist_ToolTip_If_enabled_will_save_Full_Metal_" xml:space="preserve">
     <value>如果启用，当 野火 即将冷却完毕时，会保留全金属领域</value>
   </data>
+  <data name="Machinist_ToolTip_Scattergun_Will_target_closest" xml:space="preserve">
+    <value>如果启用，霰弹枪将目标最近的敌人而不是当前目标（防御性使用）</value>
+  </data>
   <data name="Machinist_Content_Split_Shot_Combo" xml:space="preserve">
     <value>分裂弹连击</value>
   </data>
@@ -4613,6 +4616,9 @@
   </data>
   <data name="Machinist_Content_Scattergun" xml:space="preserve">
     <value>霰弹枪</value>
+  </data>
+  <data name="Machinist_Content_Scattergun_Target_Closest" xml:space="preserve">
+    <value>目标最近的敌人</value>
   </data>
   <data name="Machinist_Content_BioBlaster" xml:space="preserve">
     <value>毒菌冲击</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -3916,10 +3916,13 @@
     <value>队友需要治疗</value>
   </data>
   <data name="Generic_Sprint_Without_Target" xml:space="preserve">
-    <value>无目标时使用 冲刺</value>
+    <value>自动疾跑（无目标/逃跑时疾跑）</value>
   </data>
   <data name="Generic_Use_Mount" xml:space="preserve">
-    <value>使用坐骑</value>
+    <value>自动坐骑（安全时自动上/下坐骑）</value>
+  </data>
+  <data name="Generic_Use_Role_Actions" xml:space="preserve">
+    <value>使用职能技能</value>
   </data>
   <data name="Generic_When_There_Are" xml:space="preserve">
     <value>当有[xx]时</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -423,6 +423,24 @@
   <data name="Views_Text_NoClippyXivAlexander_simulate_a_10ms_pi" xml:space="preserve">
     <value>模拟10毫秒的延迟</value>
   </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Settings" xml:space="preserve">
+    <value>保留爆发技能设置</value>
+  </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Hotkey_Label" xml:space="preserve">
+    <value>保留爆发技能热键</value>
+  </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Description" xml:space="preserve">
+    <value>配置一个热键以在PVP中手动保留爆发技能。启用时，将保存爆发冷却技能，只使用基础攻击。</value>
+  </data>
+  <data name="GlobalPvp_Text_Hotkey" xml:space="preserve">
+    <value>热键：</value>
+  </data>
+  <data name="GlobalPvp_Text_Warmachina_Description" xml:space="preserve">
+    <value>战斗机甲是PVP中的NPC（乌鸦、猎鹰、木人、冰缚碑文等）。默认情况下，瞄准它们时会保留爆发技能。启用上方复选框以允许对战斗机甲使用爆发技能。</value>
+  </data>
+  <data name="GlobalPvp_Text_Hold_Burst_Overlay_Note" xml:space="preserve">
+    <value>注意：当PVP模式激活时，"保留PVP爆发技能"切换选项也会出现在主设置悬浮窗中，可以在那里手动切换。</value>
+  </data>
   <data name="Views_Text_Overlay_Settings" xml:space="preserve">
     <value>悬浮窗设置</value>
   </data>
@@ -518,6 +536,9 @@
   </data>
   <data name="UserControls_Content_Execute_LimitBreak" xml:space="preserve">
     <value>使用极限技</value>
+  </data>
+  <data name="UserControls_Content_Hold_PVP_Burst" xml:space="preserve">
+    <value>保留PVP爆发技能</value>
   </data>
   <data name="Astrologian_Content_Heal_Alliance_DPS" xml:space="preserve">
     <value>治疗友方输出</value>
@@ -4223,6 +4244,9 @@
   </data>
   <data name="Generic_Pvp" xml:space="preserve">
     <value>PVP</value>
+  </data>
+  <data name="Generic_PvpUseBurstOnWarmachina" xml:space="preserve">
+    <value>对战斗机甲使用爆发技能</value>
   </data>
   <data name="Generic_Toggles" xml:space="preserve">
     <value>切换选项</value>

--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -185,18 +185,24 @@ namespace Magitek.Rotations
             if (await CommonPvp.CommonTasks(AstrologianSettings.Instance)) return true;
 
             // Limit Break
-            if (await Pvp.CelestialRiverPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.CelestialRiverPvp()) return true;
+            }
 
             // Healing
             if (await Pvp.MacrocosmosPvp()) return true;
             if (await Pvp.AspectedBeneficPvp()) return true;
 
             // Special Actions
-            if (await Pvp.MinorArcanaPvp()) return true;
-            if (await Pvp.OraclePvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.MinorArcanaPvp()) return true;
+                if (await Pvp.OraclePvp()) return true;
+            }
 
             // Damage
-            if (!CommonPvp.GuardCheck(AstrologianSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(AstrologianSettings.Instance))
             {
                 if (await Pvp.DoubleCastPvp()) return true;
                 if (await Pvp.GravityIIPvp()) return true;

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -104,12 +104,15 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(BardSettings.Instance)) return true;
 
-            if (await Pvp.EncoreOfLight()) return true;
-            if (await Pvp.FinalFantasiaPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.EncoreOfLight()) return true;
+                if (await Pvp.FinalFantasiaPvp()) return true;
 
-            if (await Pvp.HarmonicArrow()) return true;
+                if (await Pvp.HarmonicArrow()) return true;
+            }
 
-            if (!CommonPvp.GuardCheck(BardSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(BardSettings.Instance))
             {
                 if (await Pvp.SilentNocturnePvp()) return true;
 
@@ -120,7 +123,11 @@ namespace Magitek.Rotations
                 if (await Pvp.ApexArrow()) return true;
             }
 
-            if (await Pvp.PitchPerfect()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.PitchPerfect()) return true;
+            }
+
             return (await Pvp.PowerfulShot());
         }
     }

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -102,12 +102,18 @@ namespace Magitek.Rotations
             if (await CommonPvp.CommonTasks(BlackMageSettings.Instance)) return true;
 
             // Limit Break
-            if (await Pvp.SoulResonancePvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.SoulResonancePvp()) return true;
+            }
 
             // Elemental Weave
-            if (await Pvp.ElementalWeave()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.ElementalWeave()) return true;
+            }
 
-            if (!CommonPvp.GuardCheck(BlackMageSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(BlackMageSettings.Instance))
             {
                 // Utility actions
                 if (await Pvp.Lethargy()) return true;
@@ -117,7 +123,7 @@ namespace Magitek.Rotations
                 if (await Pvp.Xenoglossy()) return true;
             }
 
-            // AoE and basic attacks
+            // AoE and basic attacks (ungated)
             if (await Pvp.Burst()) return true;
             if (await Pvp.Fire()) return true;
             if (await Pvp.Blizzard()) return true;

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -117,12 +117,19 @@ namespace Magitek.Rotations
             if (await CommonPvp.CommonTasks(DancerSettings.Instance)) return true;
 
             if (await Pvp.CuringWaltz()) return true;
-            if (await Pvp.EnAvant()) return true;
+
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.EnAvant()) return true;
+            }
 
             //LB
-            if (await Pvp.Contradance()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.Contradance()) return true;
+            }
 
-            if (!CommonPvp.GuardCheck(DancerSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(DancerSettings.Instance))
             {
                 //oGCD
                 if (await Pvp.HoningDance()) return true;

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -85,19 +85,24 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(DarkKnightSettings.Instance)) return true;
 
-            if (await Pvp.EventidePvp()) return true;
-            if (await Pvp.SaltAndDarkness()) return true;
-            if (await Pvp.BlackestNightPvp()) return true;
-            if (await Pvp.SaltedEarthPvp()) return true;
-
-            if (!CommonPvp.GuardCheck(DarkKnightSettings.Instance))
+            // BURST CHECK: Wrap everything except basic combo
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.PlungePvp()) return true;
-                if (await Pvp.ShadowbringerPvp()) return true;
-                if (await Pvp.ImpalementPvp()) return true;
-                if (await Pvp.DisesteemPvp()) return true;
+                if (await Pvp.EventidePvp()) return true;
+                if (await Pvp.SaltAndDarkness()) return true;
+                if (await Pvp.BlackestNightPvp()) return true;
+                if (await Pvp.SaltedEarthPvp()) return true;
+
+                if (!CommonPvp.GuardCheck(DarkKnightSettings.Instance))
+                {
+                    if (await Pvp.PlungePvp()) return true;
+                    if (await Pvp.ShadowbringerPvp()) return true;
+                    if (await Pvp.ImpalementPvp()) return true;
+                    if (await Pvp.DisesteemPvp()) return true;
+                }
             }
 
+            // Basic Combo (ungated)
             if (await Pvp.SouleaterPvp()) return true;
             if (await Pvp.SyphonStrikePvp()) return true;
             return (await Pvp.HardSlashPvp());

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -146,23 +146,29 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(DragoonSettings.Instance)) return true;
 
-            if (await Pvp.StarcrossPvp()) return true;
-            if (await Pvp.ChaoticSpringPvp()) return true;
-            if (await Pvp.HeavensThrustPvp()) return true;
-            if (await Pvp.WyrmwindThrustPvp()) return true;
-            if (await Pvp.NastrondPvp()) return true;
-            if (await Pvp.ElusiveJumpPvp()) return true;
-
-            if (!CommonPvp.GuardCheck(DragoonSettings.Instance))
+            // BURST CHECK: Wrap everything except basic combo
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.SkyHighPvp()) return true;
-                if (await Pvp.GeirskogulPvp()) return true;
+                if (await Pvp.StarcrossPvp()) return true;
+                if (await Pvp.ChaoticSpringPvp()) return true;
+                if (await Pvp.HeavensThrustPvp()) return true;
+                if (await Pvp.WyrmwindThrustPvp()) return true;
+                if (await Pvp.NastrondPvp()) return true;
+                if (await Pvp.ElusiveJumpPvp()) return true;
 
-                if (await Pvp.HighJumpPvp()) return true;
-                if (await Pvp.HorridRoarPvp()) return true;
+                if (!CommonPvp.GuardCheck(DragoonSettings.Instance))
+                {
+                    if (await Pvp.SkyHighPvp()) return true;
+                    if (await Pvp.GeirskogulPvp()) return true;
+
+                    if (await Pvp.HighJumpPvp()) return true;
+                    if (await Pvp.HorridRoarPvp()) return true;
+                }
+
+                if (await Pvp.DrakesbanePvp()) return true;
             }
 
-            if (await Pvp.DrakesbanePvp()) return true;
+            // Basic Combo (ungated)
             if (await Pvp.WheelingThrustPvp()) return true;
             if (await Pvp.FangandClawPvp()) return true;
 

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -77,18 +77,18 @@ namespace Magitek.Rotations
                 if (await Buff.Bloodfest()) return true;
             }
 
-                if (await Buff.NoMercy()) return true;
-                if (await SingleTarget.BlastingZone()) return true;
-                if (await Aoe.BowShock()) return true;
+            if (await Buff.NoMercy()) return true;
+            if (await SingleTarget.BlastingZone()) return true;
+            if (await Aoe.BowShock()) return true;
 
-                //oGCD to use with BurstStrike
-                if (await Aoe.FatedBrand()) return true;
-                if (await SingleTarget.Hypervelocity()) return true;
+            //oGCD to use with BurstStrike
+            if (await Aoe.FatedBrand()) return true;
+            if (await SingleTarget.Hypervelocity()) return true;
 
-                //oGCD to use inside Combo 2
-                if (await SingleTarget.EyeGouge()) return true;
-                if (await SingleTarget.AbdomenTear()) return true;
-                if (await SingleTarget.JugularRip()) return true;
+            //oGCD to use inside Combo 2
+            if (await SingleTarget.EyeGouge()) return true;
+            if (await SingleTarget.AbdomenTear()) return true;
+            if (await SingleTarget.JugularRip()) return true;
 
 
             //Pull or get back aggro with LightningShot
@@ -128,21 +128,27 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(GunbreakerSettings.Instance)) return true;
 
-            if (await Pvp.HeartOfCorundumPvp()) return true;
-            if (await Pvp.ContinuationPvp()) return true;
-            if (await Pvp.BlastingZonePvp()) return true;
-            if (await Pvp.FatedCirclePvp()) return true;
-            if (await Pvp.RelentlessRushPvp()) return true;
-
-            if (!CommonPvp.GuardCheck(GunbreakerSettings.Instance))
+            // BURST CHECK: Wrap everything except basic combo
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.RoughDividePvp()) return true;
-                if (await Pvp.WickedTalonPvp()) return true;
-                if (await Pvp.SavageClawPvp()) return true;
-                if (await Pvp.GnashingFangPvp()) return true;
+                if (await Pvp.HeartOfCorundumPvp()) return true;
+                if (await Pvp.ContinuationPvp()) return true;
+                if (await Pvp.BlastingZonePvp()) return true;
+                if (await Pvp.FatedCirclePvp()) return true;
+                if (await Pvp.RelentlessRushPvp()) return true;
+
+                if (!CommonPvp.GuardCheck(GunbreakerSettings.Instance))
+                {
+                    if (await Pvp.RoughDividePvp()) return true;
+                    if (await Pvp.WickedTalonPvp()) return true;
+                    if (await Pvp.SavageClawPvp()) return true;
+                    if (await Pvp.GnashingFangPvp()) return true;
+                }
+
+                if (await Pvp.BurstStrikePvp()) return true;
             }
 
-            if (await Pvp.BurstStrikePvp()) return true;
+            // Basic Combo (ungated)
             if (await Pvp.SolidBarrelPvp()) return true;
             if (await Pvp.BrutalShelPvp()) return true;
             return (await Pvp.KeenEdgePvp());

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -149,39 +149,44 @@ namespace Magitek.Rotations
             // Utilities
             if (await CommonPvp.CommonTasks(MachinistSettings.Instance)) return true;
 
-            // HIGH PRIORITY: Full Metal Field during Wildfire burst window
-            // Cast BEFORE other abilities since FMF extends Overheated buff and adds 2 Wildfire stacks
-            if (Core.Me.HasAura(Auras.PvpWildfireBuff))
+            // BURST CHECK: Wrap everything except BlastedCharge (the basic attack fallback)
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.FullMetalField()) return true;
+                // HIGH PRIORITY: Full Metal Field during Wildfire burst window
+                // Cast BEFORE other abilities since FMF extends Overheated buff and adds 2 Wildfire stacks
+                if (Core.Me.HasAura(Auras.PvpWildfireBuff))
+                {
+                    if (await Pvp.FullMetalField()) return true;
+                }
+
+                if (await Pvp.BlazingShot()) return true;
+                if (await Pvp.Scattergun()) return true;
+                if (await Pvp.Analysis()) return true;
+                if (await Pvp.Drill()) return true;
+
+                if (!CommonPvp.GuardCheck(MachinistSettings.Instance))
+                {
+                    //LB
+                    if (await Pvp.MarksmansSpite()) return true;
+
+                    if (await Pvp.Detonator()) return true;
+
+                    // Buff
+                    if (await Pvp.BishopAutoturret()) return true;
+                    if (await Pvp.WildFire()) return true;
+
+                    // Tools
+                    if (await Pvp.ChainSaw()) return true;
+                    if (await Pvp.AirAnchor()) return true;
+                    if (await Pvp.BioBlaster()) return true;
+
+                    // NORMAL PRIORITY: Full Metal Field when not in burst window
+                    if (await Pvp.FullMetalField()) return true;
+                }
             }
 
+            // Main - Basic attack fallback (ONLY ungated ability)
             if (await Pvp.BlazingShot()) return true;
-            if (await Pvp.Scattergun()) return true;
-            if (await Pvp.Analysis()) return true;
-            if (await Pvp.Drill()) return true;
-
-            if (!CommonPvp.GuardCheck(MachinistSettings.Instance))
-            {
-                //LB
-                if (await Pvp.MarksmansSpite()) return true;
-
-                if (await Pvp.Detonator()) return true;
-
-                // Buff
-                if (await Pvp.BishopAutoturret()) return true;
-                if (await Pvp.WildFire()) return true;
-
-                // Tools
-                if (await Pvp.ChainSaw()) return true;
-                if (await Pvp.AirAnchor()) return true;
-                if (await Pvp.BioBlaster()) return true;
-
-                // NORMAL PRIORITY: Full Metal Field when not in burst window
-                if (await Pvp.FullMetalField()) return true;
-            }
-
-            // Main
             return await Pvp.BlastedCharge();
         }
     }

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -157,6 +157,7 @@ namespace Magitek.Rotations
             }
 
             if (await Pvp.BlazingShot()) return true;
+            if (await Pvp.Scattergun()) return true;
             if (await Pvp.Analysis()) return true;
             if (await Pvp.Drill()) return true;
 
@@ -166,8 +167,6 @@ namespace Magitek.Rotations
                 if (await Pvp.MarksmansSpite()) return true;
 
                 if (await Pvp.Detonator()) return true;
-
-                if (await Pvp.Scattergun()) return true;
 
                 // Buff
                 if (await Pvp.BishopAutoturret()) return true;

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -145,25 +145,31 @@ namespace Magitek.Rotations
 
             if (await CommonPvp.CommonTasks(MonkSettings.Instance)) return true;
 
-            if (await Pvp.MeteodrivePvp()) return true;
-            if (await Pvp.EarthsReplyPvp()) return true;
-            if (await Pvp.RiddleofEarthPvp()) return true;
-
-            if (!CommonPvp.GuardCheck(MonkSettings.Instance))
+            // BURST CHECK: Wrap everything except basic combo
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.RisingPhoenixPvp()) return true;
-                if (await Pvp.FlintsReplyPvp()) return true;
+                if (await Pvp.MeteodrivePvp()) return true;
+                if (await Pvp.EarthsReplyPvp()) return true;
+                if (await Pvp.RiddleofEarthPvp()) return true;
 
-                if (await Pvp.WindsReplyPvp()) return true;
-                if (await Pvp.ThunderclapPvp()) return true;
+                if (!CommonPvp.GuardCheck(MonkSettings.Instance))
+                {
+                    if (await Pvp.RisingPhoenixPvp()) return true;
+                    if (await Pvp.FlintsReplyPvp()) return true;
+
+                    if (await Pvp.WindsReplyPvp()) return true;
+                    if (await Pvp.ThunderclapPvp()) return true;
+                }
+
+                // if (await Pvp.EnlightenmentPvp()) return true;
+
+                if (await Pvp.PhantomRushPvp()) return true;
+                if (await Pvp.PouncingCoeurlPvp()) return true;
+                if (await Pvp.RisingRaptorPvp()) return true;
+                if (await Pvp.LeapingOpoPvp()) return true;
             }
 
-            // if (await Pvp.EnlightenmentPvp()) return true;
-
-            if (await Pvp.PhantomRushPvp()) return true;
-            if (await Pvp.PouncingCoeurlPvp()) return true;
-            if (await Pvp.RisingRaptorPvp()) return true;
-            if (await Pvp.LeapingOpoPvp()) return true;
+            // Basic Combo (ungated)
             if (await Pvp.DemolishPvp()) return true;
             if (await Pvp.TwinSnakesPvp()) return true;
             return (await Pvp.DragonKickPvp());

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -113,32 +113,35 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(NinjaSettings.Instance)) return true;
 
-
-
-            if (!CommonPvp.GuardCheck(NinjaSettings.Instance))
+            // BURST CHECK: Wrap everything except basic combo
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.BunshinPvp()) return true;
-                if (await Pvp.ShukuchiPvp()) return true;
-                if (await Pvp.AssassinatePvp()) return true;
+                if (!CommonPvp.GuardCheck(NinjaSettings.Instance))
+                {
+                    if (await Pvp.BunshinPvp()) return true;
+                    if (await Pvp.ShukuchiPvp()) return true;
+                    if (await Pvp.AssassinatePvp()) return true;
 
-                if (await Pvp.SeitonTenchuPvp()) return true;
-                if (await Pvp.FleetingRaijuPvp()) return true;
-                if (await Pvp.DokumoriPvp()) return true;
-                if (await Pvp.ZeshoMeppoPvp()) return true;
+                    if (await Pvp.SeitonTenchuPvp()) return true;
+                    if (await Pvp.FleetingRaijuPvp()) return true;
+                    if (await Pvp.DokumoriPvp()) return true;
+                    if (await Pvp.ZeshoMeppoPvp()) return true;
 
-                if (await Pvp.FumaShurikenPvp()) return true;
+                    if (await Pvp.FumaShurikenPvp()) return true;
 
-                if (await Pvp.HutonPvp()) return true;
-                if (await Pvp.MeisuiPvp()) return true;
+                    if (await Pvp.HutonPvp()) return true;
+                    if (await Pvp.MeisuiPvp()) return true;
 
-                if (await Pvp.DotonPvp()) return true;
-                if (await Pvp.GokaMekkyakuPvp()) return true;
+                    if (await Pvp.DotonPvp()) return true;
+                    if (await Pvp.GokaMekkyakuPvp()) return true;
 
-                if (await Pvp.HyoshoRanryuPvp()) return true;
-                if (await Pvp.ForkedRaijuPvp()) return true;
-                if (await Pvp.ThreeMudraPvp()) return true;
+                    if (await Pvp.HyoshoRanryuPvp()) return true;
+                    if (await Pvp.ForkedRaijuPvp()) return true;
+                    if (await Pvp.ThreeMudraPvp()) return true;
+                }
             }
 
+            // Basic Combo (ungated)
             if (await Pvp.AeolianEdgePvp()) return true;
             if (await Pvp.GustSlashPvp()) return true;
 

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -122,26 +122,31 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(PaladinSettings.Instance)) return true;
 
-            if (await Pvp.PhalanxPvp()) return true;
-            if (await Pvp.BladeofValorPvp()) return true;
-            if (await Pvp.BladeofTruthPvp()) return true;
-            if (await Pvp.BladeofFaithPvp()) return true;
-            if (await Pvp.HolySheltronPvp()) return true;
-
-            if (await Pvp.ShieldSmitePvp()) return true;
-            if (await Pvp.HolySpiritPvp()) return true;
-
-            if (!CommonPvp.GuardCheck(PaladinSettings.Instance))
+            // BURST CHECK: Wrap everything except FastBlade combo (the basic attack fallback)
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.ImperatorPvp()) return true;
-                if (await Pvp.IntervenePvp()) return true;
+                if (await Pvp.PhalanxPvp()) return true;
+                if (await Pvp.BladeofValorPvp()) return true;
+                if (await Pvp.BladeofTruthPvp()) return true;
+                if (await Pvp.BladeofFaithPvp()) return true;
+                if (await Pvp.HolySheltronPvp()) return true;
+
+                if (await Pvp.ShieldSmitePvp()) return true;
+                if (await Pvp.HolySpiritPvp()) return true;
+
+                if (!CommonPvp.GuardCheck(PaladinSettings.Instance))
+                {
+                    if (await Pvp.ImperatorPvp()) return true;
+                    if (await Pvp.IntervenePvp()) return true;
+                }
+
+                if (await Pvp.AtonementPvp()) return true;
+                if (await Pvp.SupplicationPvp()) return true;
+                if (await Pvp.SepulchrePvp()) return true;
+                if (await Pvp.ConfiteorPvp()) return true;
             }
 
-            if (await Pvp.AtonementPvp()) return true;
-            if (await Pvp.SupplicationPvp()) return true;
-            if (await Pvp.SepulchrePvp()) return true;
-            if (await Pvp.ConfiteorPvp()) return true;
-
+            // Basic combo fallback (ONLY ungated abilities)
             if (await Pvp.RoyalAuthorityPvp()) return true;
             if (await Pvp.RiotBladePvp()) return true;
             return (await Pvp.FastBladePvp());

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -139,12 +139,12 @@ namespace Magitek.Rotations
                     if (await Pvp.ImperatorPvp()) return true;
                     if (await Pvp.IntervenePvp()) return true;
                 }
-
-                if (await Pvp.AtonementPvp()) return true;
-                if (await Pvp.SupplicationPvp()) return true;
-                if (await Pvp.SepulchrePvp()) return true;
-                if (await Pvp.ConfiteorPvp()) return true;
             }
+
+            if (await Pvp.AtonementPvp()) return true;
+            if (await Pvp.SupplicationPvp()) return true;
+            if (await Pvp.SepulchrePvp()) return true;
+            if (await Pvp.ConfiteorPvp()) return true;
 
             // Basic combo fallback (ONLY ungated abilities)
             if (await Pvp.RoyalAuthorityPvp()) return true;

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -121,20 +121,23 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(PictomancerSettings.Instance)) return true;
 
-            if (!CommonPvp.GuardCheck(PictomancerSettings.Instance))
+            if (await Pvp.TemperaCoat()) return true;
+            if (await Pvp.TemperaGrassa()) return true;
+
+            if (CommonPvp.ShouldUseBurst())
             {
-                if (await Pvp.TemperaCoat()) return true;
-                if (await Pvp.TemperaGrassa()) return true;
+                if (!CommonPvp.GuardCheck(PictomancerSettings.Instance))
+                {
+                    if (await Pvp.Starstruck()) return true;
+                    if (await Pvp.AdventofChocobastion()) return true;
+                    if (await Pvp.SubtractivePalette()) return true;
 
-                if (await Pvp.Starstruck()) return true;
-                if (await Pvp.AdventofChocobastion()) return true;
-                if (await Pvp.SubtractivePalette()) return true;
+                    if (await Pvp.PaintB()) return true;
+                    if (await Pvp.PaintW()) return true;
 
-                if (await Pvp.PaintB()) return true;
-                if (await Pvp.PaintW()) return true;
-
-                if (await Pvp.MogoftheAges()) return true;
-                if (await Pvp.LivingMuse()) return true;
+                    if (await Pvp.MogoftheAges()) return true;
+                    if (await Pvp.LivingMuse()) return true;
+                }
             }
 
             if (await Pvp.CreatureMotif()) return true;

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -125,10 +125,14 @@ namespace Magitek.Rotations
 
             // Defensive abilities
             if (await Pvp.ArcaneCrestPvp()) return true;
-            if (await Pvp.PerfectioPvp()) return true;
-            if (await Pvp.GuillotinePvp()) return true;
 
-            if (!CommonPvp.GuardCheck(ReaperSettings.Instance))
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.PerfectioPvp()) return true;
+                if (await Pvp.GuillotinePvp()) return true;
+            }
+
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(ReaperSettings.Instance))
             {
                 // Enshrouded abilities
                 if (await Pvp.TenebraeLemurumPvp()) return true;
@@ -147,7 +151,7 @@ namespace Magitek.Rotations
                 if (await Pvp.SoulSlicePvp()) return true;
             }
 
-            // Basic combo
+            // Basic combo (ungated)
             if (await Pvp.InfernalSlicePvp()) return true;
             if (await Pvp.WaxingSlicePvp()) return true;
             return await Pvp.SlicePvp();

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -149,17 +149,23 @@ namespace Magitek.Rotations
             if (await CommonPvp.CommonTasks(RedMageSettings.Instance)) return true;
 
             // Movement Abilities
-            if (await Pvp.DisplacementPvp()) return true;
-            if (await Pvp.CorpsacorpsPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.DisplacementPvp()) return true;
+                if (await Pvp.CorpsacorpsPvp()) return true;
+            }
 
             // Melee Combo
-            if (await Pvp.EnchantedRipostePvp()) return true;
-            if (await Pvp.EnchantedZwerchhauPvp()) return true;
-            if (await Pvp.EnchantedRedoublementPvp()) return true;
-            if (await Pvp.ScorchPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.EnchantedRipostePvp()) return true;
+                if (await Pvp.EnchantedZwerchhauPvp()) return true;
+                if (await Pvp.EnchantedRedoublementPvp()) return true;
+                if (await Pvp.ScorchPvp()) return true;
+            }
 
             // Main Rotation
-            if (!CommonPvp.GuardCheck(RedMageSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(RedMageSettings.Instance))
             {
                 // Limit Break
                 if (await Pvp.SouthernCrossPvp()) return true;
@@ -173,7 +179,7 @@ namespace Magitek.Rotations
                 if (await Pvp.ViceOfThornsPvp()) return true;
             }
 
-            // Basic Spells
+            // Basic Spells (ungated)
             if (await Pvp.GrandImpactPvp()) return true;
             if (await Pvp.JoltIIIPvp()) return true;
 

--- a/Magitek/Rotations/Sage.cs
+++ b/Magitek/Rotations/Sage.cs
@@ -180,13 +180,20 @@ namespace Magitek.Rotations
 
             if (await CommonPvp.CommonTasks(SageSettings.Instance)) return true;
 
-            if (await Pvp.MesotesPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.MesotesPvp()) return true;
+            }
 
             if (await Pvp.KardiaPvp()) return true;
             if (await Pvp.PneumaPvp()) return true;
-            if (await Pvp.EukrasiaPvp()) return true;
 
-            if (!CommonPvp.GuardCheck(SageSettings.Instance))
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.EukrasiaPvp()) return true;
+            }
+
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(SageSettings.Instance))
             {
                 if (await Pvp.PhlegmaIIIPvp()) return true;
                 if (await Pvp.ToxikonPvp()) return true;

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -150,19 +150,22 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(SamuraiSettings.Instance)) return true;
 
-            if (!CommonPvp.GuardCheck(SamuraiSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(SamuraiSettings.Instance))
             {
                 if (await Pvp.ZantetsukenPvp()) return true;
                 if (await Pvp.MineuchiPvp()) return true;
             }
 
-            if (await Pvp.KaeshiNamikiriPvp()) return true;
-            if (await Pvp.ZanshinPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.KaeshiNamikiriPvp()) return true;
+                if (await Pvp.ZanshinPvp()) return true;
 
-            if (await Pvp.TendoKaeshiSetsugekkaPvp()) return true;
-            if (await Pvp.TendoSetsugekkaPvp()) return true;
+                if (await Pvp.TendoKaeshiSetsugekkaPvp()) return true;
+                if (await Pvp.TendoSetsugekkaPvp()) return true;
+            }
 
-            if (!CommonPvp.GuardCheck(SamuraiSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(SamuraiSettings.Instance))
             {
                 if (await Pvp.HissatsuChitenPvp()) return true;
                 if (await Pvp.HissatsuSotenPvp()) return true;

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -203,9 +203,13 @@ namespace Magitek.Rotations
             if (await Pvp.DeploymentTacticsPvp()) return true;
             if (await Pvp.AdloquiumPvp()) return true;
             if (await Pvp.ExpedientPvp()) return true;
-            if (await Pvp.ChainStratagemPvp()) return true;
 
-            if (!CommonPvp.GuardCheck(ScholarSettings.Instance))
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.ChainStratagemPvp()) return true;
+            }
+
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(ScholarSettings.Instance))
             {
                 if (await Pvp.BiolysisPvp()) return true;
             }

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -87,11 +87,14 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(SummonerSettings.Instance)) return true;
 
-            if (await Pvp.RadiantAegisPvp()) return true;
-            if (await Pvp.SummonBahamutPvp()) return true;
-            if (await Pvp.SummonPhoenixPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.RadiantAegisPvp()) return true;
+                if (await Pvp.SummonBahamutPvp()) return true;
+                if (await Pvp.SummonPhoenixPvp()) return true;
+            }
 
-            if (!CommonPvp.GuardCheck(SummonerSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(SummonerSettings.Instance))
             {
                 if (await Pvp.MountainBusterPvp()) return true;
                 if (await Pvp.CrimsonStrikePvp()) return true;

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -109,11 +109,14 @@ namespace Magitek.Rotations
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (await Pvp.SerpentsTail()) return true;
-            if (await Pvp.WorldGeneration()) return true;
-            if (await Pvp.WorldSwallower()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.SerpentsTail()) return true;
+                if (await Pvp.WorldGeneration()) return true;
+                if (await Pvp.WorldSwallower()) return true;
+            }
 
-            if (!CommonPvp.GuardCheck(ViperSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(ViperSettings.Instance))
             {
                 if (await Pvp.RattlingCoil()) return true;
                 if (await Pvp.UncoiledFury()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -109,28 +109,32 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(WarriorSettings.Instance)) return true;
 
-            if (!CommonPvp.GuardCheck(WarriorSettings.Instance))
+            // BURST CHECK: Wrap everything except basic combo
+            if (CommonPvp.ShouldUseBurst())
             {
-                // Limit Break
-                if (await Pvp.PrimalScreamPvp()) return true;
-                if (await Pvp.PrimalWrathPvp()) return true;
+                if (!CommonPvp.GuardCheck(WarriorSettings.Instance))
+                {
+                    // Limit Break
+                    if (await Pvp.PrimalScreamPvp()) return true;
+                    if (await Pvp.PrimalWrathPvp()) return true;
 
-                // High Priority Abilities
-                if (await Pvp.PrimalRendPvp()) return true;
-                if (await Pvp.PrimalRuinationPvp()) return true;
-                if (await Pvp.InnerChaosPvp()) return true;
-                if (await Pvp.ChaoticCyclonePvp()) return true;
+                    // High Priority Abilities
+                    if (await Pvp.PrimalRendPvp()) return true;
+                    if (await Pvp.PrimalRuinationPvp()) return true;
+                    if (await Pvp.InnerChaosPvp()) return true;
+                    if (await Pvp.ChaoticCyclonePvp()) return true;
 
-                // Gap Closers and Utility
-                if (await Pvp.OnslaughtPvp()) return true;
-                if (await Pvp.BlotaPvp()) return true;
+                    // Gap Closers and Utility
+                    if (await Pvp.OnslaughtPvp()) return true;
+                    if (await Pvp.BlotaPvp()) return true;
 
-                // Defensive and Healing
-                if (await Pvp.BloodwhettingPvp()) return true;
-                if (await Pvp.OrogenyPvp()) return true;
+                    // Defensive and Healing
+                    if (await Pvp.BloodwhettingPvp()) return true;
+                    if (await Pvp.OrogenyPvp()) return true;
+                }
             }
 
-            // Basic Combo
+            // Basic Combo (ungated)
             if (await Pvp.StormPathPvp()) return true;
             if (await Pvp.MaimPvp()) return true;
             if (await Pvp.HeavySwingPvp()) return true;

--- a/Magitek/Rotations/WhiteMage.cs
+++ b/Magitek/Rotations/WhiteMage.cs
@@ -186,13 +186,16 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(WhiteMageSettings.Instance)) return true;
 
-            if (await Pvp.AfflatusPurgationPvp()) return true;
+            if (CommonPvp.ShouldUseBurst())
+            {
+                if (await Pvp.AfflatusPurgationPvp()) return true;
+            }
 
             if (await Pvp.CureIIIPvp()) return true;
             if (await Pvp.AquaveilPvp()) return true;
             if (await Pvp.CureIIPvp()) return true;
 
-            if (!CommonPvp.GuardCheck(WhiteMageSettings.Instance))
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(WhiteMageSettings.Instance))
             {
                 if (await Pvp.GlareIVPvp()) return true;
                 if (await Pvp.AfflatusMiseryPvp()) return true;

--- a/Magitek/Toggles/SettingsToggle.cs
+++ b/Magitek/Toggles/SettingsToggle.cs
@@ -76,20 +76,22 @@ namespace Magitek.Toggles
                 return;
             }
 
-            var settingsInstance = ToggleJob.GetIRoutineSettingsFromJobString();
-            var settingsProperties = settingsInstance.GetType().GetProperties();
+            var jobSettingsInstance = ToggleJob.GetIRoutineSettingsFromJobString();
+            if (jobSettingsInstance == null)
+                return;
 
             foreach (var settingsToggleSetting in Settings)
             {
-                // Find the property that matches the toggle setting
-                var settingsProperty = settingsProperties.FirstOrDefault(r => r.Name == settingsToggleSetting.Name);
+                // Get the appropriate instance (BaseSettings for PvP_ properties, otherwise job settings)
+                var targetInstance = SettingsHandler.GetSettingsInstanceForProperty(settingsToggleSetting.Name, jobSettingsInstance);
+                var targetProperty = targetInstance.GetType().GetProperty(settingsToggleSetting.Name);
 
                 // If there's no property, continue the loop
-                if (settingsProperty == null)
+                if (targetProperty == null)
                     continue;
 
                 // Check to see if the value on the property matches what our Checked value should be 
-                if (SettingsHandler.SettingToggleSettingMatchesProperty(settingsToggleSetting, settingsProperty, settingsInstance))
+                if (SettingsHandler.SettingToggleSettingMatchesProperty(settingsToggleSetting, targetProperty, jobSettingsInstance))
                     continue;
 
                 // Toggle is unchecked because one of its properties does not match its checked value

--- a/Magitek/ViewModels/GlobalPvpViewModel.cs
+++ b/Magitek/ViewModels/GlobalPvpViewModel.cs
@@ -24,8 +24,8 @@ namespace Magitek.ViewModels
             GeneralSettings.Save();
 
             // Re-register hotkey when hotkey properties change
-            if (e.PropertyName == nameof(GeneralSettings.HoldPvpBurstKey) ||
-                e.PropertyName == nameof(GeneralSettings.HoldPvpBurstModkey))
+            if (e.PropertyName == nameof(GeneralSettings.Pvp_HoldBurstKey) ||
+                e.PropertyName == nameof(GeneralSettings.Pvp_HoldBurstModkey))
             {
                 Magitek.RegisterHoldPvpBurstHotkey();
             }

--- a/Magitek/ViewModels/GlobalPvpViewModel.cs
+++ b/Magitek/ViewModels/GlobalPvpViewModel.cs
@@ -1,0 +1,35 @@
+using PropertyChanged;
+using System.ComponentModel;
+
+namespace Magitek.ViewModels
+{
+    [AddINotifyPropertyChangedInterface]
+    public class GlobalPvpViewModel
+    {
+        private static GlobalPvpViewModel _instance;
+        public static GlobalPvpViewModel Instance => _instance ?? (_instance = new GlobalPvpViewModel());
+
+        // Match the pattern used in other ViewModels (expose Models.Account.BaseSettings via property)
+        public Models.Account.BaseSettings GeneralSettings { get; set; } = Models.Account.BaseSettings.Instance;
+
+        public GlobalPvpViewModel()
+        {
+            // Listen for property changes to save settings and re-register hotkey
+            GeneralSettings.PropertyChanged += GeneralSettings_PropertyChanged;
+        }
+
+        private void GeneralSettings_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // Save immediately when any property changes
+            GeneralSettings.Save();
+
+            // Re-register hotkey when hotkey properties change
+            if (e.PropertyName == nameof(GeneralSettings.HoldPvpBurstKey) ||
+                e.PropertyName == nameof(GeneralSettings.HoldPvpBurstModkey))
+            {
+                Magitek.RegisterHoldPvpBurstHotkey();
+            }
+        }
+    }
+}
+

--- a/Magitek/ViewModels/MagitekApi.cs
+++ b/Magitek/ViewModels/MagitekApi.cs
@@ -22,6 +22,7 @@ namespace Magitek.ViewModels
         private readonly HttpClient _webClient = new HttpClient();
         private const string GithubAddress = "https://api.github.com";
         private const string VersionUrl = "https://github.com/MagitekRB/MagitekRoutine/releases/latest/download/Version.txt";
+        private DateTime _lastFetchTime = DateTime.MinValue;
 
         public static MagitekApi Instance => _instance ?? (_instance = new MagitekApi());
         public bool SpinnerVisible { get; set; } = false;
@@ -96,6 +97,7 @@ namespace Magitek.ViewModels
                     if (response == null)
                         return;
 
+                    NewsList.Clear();
                     response.ForEach(x =>
                     {
                         if (x?.prerelease == true)
@@ -148,6 +150,8 @@ namespace Magitek.ViewModels
                             Message = filteredBody
                         });
                     });
+
+                    _lastFetchTime = DateTime.Now;
                 }
                 ;
             }
@@ -156,6 +160,15 @@ namespace Magitek.ViewModels
                 Logger.Error(e.Message);
             }
             SpinnerVisible = false;
+        }
+
+        public void RefreshIfNeeded()
+        {
+            var timeSinceLastFetch = DateTime.Now - _lastFetchTime;
+            if (timeSinceLastFetch.TotalHours >= 1)
+            {
+                UpdateNews();
+            }
         }
     }
 }

--- a/Magitek/ViewModels/TogglesViewModel.cs
+++ b/Magitek/ViewModels/TogglesViewModel.cs
@@ -28,6 +28,7 @@ using Magitek.Utilities;
 using Newtonsoft.Json;
 using PropertyChanged;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -199,96 +200,108 @@ namespace Magitek.ViewModels
 
         private void ResetPropertiesForJob(string job)
         {
+            List<ToggleProperty> jobProperties;
+
             switch (SelectedJob)
             {
                 case "Scholar":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(ScholarSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(ScholarSettings.Instance));
                     break;
 
                 case "WhiteMage":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(WhiteMageSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(WhiteMageSettings.Instance));
                     break;
 
                 case "Astrologian":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(AstrologianSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(AstrologianSettings.Instance));
                     break;
 
                 case "Paladin":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(PaladinSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(PaladinSettings.Instance));
                     break;
 
                 case "Warrior":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(WarriorSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(WarriorSettings.Instance));
                     break;
 
                 case "DarkKnight":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(DarkKnightSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(DarkKnightSettings.Instance));
                     break;
 
                 case "Gunbreaker":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(GunbreakerSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(GunbreakerSettings.Instance));
                     break;
 
                 case "Bard":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(BardSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(BardSettings.Instance));
                     break;
 
                 case "Machinist":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(MachinistSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(MachinistSettings.Instance));
                     break;
 
                 case "Dancer":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(DancerSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(DancerSettings.Instance));
                     break;
 
                 case "BlackMage":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(BlackMageSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(BlackMageSettings.Instance));
                     break;
 
                 case "Summoner":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(SummonerSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(SummonerSettings.Instance));
                     break;
 
                 case "RedMage":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(RedMageSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(RedMageSettings.Instance));
                     break;
 
                 case "Monk":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(MonkSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(MonkSettings.Instance));
                     break;
 
                 case "Dragoon":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(DragoonSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(DragoonSettings.Instance));
                     break;
 
                 case "Ninja":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(NinjaSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(NinjaSettings.Instance));
                     break;
 
                 case "Samurai":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(SamuraiSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(SamuraiSettings.Instance));
                     break;
 
                 case "Reaper":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(ReaperSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(ReaperSettings.Instance));
                     break;
 
                 case "Sage":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(SageSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(SageSettings.Instance));
                     break;
 
                 case "Pictomancer":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(PictomancerSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(PictomancerSettings.Instance));
                     break;
 
                 case "Viper":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(ViperSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(ViperSettings.Instance));
                     break;
 
                 case "BlueMage":
-                    JobSettingsList = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(BlueMageSettings.Instance));
+                    jobProperties = new List<ToggleProperty>(SettingsHandler.ExtractPropertyNamesAndTypesFromSettingsInstance(BlueMageSettings.Instance));
+                    break;
+
+                default:
+                    jobProperties = new List<ToggleProperty>();
                     break;
             }
+
+            // Combine job properties with BaseSettings PvP properties
+            var baseSettingsPvpProperties = SettingsHandler.ExtractBaseSettingsPvpProperties();
+            JobSettingsList = jobProperties.Concat(baseSettingsPvpProperties)
+                .OrderBy(p => p.Name)
+                .ToList();
         }
     }
 }

--- a/Magitek/Views/SettingsWindow.xaml
+++ b/Magitek/Views/SettingsWindow.xaml
@@ -29,6 +29,7 @@
         xmlns:viper="clr-namespace:Magitek.Views.UserControls.Viper"
         xmlns:pictomancer="clr-namespace:Magitek.Views.UserControls.Pictomancer"
         xmlns:occultCrescent="clr-namespace:Magitek.Views.UserControls.OccultCrescent"
+        xmlns:globalPvp="clr-namespace:Magitek.Views.UserControls.GlobalPvp"
         Width="1000"
         Height="700"
         AllowsTransparency="True"
@@ -426,6 +427,10 @@
                         <TabItem Header="Changelog"
                                  Style="{DynamicResource MainTabChangelog}">
                             <customControls:CurrentNews/>
+                        </TabItem>
+                        <TabItem Header="Global PVP"
+                                 Style="{DynamicResource MainTabPvp}">
+                            <globalPvp:General/>
                         </TabItem>
                         <TabItem Header="Occult Crescent"
                                  Style="{DynamicResource MainTabOccultCrescent}">

--- a/Magitek/Views/SettingsWindow.xaml.cs
+++ b/Magitek/Views/SettingsWindow.xaml.cs
@@ -162,6 +162,7 @@ namespace Magitek.Views
             TogglesViewModel.Instance.SaveToggles();
 
             #region Save Settings For All Routines
+            Models.Account.BaseSettings.Instance.Save();
             ScholarSettings.Instance.Save();
             WhiteMageSettings.Instance.Save();
             AstrologianSettings.Instance.Save();

--- a/Magitek/Views/UserControls/Common/PvpUtilities.xaml
+++ b/Magitek/Views/UserControls/Common/PvpUtilities.xaml
@@ -24,6 +24,11 @@
                               IsChecked="{Binding Pvp_UsePurify, Mode=TwoWay}"
                               Style="{DynamicResource CheckBoxFlat}"/>
                 </StackPanel>
+                <StackPanel Margin="5">
+                    <CheckBox Content="{x:Static properties:Resources.Generic_Use_Role_Actions}"
+                              IsChecked="{Binding Pvp_UseRoleActions, Mode=TwoWay}"
+                              Style="{DynamicResource CheckBoxFlat}"/>
+                </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="{x:Static properties:Resources.Generic_Guard_Shield_At}"
                               IsChecked="{Binding Pvp_UseGuard, Mode=TwoWay}"
@@ -34,7 +39,7 @@
                     <TextBlock Style="{DynamicResource TextBlockDefault}"
                                Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
                 </StackPanel>
-                <StackPanel Margin="5">
+                <StackPanel Margin="5,5,5,5">
                     <CheckBox Content="{x:Static properties:Resources.Generic_AutoGuard_MarksmansSpite}"
                               IsChecked="{Binding Pvp_AutoGuardMarksmanSpite, Mode=TwoWay}"
                               Margin="15,0,0,0"
@@ -49,26 +54,6 @@
                                       Value="{Binding Pvp_RecuperateHealthPercent, Mode=TwoWay}"/>
                     <TextBlock Style="{DynamicResource TextBlockDefault}"
                                Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                </StackPanel>
-                <StackPanel Margin="5">
-                    <CheckBox Content="{x:Static properties:Resources.Generic_Sprint_Without_Target}"
-                              IsChecked="{Binding Pvp_SprintWithoutTarget, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
-                </StackPanel>
-                <StackPanel Margin="5">
-                    <CheckBox Content="{x:Static properties:Resources.Generic_Use_Mount}"
-                              IsChecked="{Binding Pvp_UseMount, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
-                </StackPanel>
-                <StackPanel Margin="5">
-                    <CheckBox Content="{x:Static properties:Resources.Generic_Dont_Attack_Guard}"
-                              IsChecked="{Binding Pvp_GuardCheck, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
-                </StackPanel>
-                <StackPanel Margin="5">
-                    <CheckBox Content="{x:Static properties:Resources.Generic_Dont_Attack_Invuln_Hallowed_Ground}"
-                              IsChecked="{Binding Pvp_InvulnCheck, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/Magitek/Views/UserControls/GlobalPvp/General.xaml
+++ b/Magitek/Views/UserControls/GlobalPvp/General.xaml
@@ -38,15 +38,15 @@
                                    VerticalAlignment="Center"
                                    Margin="0,0,10,0"/>
                         <controls:Hotkey Text="{x:Static properties:Resources.GlobalPvp_Text_Hold_Burst_Hotkey_Label}"
-                                         KeySetting="{Binding GeneralSettings.HoldPvpBurstKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                         ModKeySetting="{Binding GeneralSettings.HoldPvpBurstModkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                         KeySetting="{Binding GeneralSettings.Pvp_HoldBurstKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         ModKeySetting="{Binding GeneralSettings.Pvp_HoldBurstModkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                     </StackPanel>
 
                     <!-- Warmachina Setting -->
                     <StackPanel Margin="5"
                                 Orientation="Horizontal">
                         <CheckBox Content="{x:Static properties:Resources.Generic_PvpUseBurstOnWarmachina}"
-                                  IsChecked="{Binding GeneralSettings.PvpUseBurstOnWarmachina, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  IsChecked="{Binding GeneralSettings.Pvp_UseBurstOnWarmachina, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                   Style="{DynamicResource CheckBoxFlat}"/>
                     </StackPanel>
 
@@ -65,6 +65,40 @@
                                FontStyle="Italic"
                                Foreground="Orange"
                                Text="{x:Static properties:Resources.GlobalPvp_Text_Hold_Burst_Overlay_Note}"/>
+
+                </StackPanel>
+            </controls:SettingsBlock>
+
+            <!-- Global PvP Utilities Settings -->
+            <controls:SettingsBlock Margin="0,5"
+                                    Background="{DynamicResource ClassSelectorBackground}">
+                <StackPanel Margin="5">
+                    <TextBlock Style="{DynamicResource TextBlockSection}"
+                               Text="{x:Static properties:Resources.Generic_Utilities}"/>
+
+                    <StackPanel Margin="5">
+                        <CheckBox Content="{x:Static properties:Resources.Generic_Dont_Attack_Guard}"
+                                  IsChecked="{Binding GeneralSettings.Pvp_GuardCheck, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  Style="{DynamicResource CheckBoxFlat}"/>
+                    </StackPanel>
+
+                    <StackPanel Margin="5">
+                        <CheckBox Content="{x:Static properties:Resources.Generic_Dont_Attack_Invuln_Hallowed_Ground}"
+                                  IsChecked="{Binding GeneralSettings.Pvp_InvulnCheck, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  Style="{DynamicResource CheckBoxFlat}"/>
+                    </StackPanel>
+
+                    <StackPanel Margin="5">
+                        <CheckBox Content="{x:Static properties:Resources.Generic_Sprint_Without_Target}"
+                                  IsChecked="{Binding GeneralSettings.Pvp_SprintWithoutTarget, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  Style="{DynamicResource CheckBoxFlat}"/>
+                    </StackPanel>
+
+                    <StackPanel Margin="5">
+                        <CheckBox Content="{x:Static properties:Resources.Generic_Use_Mount}"
+                                  IsChecked="{Binding GeneralSettings.Pvp_UseMount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  Style="{DynamicResource CheckBoxFlat}"/>
+                    </StackPanel>
 
                 </StackPanel>
             </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/GlobalPvp/General.xaml
+++ b/Magitek/Views/UserControls/GlobalPvp/General.xaml
@@ -1,0 +1,75 @@
+<UserControl x:Class="Magitek.Views.UserControls.GlobalPvp.General"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:properties="clr-namespace:Magitek.Properties"
+             xmlns:controls="clr-namespace:Magitek.Controls"
+             xmlns:viewModels="clr-namespace:Magitek.ViewModels">
+
+<UserControl.DataContext>
+        <Binding Source="{x:Static viewModels:GlobalPvpViewModel.Instance}"/>
+    </UserControl.DataContext>
+
+    <UserControl.Resources>
+        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml"/>
+    </UserControl.Resources>
+
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="10">
+
+            <!-- Hold Burst Settings -->
+            <controls:SettingsBlock Margin="0,5"
+                                    Background="{DynamicResource ClassSelectorBackground}">
+                <StackPanel Margin="5">
+                    <TextBlock Style="{DynamicResource TextBlockSection}"
+                               Text="{x:Static properties:Resources.GlobalPvp_Text_Hold_Burst_Settings}"/>
+
+                    <!-- Description -->
+                    <TextBlock Margin="5"
+                               Style="{DynamicResource TextBlockDefault}"
+                               TextWrapping="Wrap"
+                               FontStyle="Italic"
+                               Text="{x:Static properties:Resources.GlobalPvp_Text_Hold_Burst_Description}"/>
+
+                    <!-- Hotkey Configuration -->
+                    <StackPanel Margin="5"
+                                Orientation="Horizontal">
+                        <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                   Text="{x:Static properties:Resources.GlobalPvp_Text_Hotkey}"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,10,0"/>
+                        <controls:Hotkey Text="{x:Static properties:Resources.GlobalPvp_Text_Hold_Burst_Hotkey_Label}"
+                                         KeySetting="{Binding GeneralSettings.HoldPvpBurstKey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         ModKeySetting="{Binding GeneralSettings.HoldPvpBurstModkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    </StackPanel>
+
+                    <!-- Warmachina Setting -->
+                    <StackPanel Margin="5"
+                                Orientation="Horizontal">
+                        <CheckBox Content="{x:Static properties:Resources.Generic_PvpUseBurstOnWarmachina}"
+                                  IsChecked="{Binding GeneralSettings.PvpUseBurstOnWarmachina, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  Style="{DynamicResource CheckBoxFlat}"/>
+                    </StackPanel>
+
+                    <!-- Info Text -->
+                    <TextBlock Margin="5"
+                               Style="{DynamicResource TextBlockDefault}"
+                               TextWrapping="Wrap"
+                               FontStyle="Italic"
+                               Foreground="LightBlue"
+                               Text="{x:Static properties:Resources.GlobalPvp_Text_Warmachina_Description}"/>
+
+                    <!-- Additional Info -->
+                    <TextBlock Margin="5"
+                               Style="{DynamicResource TextBlockDefault}"
+                               TextWrapping="Wrap"
+                               FontStyle="Italic"
+                               Foreground="Orange"
+                               Text="{x:Static properties:Resources.GlobalPvp_Text_Hold_Burst_Overlay_Note}"/>
+
+                </StackPanel>
+            </controls:SettingsBlock>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>
+

--- a/Magitek/Views/UserControls/GlobalPvp/General.xaml.cs
+++ b/Magitek/Views/UserControls/GlobalPvp/General.xaml.cs
@@ -1,0 +1,16 @@
+using System.Windows.Controls;
+
+namespace Magitek.Views.UserControls.GlobalPvp
+{
+    /// <summary>
+    /// Interaction logic for General.xaml
+    /// </summary>
+    public partial class General : UserControl
+    {
+        public General()
+        {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/Magitek/Views/UserControls/Machinist/Pvp.xaml
+++ b/Magitek/Views/UserControls/Machinist/Pvp.xaml
@@ -44,11 +44,15 @@
                               Margin="20,2,0,0"
                               ToolTip="{x:Static properties:Resources.Machinist_ToolTip_If_enabled_will_save_Full_Metal_}"/>
                 </StackPanel>
-                <StackPanel Margin="5"
-                            Orientation="Horizontal">
+                <StackPanel Margin="5">
                     <CheckBox Content="{x:Static properties:Resources.Machinist_Content_Scattergun}"
                               IsChecked="{Binding MachinistSettings.Pvp_Scattergun, Mode=TwoWay}"
                               Style="{DynamicResource CheckBoxFlat}"/>
+                    <CheckBox Content="{x:Static properties:Resources.Machinist_Content_Scattergun_Target_Closest}"
+                              IsChecked="{Binding MachinistSettings.Pvp_ScattergunTargetClosest, Mode=TwoWay}"
+                              Style="{DynamicResource CheckBoxFlat}"
+                              Margin="20,2,0,0"
+                              ToolTip="{x:Static properties:Resources.Machinist_ToolTip_Scattergun_Will_target_closest}"/>
                 </StackPanel>
                 <StackPanel Margin="5"
                             Orientation="Horizontal">

--- a/Magitek/Views/UserControls/MainSettingsOverlay.xaml
+++ b/Magitek/Views/UserControls/MainSettingsOverlay.xaml
@@ -60,6 +60,7 @@
                         <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Reset_Custom_Opener}" IsChecked="{Binding GeneralSettings.GeneralSettings.ResetOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
                         <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Use_Chocobo}" IsChecked="{Binding GeneralSettings.GeneralSettings.SummonChocobo, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
                         <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Execute_LimitBreak}" IsChecked="{Binding GeneralSettings.GeneralSettings.ForceLimitBreak}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
+                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Hold_PVP_Burst}" IsChecked="{Binding GeneralSettings.GeneralSettings.HoldPvpBurst, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource BoolToVis}}" />
                     </WrapPanel>
                 </WrapPanel>
                 <ItemsControl Grid.Row="1" ItemsSource="{Binding SettingsToggles, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" VerticalAlignment="Center">

--- a/Magitek/Views/UserControls/MainSettingsOverlay.xaml
+++ b/Magitek/Views/UserControls/MainSettingsOverlay.xaml
@@ -18,6 +18,7 @@
     <Grid>
         <Grid.Resources>
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
+            <converters:InvertedBooleanToVisibilityConverter x:Key="InvertedBoolToVis" xmlns:converters="clr-namespace:Magitek.Converters" />
             <ObjectDataProvider x:Key="SummonerPets" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
                 <ObjectDataProvider.MethodParameters>
                     <x:Type TypeName="enumerations:SummonerPets" />
@@ -56,11 +57,11 @@
                     <WrapPanel Orientation="Horizontal">
                         <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Active_CR}" IsChecked="{Binding GeneralSettings.GeneralSettings.ActiveCombatRoutine, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
                         <CheckBox Content="{x:Static properties:Resources.UserControls_Content_PVP_Mode}" IsChecked="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Mode=TwoWay}" Command="{Binding EnablePvpOverlay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
-                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Use_Custom_Opener}" IsChecked="{Binding GeneralSettings.GeneralSettings.UseOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
-                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Reset_Custom_Opener}" IsChecked="{Binding GeneralSettings.GeneralSettings.ResetOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
-                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Use_Chocobo}" IsChecked="{Binding GeneralSettings.GeneralSettings.SummonChocobo, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
-                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Execute_LimitBreak}" IsChecked="{Binding GeneralSettings.GeneralSettings.ForceLimitBreak}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" />
-                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Hold_PVP_Burst}" IsChecked="{Binding GeneralSettings.GeneralSettings.HoldPvpBurst, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource BoolToVis}}" />
+                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Use_Custom_Opener}" IsChecked="{Binding GeneralSettings.GeneralSettings.UseOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource InvertedBoolToVis}}" />
+                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Reset_Custom_Opener}" IsChecked="{Binding GeneralSettings.GeneralSettings.ResetOpeners, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource InvertedBoolToVis}}" />
+                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Use_Chocobo}" IsChecked="{Binding GeneralSettings.GeneralSettings.SummonChocobo, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource InvertedBoolToVis}}" />
+                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Execute_LimitBreak}" IsChecked="{Binding GeneralSettings.GeneralSettings.ForceLimitBreak}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource InvertedBoolToVis}}" />
+                        <CheckBox Content="{x:Static properties:Resources.UserControls_Content_Hold_PVP_Burst}" IsChecked="{Binding GeneralSettings.GeneralSettings.Pvp_HoldBurst, Mode=TwoWay}" Style="{DynamicResource CheckBoxOverlayCustomToggle}" Visibility="{Binding GeneralSettings.GeneralSettings.ActivePvpCombatRoutine, Converter={StaticResource BoolToVis}}" />
                     </WrapPanel>
                 </WrapPanel>
                 <ItemsControl Grid.Row="1" ItemsSource="{Binding SettingsToggles, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" VerticalAlignment="Center">


### PR DESCRIPTION
Add global PvP burst control system that prevents burst abilities from
being wasted on Warmachina NPCs and provides manual burst control via hotkey.

Features:
- Global "Hold Burst" toggle with configurable hotkey binding
- Warmachina detection (Ravens, Falcons, Striking Dummies, Icebound Tomeliths, Interceptors)
- "Use Burst on Warmachina" option in Global PvP settings
- Centralized ShouldUseBurst() logic in CommonPvp.cs
- Burst gating implemented across all 21 jobs preserving exact ability order
- Full localization support (English/Chinese)

Technical Changes:
- Added HoldPvpBurst, HoldPvpBurstKey, HoldPvpBurstModkey, PvpUseBurstOnWarmachina to BaseSettings
- Created CommonPvp.ShouldUseBurst() method for centralized burst gating logic
- Updated all job PvP rotations to wrap burst abilities in ShouldUseBurst() checks
- Added Global PvP settings UI with hotkey binding and Warmachina checkbox
- Hotkey registration persists across sessions and updates immediately on change

All rotations preserve original ability order