### PR TITLE
Fix nearby enemy guards and smart AoE targeting

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -236,17 +236,29 @@ namespace Magitek.Extensions
 
         public static IEnumerable<BattleCharacter> EnemiesNearby(this GameObject unit, float distance)
         {
-            return Combat.Enemies.Where(r => r.Distance(unit) <= distance + Core.Me.CombatReach + unit.CombatReach);
+            if (unit == null || Core.Me == null)
+                return Enumerable.Empty<BattleCharacter>();
+
+            var meCombatReach = Core.Me.CombatReach;
+            var unitCombatReach = unit.CombatReach;
+
+            return Combat.Enemies.Where(r => r != null && r.Distance(unit) <= distance + meCombatReach + unitCombatReach);
         }
 
         public static IEnumerable<BattleCharacter> EnemiesNearbyOoc(this GameObject unit, float distance)
         {
-            return GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r.IsTargetable && r.CurrentHealth > 0 && r.CanAttack && r.Distance(unit) <= distance);
+            if (unit == null)
+                return Enumerable.Empty<BattleCharacter>();
+
+            return GameObjectManager.GetObjectsOfType<BattleCharacter>().Where(r => r != null && r.IsTargetable && r.CurrentHealth > 0 && r.CanAttack && r.Distance(unit) <= distance);
         }
 
         public static IEnumerable<BattleCharacter> EnemiesNearbyWithMyAura(this GameObject unit, float distance, uint aura)
         {
-            return Combat.Enemies.Where(r => r.Distance(unit) <= distance && r.HasAura(aura, true));
+            if (unit == null)
+                return Enumerable.Empty<BattleCharacter>();
+
+            return Combat.Enemies.Where(r => r != null && r.Distance(unit) <= distance && r.HasAura(aura, true));
         }
 
         public static bool IsMelee(this GameObject unit)

--- a/Magitek/Utilities/Combat.cs
+++ b/Magitek/Utilities/Combat.cs
@@ -127,7 +127,7 @@ namespace Magitek.Utilities
                 return Core.Me.CurrentTarget == null ? null : (BattleCharacter)Core.Me.CurrentTarget;
 
             var bestTarget = Enemies.Where(x => x.WithinSpellRange(spell.Range))
-                .OrderBy(x => x.EnemiesNearby(spell.Radius).Count());
+                .OrderByDescending(x => x.EnemiesNearby(spell.Radius).Count());
 
             return bestTarget?.FirstOrDefault();
         }


### PR DESCRIPTION
## Summary
- Return an empty enemy sequence when nearby-enemy helpers are called with a null anchor unit.
- Guard null enemy entries before distance/aura checks.
- Make SmartAoeTarget prefer the densest enemy cluster instead of the sparsest one.

## Root Cause
Summoner Painflare could call `Core.Me.CurrentTarget.EnemiesNearby(5).Count()` after the current target disappeared. Because `EnemiesNearby()` deferred its null dereference into the LINQ query, the crash surfaced from `WhereListIterator.GetCount(...)` during `Count()`.

The shared smart AoE helper also sorted nearby enemy counts ascending, so the smart target option selected the least clustered target.

## Validation
- `dotnet build Magitek\Magitek.sln`