### PR TITLE
BLM - Fix the low level rotation below level 35ish fire/blizz/transpose. && retrace leylines

### DIFF
--- a/Magitek/Logic/BlackMage/Buff.cs
+++ b/Magitek/Logic/BlackMage/Buff.cs
@@ -30,7 +30,7 @@ namespace Magitek.Logic.BlackMage
             if ((MovementManager.IsMoving && AstralStacks == 3))
                 return await Spells.Triplecast.Cast(Core.Me);
 
-            if (BlackMageSettings.Instance.TripleCastWhileMoving && Spells.Triplecast.Charges<= 1)
+            if (BlackMageSettings.Instance.TripleCastWhileMoving && Spells.Triplecast.Charges <= 1)
                 return false;
 
             // Don't dot if time in combat less than 30 seconds
@@ -101,12 +101,12 @@ namespace Magitek.Logic.BlackMage
                 || Core.Me.HasAura(Auras.Triplecast)))
                 // High Fire II is always used at the start of Astral
                 return await Spells.LeyLines.Cast(Core.Me);
-           
+
             return await Spells.LeyLines.Cast(Core.Me);
         }
 
-       private static readonly uint[] ThunderAuras =
-       {
+        private static readonly uint[] ThunderAuras =
+        {
             Auras.Thunder,
             Auras.Thunder2,
             Auras.Thunder3,
@@ -120,26 +120,25 @@ namespace Magitek.Logic.BlackMage
             if (Core.Me.ClassLevel < Spells.Retrace.LevelAcquired)
                 return false;
 
+            if (!Spells.Retrace.IsKnownAndReady())
+                return false;
+
             if (Spells.Retrace.Cooldown != TimeSpan.Zero)
+                return false;
+
+            if (!Core.Me.HasAura(Auras.LeyLines))
+                return false;
+
+            if (Core.Me.HasAura(Auras.CircleOfPower))
                 return false;
 
             if (MovementManager.IsMoving)
                 return false;
 
-            if (Core.Me.HasAura(Auras.LeyLines))
-                return false;
-
             if (!Core.Me.InCombat)
                 return false;
 
-            if (!Spells.Retrace.IsKnownAndReady())
-                return false;
-
-            if (Casting.SpellCastHistory.Count() > 0
-                && Casting.SpellCastHistory.Take(10).Any(s => s.Spell == Spells.LeyLines))
-                return await Spells.LeyLines.Masked().Cast(Core.Me);
-
-            return false;
+            return await Spells.Retrace.Cast(Core.Me);
         }
         public static async Task<bool> UmbralSoul()
         {
@@ -168,6 +167,32 @@ namespace Magitek.Logic.BlackMage
 
         }
 
+        public static async Task<bool> PreCombatUmbralSoul()
+        {
+            if (Core.Me.ClassLevel < Spells.UmbralSoul.LevelAcquired)
+                return false;
+
+            if (!BlackMageSettings.Instance.UmbralSoul)
+                return false;
+
+            if (!Spells.UmbralSoul.IsKnownAndReady())
+                return false;
+
+            // Only use out of combat (restores 10,000 MP when used outside combat)
+            if (Core.Me.InCombat)
+                return false;
+
+            // Can only be executed while under the effect of Umbral Ice
+            if (UmbralStacks == 0)
+                return false;
+
+            // Only use when not at max mana (to restore MP)
+            if (Core.Me.CurrentMana >= Core.Me.MaxMana)
+                return false;
+
+            return await Spells.UmbralSoul.Cast(Core.Me);
+        }
+
         public static async Task<bool> ManaFont()
         {
             if (Core.Me.ClassLevel < Spells.ManaFont.LevelAcquired)
@@ -176,7 +201,7 @@ namespace Magitek.Logic.BlackMage
             if (!BlackMageSettings.Instance.ManaFont)
                 return false;
 
-            if(UmbralStacks != 0)
+            if (UmbralStacks != 0)
                 return false;
 
             /*
@@ -238,6 +263,29 @@ namespace Magitek.Logic.BlackMage
         public static async Task<bool> Transpose()
         {
             if (Core.Me.ClassLevel < Spells.Transpose.LevelAcquired)
+                return false;
+
+            return await Spells.Transpose.Cast(Core.Me);
+        }
+
+        public static async Task<bool> PreCombatTranspose()
+        {
+            if (Core.Me.ClassLevel < Spells.Transpose.LevelAcquired)
+                return false;
+
+            if (!Spells.Transpose.IsKnownAndReady())
+                return false;
+
+            // Only transpose out of combat
+            if (Core.Me.InCombat)
+                return false;
+
+            // Only transpose when we have astral fire
+            if (AstralStacks == 0)
+                return false;
+
+            // Only transpose when not at max mana
+            if (Core.Me.CurrentMana >= Core.Me.MaxMana)
                 return false;
 
             return await Spells.Transpose.Cast(Core.Me);

--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -261,6 +261,10 @@ namespace Magitek
 
         public override void Pulse()
         {
+            // Early return if bot is shutting down to prevent accessing cached objects during cancellation
+            if (!TreeRoot.IsRunning)
+                return;
+
             Tracking.Update();
             Combat.AdjustCombatTime();
             Combat.AdjustDutyTime();

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -25,8 +25,8 @@ namespace Magitek.Rotations
             if (!BlackMageSettings.Instance.UsePreCombatTranspose)
                 return false;
 
-            if (await Buff.UmbralSoul()) return true;
-            if (await Buff.Transpose()) return true;
+            if (await Buff.PreCombatUmbralSoul()) return true;
+            if (await Buff.PreCombatTranspose()) return true;
 
             return false;
         }
@@ -61,6 +61,7 @@ namespace Magitek.Rotations
             if (await Buff.Amplifier()) return true;
             if (await Buff.Triplecast()) return true;
             if (await Buff.LeyLines()) return true;
+            if (await Buff.Retrace()) return true;
             if (await Buff.ManaFont()) return true;
             if (await Buff.UmbralSoul()) return true;
 
@@ -90,9 +91,13 @@ namespace Magitek.Rotations
             if (await SingleTarget.Fire3()) return true;
 
             // Low-level mana management: Transpose from Astral Fire to Umbral Ice when out of mana
-            if (Core.Me.ClassLevel < Spells.Blizzard3.LevelAcquired)
+            if (Core.Me.ClassLevel < Spells.Blizzard3.LevelAcquired || !Spells.Blizzard3.IsKnown() || !Spells.Fire3.IsKnown())
             {
-                if (AstralStacks > 0 && Core.Me.CurrentMana < 800 && Spells.Transpose.IsKnownAndReady())
+                if (AstralStacks > 0 && Core.Me.CurrentMana < Spells.Fire.Cost && Spells.Transpose.IsKnownAndReady())
+                {
+                    if (await Buff.Transpose()) return true;
+                }
+                if (UmbralStacks > 0 && Core.Me.CurrentMana == Core.Me.MaxMana && Spells.Transpose.IsKnownAndReady())
                 {
                     if (await Buff.Transpose()) return true;
                 }
@@ -111,7 +116,7 @@ namespace Magitek.Rotations
             if (await CommonPvp.CommonTasks(BlackMageSettings.Instance)) return true;
 
             // Limit Break
-            if (CommonPvp.ShouldUseBurst())
+            if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(BlackMageSettings.Instance))
             {
                 if (await Pvp.SoulResonancePvp()) return true;
             }


### PR DESCRIPTION
BLM - Add retrace leylines support.
Core - Fix stack trace that can occur when stopping the bot during combat.