### PR TITLE
PvP - Reorder LINQ predicates to defer InLineOfSight raycasts

### DIFF
--- a/Magitek/Logic/Machinist/Pvp.cs
+++ b/Magitek/Logic/Machinist/Pvp.cs
@@ -179,9 +179,9 @@ namespace Magitek.Logic.Machinist
                 var nearby = Combat.Enemies
                     .Where(e => e.WithinSpellRange(Spells.ScattergunPvp.Range)
                             && e.ValidAttackUnit()
-                            && e.InLineOfSight()
                             && !e.IsWarMachina()
-                            && !CommonPvp.GuardCheck(MachinistSettings.Instance, e))
+                            && !CommonPvp.GuardCheck(MachinistSettings.Instance, e)
+                            && e.InLineOfSight())
                     .OrderBy(e => e.Distance(Core.Me));
                 var nearbyTarget = nearby.FirstOrDefault();
 
@@ -297,9 +297,9 @@ namespace Magitek.Logic.Machinist
                 var nearby = Combat.Enemies
                     .Where(e => e.WithinSpellRange(Spells.BioblasterPvp.Range)
                             && e.ValidAttackUnit()
-                            && e.InLineOfSight()
                             && !e.IsWarMachina()
-                            && !CommonPvp.GuardCheck(MachinistSettings.Instance, e))
+                            && !CommonPvp.GuardCheck(MachinistSettings.Instance, e)
+                            && e.InLineOfSight())
                     .OrderBy(e => e.Distance(Core.Me));
                 var nearbyTarget = nearby.FirstOrDefault();
 

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -911,12 +911,12 @@ namespace Magitek.Logic.Roles
 
             // Search for any killable target in range
             var nearby = Combat.Enemies
-                .Where(e => e.WithinSpellRange(range)
+                .Where(e => !e.IsWarMachina()
+                        && e.WithinSpellRange(range)
                         && e.ValidAttackUnit()
-                        && e.InLineOfSight()
-                        && !e.IsWarMachina()
                         && (!checkGuard || !GuardCheck(settings, e))
-                        && (maxAlliesTargetingLimit <= 0 || !TooManyAlliesTargeting(settings, e)))
+                        && (maxAlliesTargetingLimit <= 0 || !TooManyAlliesTargeting(settings, e))
+                        && e.InLineOfSight())
                 .OrderBy(e => e.Distance(Core.Me));
 
             foreach (var target in nearby)


### PR DESCRIPTION
## Summary
- Reorder `Where()` predicate chains in PvP LINQ queries so `InLineOfSight()` (a raycast) is evaluated **last**, after cheap property checks (`WithinSpellRange`, `ValidAttackUnit`, `IsWarMachina`, `GuardCheck`) have already eliminated candidates.
- Affects `CommonPvp.FindKillableTargetInRange` (used by ~9 job PvP files) and two Machinist-specific targeting chains (Scattergun, Bioblaster).
- Reduces unnecessary raycasts in high-player-count PvP (72-player Frontline).

## Test plan
- [ ] Verify PvP targeting behavior unchanged in Crystalline Conflict
- [ ] Verify PvP targeting behavior unchanged in Frontline
- [ ] Verify WouldKill system still correctly identifies killable targets