### PR TITLE
NIN - Fix Kassatsu and Hyosho burst alignment with Kunai's Bane

### DIFF
--- a/Magitek/Logic/Ninja/Buff.cs
+++ b/Magitek/Logic/Ninja/Buff.cs
@@ -29,6 +29,11 @@ namespace Magitek.Logic.Ninja
             if (Core.Me.HasAura(Auras.TenChiJin) || NinjaRoutine.UsedMudras.Count() > 0)
                 return false;
 
+            // Hold Kassatsu until Trick Attack/Kunai's Bane is on cooldown so Hyosho lands inside the debuff window
+            if (NinjaSettings.Instance.UseTrickAttack && !NinjaSettings.Instance.BurstLogicHoldBurst
+                && Spells.TrickAttack.IsKnownAndReady())
+                return false;
+
             return await Spells.Kassatsu.Cast(Core.Me);
 
         }

--- a/Magitek/Logic/Ninja/Ninjutsu.cs
+++ b/Magitek/Logic/Ninja/Ninjutsu.cs
@@ -198,10 +198,7 @@ namespace Magitek.Logic.Ninja
             if (!Spells.Jin.IsKnown())
                 return false;
 
-            if (!Core.Me.HasAura(Auras.Kassatsu) && (Casting.SpellCastHistory.Count() > 0 && Casting.SpellCastHistory.First().Spell != Spells.Kassatsu))
-                return false;
-
-            if (Spells.TrickAttack.Cooldown < new TimeSpan(0, 0, 45))
+            if (!Core.Me.HasAura(Auras.Kassatsu))
                 return false;
 
             if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() >= 3)
@@ -220,10 +217,7 @@ namespace Magitek.Logic.Ninja
             if (!Spells.Jin.IsKnown())
                 return false;
 
-            if (!Core.Me.HasAura(Auras.Kassatsu) && (Casting.SpellCastHistory.Count() > 0 && Casting.SpellCastHistory.First().Spell != Spells.Kassatsu))
-                return false;
-
-            if (Spells.TrickAttack.Cooldown < new TimeSpan(0, 0, 45))
+            if (!Core.Me.HasAura(Auras.Kassatsu))
                 return false;
 
             if (Core.Me.CurrentTarget.EnemiesNearby(5).Count() < 3)


### PR DESCRIPTION
## Summary
- **Hold Kassatsu until Trick Attack/Kunai's Bane is on cooldown** so the burst sequence is Kunai's Bane → Kassatsu → Hyosho Ranryu, ensuring Hyosho lands inside the Kunai's Bane debuff window with both damage bonuses active
- **Simplify Hyosho/Goka Kassatsu guard** to just check `HasAura(Auras.Kassatsu)` — removes the fragile `SpellCastHistory` fallback that could fail mid-mudra sequence (each mudra press pushes Kassatsu out of `First()` position), and removes the redundant `TrickAttack.Cooldown < 45s` gate that permanently blocked Hyosho when `UseTrickAttack` was disabled or `BurstLogicHoldBurst` was enabled
- Kassatsu hold respects `UseTrickAttack` and `BurstLogicHoldBurst` settings so it won't be held indefinitely when those features are disabled

## Test plan
- [x] Verified via hot-reload on striking dummy — burst sequence now correctly orders: Mug/Dokumori → Bunshin → Trick Attack/Kunai's Bane → Kassatsu → Hyosho Ranryu
- [x] Confirmed Hyosho lands ~4.5s into Kunai's Bane window (previously landed ~3s before it)
- [x] Build passes with 0 errors
- [ ] Test in level-synced content (below 76) to verify Kassatsu still enhances regular ninjutsu
- [ ] Test with `UseTrickAttack = false` to verify Kassatsu fires without being held
- [ ] Test with `BurstLogicHoldBurst = true` to verify Kassatsu fires without being held