### PR TITLE
Add ZoomHack logging and add property changed handler

### DIFF
--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -12,6 +12,12 @@
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\release\</OutputPath>
@@ -28,6 +34,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Deploy|AnyCPU'">
     <OutputPath>bin\deploy\</OutputPath>
     <Optimize>true</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
@@ -76,7 +83,7 @@
       <Version>4.1.0</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.732" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.781" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/Magitek/Models/Account/BaseSettings.cs
+++ b/Magitek/Models/Account/BaseSettings.cs
@@ -1,4 +1,5 @@
 ﻿using ff14bot.Enums;
+using Magitek.Utilities;
 using PropertyChanged;
 using System.ComponentModel;
 using System.Configuration;
@@ -10,7 +11,18 @@ namespace Magitek.Models.Account
     [AddINotifyPropertyChangedInterface]
     public class BaseSettings : JsonSettings
     {
-        public BaseSettings() : base(CharacterSettingsDirectory + "/Magitek/BaseSettings.json") { }
+        public BaseSettings() : base(CharacterSettingsDirectory + "/Magitek/BaseSettings.json")
+        {
+            PropertyChanged += OnPropertyChanged;
+        }
+
+        public void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ZoomHack))
+            {
+                Utilities.ZoomHack.Toggle();
+            }
+        }
 
         private static BaseSettings _instance;
 

--- a/Magitek/Utilities/ZoomHack.cs
+++ b/Magitek/Utilities/ZoomHack.cs
@@ -12,7 +12,7 @@ namespace Magitek.Utilities
 
         private const string MaxZoomOffsetPattern = "Search F3 0F 10 9F ? ? ? ? 4C 8D 44 24 Add 4 Read32";
 
-        private static readonly bool offsetFound = false;
+        private static readonly bool offsetFound;
         private static readonly int Offset;
         static ZoomHack()
         {
@@ -24,7 +24,8 @@ namespace Magitek.Utilities
             }
             catch
             {
-                Logger.Write($@"[Magitek] ZoomHack Failed due to FFXIV Update");
+                offsetFound = false;
+                Logger.WriteInfo("ZoomHack Failed due to FFXIV Update");
             }
         }
 
@@ -36,6 +37,8 @@ namespace Magitek.Utilities
             if (!offsetFound)
                 return;
 
+            var status = BaseSettings.Instance.ZoomHack ? "Enabled" : "Disabled";
+            Logger.WriteInfo($"ZoomHack {status}");
             Core.Memory.Write(CameraManager.CameraPtr + Offset, BaseSettings.Instance.ZoomHack ? 200f : 20f);
             _isEnabled = BaseSettings.Instance.ZoomHack;
         }

--- a/MagitekLoader/MagitekLoader.csproj
+++ b/MagitekLoader/MagitekLoader.csproj
@@ -11,6 +11,7 @@
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <LangVersion>11</LangVersion>
+    <PlatformTarget>x64</PlatformTarget>
     <AssemblyTitle>MagitekLoader</AssemblyTitle>
     <Product>MagitekLoader</Product>
     <Copyright>Copyright ©  2017</Copyright>
@@ -32,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.658" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.781" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Changed Logger.Write to Logger.WriteInfo for better visibility (gold color)
- Fixed offsetFound initialization in ZoomHack static constructor
- Added property changed handler in BaseSettings to call ZoomHack.Toggle() when setting changes
- Made OnPropertyChanged public so PropertyChanged.Fody can access it
- Removed redundant [Magitek] prefix from log messages