### PR TITLE
PvP - Fix guard, range, targeting, and rotation bugs across all jobs

### DIFF
--- a/Magitek/Logic/Astrologian/Pvp.cs
+++ b/Magitek/Logic/Astrologian/Pvp.cs
@@ -16,6 +16,9 @@ namespace Magitek.Logic.Astrologian
             if (!Spells.FallMaleficPvp.CanCast())
                 return false;
 
+            if (!AstrologianSettings.Instance.Pvp_FallMalefic)
+                return false;
+
             if (MovementManager.IsMoving)
                 return false;
 
@@ -98,6 +101,9 @@ namespace Magitek.Logic.Astrologian
             // Handle each possible masked spell type
             if (maskedSpell.Id == Spells.DoubleFallMaleficPvp.Id)
             {
+                if (!AstrologianSettings.Instance.Pvp_FallMalefic)
+                    return false;
+
                 if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                     return false;
 
@@ -105,6 +111,9 @@ namespace Magitek.Logic.Astrologian
             }
             else if (maskedSpell.Id == Spells.DoubleAspectedBeneficPvp.Id)
             {
+                if (!AstrologianSettings.Instance.Pvp_AspectedBenefic)
+                    return false;
+
                 if (Globals.HealTarget?.CurrentHealthPercent <= AstrologianSettings.Instance.Pvp_AspectedBeneficHealthPercent)
                 {
                     return await maskedSpell.Cast(Globals.HealTarget);
@@ -120,6 +129,9 @@ namespace Magitek.Logic.Astrologian
             }
             else if (maskedSpell.Id == Spells.DoubleGravityIIPvp.Id)
             {
+                if (!AstrologianSettings.Instance.Pvp_GravityII)
+                    return false;
+
                 if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                     return false;
 
@@ -154,6 +166,37 @@ namespace Magitek.Logic.Astrologian
                 return false;
 
             return await Spells.MacrocosmosPvp.Cast(Core.Me);
+        }
+
+        public static async Task<bool> MicrocosmosPvp()
+        {
+            if (!Spells.MicrocosmosPvp.CanCast())
+                return false;
+
+            if (!AstrologianSettings.Instance.Pvp_Microcosmos)
+                return false;
+
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            // Microcosmos detonates the Macrocosmos buff early for its heal — only meaningful while it's active.
+            if (!Core.Me.HasAura(Auras.PvpMacrocosmos))
+                return false;
+
+            // Detonate early when an ally (or self) within range drops below the configured heal threshold,
+            // rather than waiting for the buff to expire on its own (the dev wanted that control).
+            var alliesNeedingHealing = Group.CastableAlliesWithin15.Count(x =>
+                x.IsValid &&
+                x.IsAlive &&
+                x.CurrentHealthPercent <= AstrologianSettings.Instance.Pvp_MicrocosmosHealthPercent);
+
+            if (Core.Me.CurrentHealthPercent <= AstrologianSettings.Instance.Pvp_MicrocosmosHealthPercent)
+                alliesNeedingHealing++;
+
+            if (alliesNeedingHealing < 1)
+                return false;
+
+            return await Spells.MicrocosmosPvp.Cast(Core.Me);
         }
 
         public static async Task<bool> MinorArcanaPvp()

--- a/Magitek/Logic/Bard/Pvp.cs
+++ b/Magitek/Logic/Bard/Pvp.cs
@@ -222,6 +222,8 @@ namespace Magitek.Logic.Bard
 
         public static async Task<bool> FinalFantasiaPvp()
         {
+            // Self-buff + Encore of Light enabler with no range of its own. Only fire it on an attackable, in-range,
+            // low-HP target so the buff converts into a secured kill instead of being spent on a random full-HP enemy.
             if (!BardSettings.Instance.Pvp_UseFinalFantasia)
                 return false;
 
@@ -259,6 +261,14 @@ namespace Magitek.Logic.Bard
                 return false;
 
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.EncoreOfLightPvp.Range))
+                return false;
+
+            // Encore of Light is ~10k damage (not guard-ignoring) — don't waste it into a Guarded target (99% mitigated)
+            if (CommonPvp.GuardCheck(BardSettings.Instance, Core.Me.CurrentTarget))
+                return false;
+
+            // Encore of Light can't apply to Warmachina riders — don't waste it on a mounted target
+            if (CommonPvp.IsPvpMounted(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.EncoreOfLightPvp.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/BlackMage/Pvp.cs
+++ b/Magitek/Logic/BlackMage/Pvp.cs
@@ -132,13 +132,17 @@ namespace Magitek.Logic.BlackMage
             if (CommonPvp.WouldKillWithPotency(potency, Core.Me.CurrentTarget))
                 return await Spells.XenoglossyPvp.Cast(Core.Me.CurrentTarget);
 
+            // Beyond securing a kill, don't sink Xenoglossy into a Guarded target (99% mitigated) as overcap/movement filler
+            if (CommonPvp.GuardCheck(BlackMageSettings.Instance, Core.Me.CurrentTarget))
+                return false;
+
             // If "Save for Kills" is enabled, skip overcap protection (would prevent us from ever using charges for movement/healing)
             if (!BlackMageSettings.Instance.Pvp_SaveXenoglossyForKills)
             {
-                // Calculate overcap threshold: GCD is 2.5s, charge time is 16s
+                // Calculate overcap threshold: GCD is 2.5s, charge time is 15s (Patch 7.5; was 16s)
                 // We need to cast if we'll get a charge within the next GCD window
                 const double PvpGcdSeconds = 2.5;
-                const double ChargeTimeSeconds = 16.0;
+                const double ChargeTimeSeconds = 15.0;
                 double overcapThreshold = Spells.XenoglossyPvp.MaxCharges - (PvpGcdSeconds / ChargeTimeSeconds);
 
                 // 2. Cast if about to overcap charges (prevent waste)

--- a/Magitek/Logic/Dancer/Pvp.cs
+++ b/Magitek/Logic/Dancer/Pvp.cs
@@ -272,9 +272,9 @@ namespace Magitek.Logic.Dancer
 
             var cureTargets = Group.CastableParty.Count(x => x.IsValid && x.CurrentHealthPercent < DancerSettings.Instance.Pvp_CuringWaltzHP && x.Distance(Core.Me) < 5 + x.CombatReach);
 
-            if (Core.Me.HasAura(Auras.ClosedPosition))
+            if (Core.Me.HasAura(Auras.PvpClosedPosition))
             {
-                var DancePartner = Group.CastableParty.FirstOrDefault(x => x.HasMyAura(Auras.DancePartner));
+                var DancePartner = Group.CastableParty.FirstOrDefault(x => x.HasMyAura(Auras.PvpDancePartner));
 
                 if (DancePartner != null)
                     cureTargets += Group.CastableParty.Count(x => x.IsValid && x.CurrentHealthPercent < DancerSettings.Instance.Pvp_CuringWaltzHP && x.Distance(DancePartner) < 5 + x.CombatReach);
@@ -283,7 +283,8 @@ namespace Magitek.Logic.Dancer
             if (cureTargets < 1)
                 return false;
 
-            return await Spells.CuringWaltzPvp.Cast(Core.Me.CurrentTarget);
+            // Curing Waltz is a self-centered AoE heal — cast on self, not the enemy target (matches the PvE usage).
+            return await Spells.CuringWaltzPvp.Cast(Core.Me);
         }
 
         private static int GetWeight(Character c)

--- a/Magitek/Logic/DarkKnight/Pvp.cs
+++ b/Magitek/Logic/DarkKnight/Pvp.cs
@@ -154,6 +154,8 @@ namespace Magitek.Logic.DarkKnight
             if (Core.Me.CurrentHealthPercent > DarkKnightSettings.Instance.Pvp_EventideHealthPercent)
                 return false;
 
+            // Eventide is a tank-invuln line/rectangle AoE, not a gap-closer — require enemies nearby so it's used in
+            // a swarm rather than fired at a single stray target.
             if (Combat.Enemies.Count(x => x.WithinSpellRange(20)) < 1)
                 return false;
 

--- a/Magitek/Logic/Dragoon/Pvp.cs
+++ b/Magitek/Logic/Dragoon/Pvp.cs
@@ -117,6 +117,13 @@ namespace Magitek.Logic.Dragoon
             if (!DragoonSettings.Instance.Pvp_Geirskogul)
                 return false;
 
+            // Starcross Ready and Nastrond Ready can be up simultaneously, but casting Nastrond CONSUMES Starcross
+            // Ready while casting Starcross leaves Nastrond Ready intact. So whenever Starcross is ready (and enabled),
+            // hold Nastrond and let Starcross fire first — otherwise we'd waste the queued Starcross. The aura (not
+            // CanCast) is used deliberately: it persists across GCDs/range gaps until Starcross is actually cast.
+            if (DragoonSettings.Instance.Pvp_Starcross && Core.Me.HasAura(Auras.PvpStarcrossReady))
+                return false;
+
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.NastrondPvp.Range))
                 return false;
 
@@ -232,7 +239,7 @@ namespace Magitek.Logic.Dragoon
             if (!DragoonSettings.Instance.Pvp_Starcross)
                 return false;
 
-            if (Core.Me.CurrentTarget.WithinSpellRange(Spells.StarcrossPvp.Range))
+            if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.StarcrossPvp.Range))
                 return false;
 
             return await Spells.StarcrossPvp.Cast(Core.Me.CurrentTarget);
@@ -240,6 +247,8 @@ namespace Magitek.Logic.Dragoon
 
         public static async Task<bool> SkyShatterPvp()
         {
+            // Not wired into the rotation: Sky Shatter is the "land" payoff of Sky High, and a routine can't reliably
+            // time the dive (early dives waste it, and it's sometimes used purely to escape). Left for manual use.
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 

--- a/Magitek/Logic/Gunbreaker/Pvp.cs
+++ b/Magitek/Logic/Gunbreaker/Pvp.cs
@@ -55,6 +55,9 @@ namespace Magitek.Logic.Gunbreaker
             if (!Spells.BurstStrikePvp.CanCast())
                 return false;
 
+            if (!GunbreakerSettings.Instance.Pvp_BurstStrike)
+                return false;
+
             return await Spells.BurstStrikePvp.CastPvpCombo(Spells.SolidBarrelPvpCombo, Core.Me.CurrentTarget);
         }
 
@@ -154,6 +157,9 @@ namespace Magitek.Logic.Gunbreaker
             if (!Core.Me.CurrentTarget.WithinSpellRange(spell.Range))
                 return false;
 
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
             return await spell.Cast(Core.Me.CurrentTarget);
         }
 
@@ -245,6 +251,10 @@ namespace Magitek.Logic.Gunbreaker
                     return false;
 
                 if (Core.Me.CurrentTarget.CurrentHealthPercent > 50)
+                    return false;
+
+                // Blasting Zone is normal damage (not guard-ignoring) — don't waste it into a Guarded target.
+                if (CommonPvp.GuardCheck(GunbreakerSettings.Instance, Core.Me.CurrentTarget))
                     return false;
 
                 return await Spells.BlastingZonePvp.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Machinist/Pvp.cs
+++ b/Magitek/Logic/Machinist/Pvp.cs
@@ -107,7 +107,7 @@ namespace Magitek.Logic.Machinist
             if (!Spells.DetonatorPvp.CanCast())
                 return false;
 
-            if (WildfireTarget == null || !WildfireTarget.HasAura(Auras.PvpWildfire))
+            if (WildfireTarget == null || !WildfireTarget.HasAura(Auras.PvpWildfire, true))
             {
                 WildfireTarget = null;
                 WildfireStacks = 0;
@@ -146,7 +146,9 @@ namespace Magitek.Logic.Machinist
             if (!Spells.FullMetalFieldPvp.CanCast())
                 return false;
 
-            if (MachinistSettings.Instance.Pvp_SaveFullMetalForWildfire)
+            // Only hold Full Metal Field for a Wildfire combo if Wildfire is actually enabled — otherwise the hold
+            // would suppress Full Metal Field forever, waiting on a Wildfire that never fires.
+            if (MachinistSettings.Instance.Pvp_SaveFullMetalForWildfire && MachinistSettings.Instance.Pvp_Wildfire)
             {
                 var wildfireReady = Spells.WildfirePvp.Cooldown.TotalSeconds;
                 if (wildfireReady <= 8)
@@ -368,7 +370,8 @@ namespace Magitek.Logic.Machinist
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.BishopAutoturretPvp.Range))
                 return false;
 
-            // Count total enemies nearby (within 20 yalms)
+            // Flat 20y proximity (not WithinSpellRange): a wider awareness radius than the turret's range, to tell a
+            // 1v1 apart from a grouped fight.
             var nearbyEnemyCount = Combat.Enemies.Count(x => x.Distance(Core.Me) <= 20);
 
             // If only 1 enemy nearby (1v1 situation), always cast turret

--- a/Magitek/Logic/Monk/Pvp.cs
+++ b/Magitek/Logic/Monk/Pvp.cs
@@ -104,6 +104,9 @@ namespace Magitek.Logic.Monk
             if (!Core.Me.CurrentTarget.WithinSpellRange(spell.Range))
                 return false;
 
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
             return await spell.Cast(Core.Me.CurrentTarget);
         }
 
@@ -119,6 +122,9 @@ namespace Magitek.Logic.Monk
                 return false;
 
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.WindsReplyPvp.Range))
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
             return await Spells.WindsReplyPvp.Cast(Core.Me.CurrentTarget);
@@ -178,6 +184,9 @@ namespace Magitek.Logic.Monk
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.ThunderclapPvp.Range))
                 return false;
 
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
             return await Spells.ThunderclapPvp.Cast(Core.Me.CurrentTarget);
         }
 
@@ -196,6 +205,10 @@ namespace Magitek.Logic.Monk
                 return false;
 
             if (Core.Me.HasAura(Auras.PvpEarthResonance, true, 5555))
+                return false;
+
+            // Honor the configured HP threshold — hold Earth's Reply for emergencies instead of firing at full HP.
+            if (Core.Me.CurrentHealthPercent > MonkSettings.Instance.Pvp_EarthReplyHealthPercent)
                 return false;
 
             if (Combat.Enemies.Count(x => x.WithinSpellRange(6)) < 1)

--- a/Magitek/Logic/Ninja/Pvp.cs
+++ b/Magitek/Logic/Ninja/Pvp.cs
@@ -71,6 +71,9 @@ namespace Magitek.Logic.Ninja
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.AssassinatePvp.Range))
                 return false;
 
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
             return await Spells.AssassinatePvp.Cast(Core.Me.CurrentTarget);
         }
 
@@ -279,7 +282,7 @@ namespace Magitek.Logic.Ninja
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (Combat.Enemies.Count(x => x.Distance(Core.Me.CurrentTarget) <= 5 + x.CombatReach) < NinjaSettings.Instance.Pvp_GokaMekkyakuMinEnemies)
+            if (Combat.Enemies.Count(x => x.Distance(Core.Me.CurrentTarget) < Spells.GokaMekkyakuPvp.Radius) < NinjaSettings.Instance.Pvp_GokaMekkyakuMinEnemies)
                 return false;
 
             return await Spells.GokaMekkyakuPvp.Cast(Core.Me.CurrentTarget);
@@ -426,6 +429,9 @@ namespace Magitek.Logic.Ninja
                 return false;
 
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.ZeshoMeppoPvp.Range))
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
             return await Spells.ZeshoMeppoPvp.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Paladin/Pvp.cs
+++ b/Magitek/Logic/Paladin/Pvp.cs
@@ -260,6 +260,29 @@ namespace Magitek.Logic.Paladin
             return await Spells.HolySheltronPvp.Cast(Core.Me);
         }
 
+        public static async Task<bool> GuardianPvp()
+        {
+            if (Core.Me.HasAura(Auras.PvpGuard))
+                return false;
+
+            if (!Spells.GuardianPvp.CanCast())
+                return false;
+
+            if (!PaladinSettings.Instance.Pvp_Guardian)
+                return false;
+
+            // Protect the most-hurt nearby ally below the configured HP threshold (Pvp_GuardianHealthPercent).
+            var ally = Group.CastableAlliesWithin30
+                .Where(a => a.IsValid && a.IsAlive && !a.IsMe && a.CurrentHealthPercent <= PaladinSettings.Instance.Pvp_GuardianHealthPercent)
+                .OrderBy(a => a.CurrentHealthPercent)
+                .FirstOrDefault();
+
+            if (ally == null)
+                return false;
+
+            return await Spells.GuardianPvp.Cast(ally);
+        }
+
         public static async Task<bool> IntervenePvp()
         {
             if (Core.Me.HasAura(Auras.PvpGuard))
@@ -311,13 +334,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.BladeofFaithPvp.CanCast())
-                return false;
-
             if (!Core.Me.HasTarget)
                 return false;
 
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.BladeofFaithPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.BladeofFaithPvp.Cast(Core.Me.CurrentTarget);
@@ -328,13 +351,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.BladeofTruthPvp.CanCast())
-                return false;
-
             if (!Core.Me.HasTarget)
                 return false;
 
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.BladeofTruthPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.BladeofTruthPvp.Cast(Core.Me.CurrentTarget);
@@ -345,13 +368,13 @@ namespace Magitek.Logic.Paladin
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Spells.BladeofValorPvp.CanCast())
-                return false;
-
             if (!Core.Me.HasTarget)
                 return false;
 
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+                return false;
+
+            if (!Spells.BladeofValorPvp.CanCast(Core.Me.CurrentTarget))
                 return false;
 
             return await Spells.BladeofValorPvp.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/Pictomancer/Pvp.cs
+++ b/Magitek/Logic/Pictomancer/Pvp.cs
@@ -120,6 +120,11 @@ namespace Magitek.Logic.Pictomancer
             if (!PictomancerSettings.Instance.Pvp_UsePaintBlack)
                 return false;
 
+            // Comet in Black is the black-paint cast under Subtractive Palette — honor its dedicated toggle too
+            // (previously dead: only Pvp_UsePaintBlack gated this cast).
+            if (!PictomancerSettings.Instance.Pvp_UseCometInBlack)
+                return false;
+
             if (!Core.Me.HasAura(Auras.PvpSubtractivePalette))
                 return false;
 
@@ -222,9 +227,9 @@ namespace Magitek.Logic.Pictomancer
             if (!spell.CanCast())
                 return false;
 
-            // Check if masked spell is Retribution of Madeen (ID 39783) or Mog of the Ages (ID 39782)
-            // Mog of the Ages: 14,000 potency, Retribution of Madeen: 16,000 potency
-            double potency = (spell.Id == Spells.RetributionOfMadeenPvp.Id) ? 16000 : 14000;
+            // Mog of the Ages and Retribution of the Madeen are both 14,000 potency as of Patch 7.5
+            // (7.5 reduced Retribution of the Madeen from 16,000 -> 14,000).
+            double potency = 14000;
 
             // Find killable target in range (handles target validation internally)
             var killableTarget = CommonPvp.FindKillableTargetInRange(
@@ -328,6 +333,7 @@ namespace Magitek.Logic.Pictomancer
             if (!spell.CanCast())
                 return false;
 
+            // Raw-distance count with a configurable yalm radius, intentionally wider than the spell's own radius.
             if (Combat.Enemies.Count(x => x.Distance(Core.Me) <= PictomancerSettings.Instance.Pvp_AdventofChocobastionYalms + x.CombatReach) < PictomancerSettings.Instance.Pvp_AdventofChocobastionCount)
                 return false;
 

--- a/Magitek/Logic/Reaper/Normal/Pvp.cs
+++ b/Magitek/Logic/Reaper/Normal/Pvp.cs
@@ -120,7 +120,7 @@ namespace Magitek.Logic.Reaper
             if (!ReaperSettings.Instance.Pvp_DeathWarrant)
                 return false;
 
-            if (Core.Me.CurrentTarget.WithinSpellRange(7))
+            if (!Core.Me.CurrentTarget.WithinSpellRange(25))
                 return false;
 
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
@@ -196,10 +196,6 @@ namespace Magitek.Logic.Reaper
             if (Core.Me.CurrentTarget.CurrentHealthPercent > ReaperSettings.Instance.Pvp_HarvestMoonTargetHealthPercent)
                 return false;
 
-            // Don't use if target is above 50% HP and we have Soulsow with 2s+ remaining
-            if (Core.Me.CurrentTarget.CurrentHealthPercent > 50)
-                return false;
-
             return await Spells.HarvestMoonPvp.Cast(Core.Me.CurrentTarget);
         }
 
@@ -241,6 +237,9 @@ namespace Magitek.Logic.Reaper
                 return false;
 
             if (!Core.Me.CurrentTarget.WithinSpellRange(8))
+                return false;
+
+            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
             return await Spells.GuillotinePvp.Cast(Core.Me.CurrentTarget);

--- a/Magitek/Logic/RedMage/Pvp.cs
+++ b/Magitek/Logic/RedMage/Pvp.cs
@@ -245,6 +245,7 @@ namespace Magitek.Logic.RedMage
 
         public static async Task<bool> ResolutionPvp()
         {
+            // Standalone HP-gated finisher, not a step of the Enchanted combo, so the HP gate can't stall the combo.
             if (!Spells.ResolutionPvp.CanCast())
                 return false;
 
@@ -287,7 +288,8 @@ namespace Magitek.Logic.RedMage
                 (float)Spells.SouthernCrossPvp.Range,
                 ignoreGuard: false,
                 checkGuard: true,
-                searchAllTargets: RedMageSettings.Instance.Pvp_SouthernCrossAnyTarget);
+                searchAllTargets: RedMageSettings.Instance.Pvp_SouthernCrossAnyTarget,
+                maxAlliesTargetingLimit: RedMageSettings.Instance.Pvp_MaxAlliesTargetingLimit);
 
             if (killableTarget != null)
             {
@@ -307,6 +309,10 @@ namespace Magitek.Logic.RedMage
                     return false;
 
                 if (Core.Me.CurrentTarget.CurrentHealthPercent > RedMageSettings.Instance.Pvp_SouthernCrossTargetHealthPercent)
+                    return false;
+
+                if (RedMageSettings.Instance.Pvp_MaxAlliesTargetingLimit > 0 &&
+                    CommonPvp.TooManyAlliesTargeting(RedMageSettings.Instance, Core.Me.CurrentTarget))
                     return false;
 
                 if (!Spells.SouthernCrossPvp.CanCast(Core.Me.CurrentTarget))

--- a/Magitek/Logic/Roles/CommonPvp.cs
+++ b/Magitek/Logic/Roles/CommonPvp.cs
@@ -790,22 +790,20 @@ namespace Magitek.Logic.Roles
                 }
             }
 
-            // Special case: Debana (SAM) - only applies if we're SAM and we applied it
-            // Note: We can't easily verify if we applied it, so we check if we're SAM
-            if (target.HasAura(Auras.PvpDebana) && Core.Me.CurrentJob == ClassJobType.Samurai)
+            // Special case: Debana (SAM) - only applies if WE applied it (isMyAura) and we're SAM
+            if (target.HasAura(Auras.PvpDebana, true) && Core.Me.CurrentJob == ClassJobType.Samurai)
             {
                 estimatedDamage *= 1.15; // Increases damage dealt to target by 15%
             }
 
-            // Special case: Noxious Gnash (VPR) - only applies if we're VPR and we applied it
-            // Note: We can't easily verify if we applied it, so we check if we're VPR
-            if (target.HasAura(Auras.PvpNoxiousGnash) && Core.Me.CurrentJob == ClassJobType.Viper)
+            // Special case: Noxious Gnash (VPR) - only applies if WE applied it (isMyAura) and we're VPR
+            if (target.HasAura(Auras.PvpNoxiousGnash, true) && Core.Me.CurrentJob == ClassJobType.Viper)
             {
                 estimatedDamage *= 1.25; // Increases damage dealt to target by 25%
             }
 
             // Special case: Kuzushi (SAM) - increases damage dealt to target by 25% if we're SAM
-            if (target.HasAura(Auras.PvpKuzushi) && Core.Me.CurrentJob == ClassJobType.Samurai)
+            if (target.HasAura(Auras.PvpKuzushi, true) && Core.Me.CurrentJob == ClassJobType.Samurai)
             {
                 estimatedDamage *= 1.25; // Increases damage dealt to target by 25%
             }

--- a/Magitek/Logic/Sage/Pvp.cs
+++ b/Magitek/Logic/Sage/Pvp.cs
@@ -143,7 +143,7 @@ namespace Magitek.Logic.Sage
 
             var currentKardiaTarget = Group.CastableAlliesWithin30.Where(a => a.HasAura(Auras.PvpKardion, true)).FirstOrDefault();
 
-            // Only switch targets if current target is above 80% HP or if we don't have a target
+            // Only switch Kardia target if the current one is above 80% HP (hardcoded) or we don't have one.
             if (currentKardiaTarget != null && currentKardiaTarget.CurrentHealthPercent > 80 && currentKardiaTarget.WithinSpellRange(30))
             {
                 var kardiaTarget = Group.CastableAlliesWithin30
@@ -207,6 +207,9 @@ namespace Magitek.Logic.Sage
         public static async Task<bool> MesotesPvp()
         {
             if (!Spells.MesotesPvp.CanCast())
+                return false;
+
+            if (!SageSettings.Instance.Pvp_Mesotes)
                 return false;
 
             if (Core.Me.HasAura(Auras.PvpMesotes))

--- a/Magitek/Logic/Samurai/Pvp.cs
+++ b/Magitek/Logic/Samurai/Pvp.cs
@@ -1,11 +1,14 @@
 ﻿using ff14bot;
 using ff14bot.Managers;
+using ff14bot.Objects;
 using Magitek.Extensions;
 using Magitek.Models.Samurai;
 using Magitek.Utilities;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Magitek.Logic.Roles;
+using Auras = Magitek.Utilities.Auras;
 
 namespace Magitek.Logic.Samurai
 {
@@ -260,16 +263,58 @@ namespace Magitek.Logic.Samurai
             if (!Spells.ZantetsukenPvp.CanCast())
                 return false;
 
+            // Zantetsuken deals 24,000 potency, or 100% of the target's max HP when OUR Kuzushi is on them.
+            // Mitigation and ally damage buffs still scale it, so run the real number per-target through the potency
+            // calculator (same pattern as MCH Marksman's Spite / role Smite). Zantetsuken ignores Guard.
+            //
+            // When "only with Kuzushi" is enabled, returning 0 potency for non-Kuzushi targets makes them count as
+            // unkillable, so FindKillableTargetInRange skips them during the all-target search.
+            Func<GameObject, double> zantetsukenPotency = target =>
+            {
+                bool hasKuzushi = target.HasAura(Auras.PvpKuzushi, true);
+
+                if (SamuraiSettings.Instance.Pvp_ZantetsukenWithKuzushi && !hasKuzushi)
+                    return 0d;
+
+                return hasKuzushi ? target.MaxHealth : 24000d;
+            };
+
+            // Prefer a confirmed kill. Searches every enemy in range only when the user opted in; otherwise just the
+            // current target. Honors the ally-targeting cap the same way MCH does. Zantetsuken ignores Guard, so we
+            // skip the Guard filter on candidates.
+            var killableTarget = CommonPvp.FindKillableTargetInRange(
+                SamuraiSettings.Instance,
+                24000d, // base potency, overridden per-target by the calculator below
+                (float)Spells.ZantetsukenPvp.Range,
+                ignoreGuard: true,
+                checkGuard: false,
+                searchAllTargets: SamuraiSettings.Instance.Pvp_ZantetsukenAnyTarget,
+                potencyCalculator: zantetsukenPotency,
+                maxAlliesTargetingLimit: SamuraiSettings.Instance.Pvp_MaxAlliesTargetingLimit);
+
+            if (killableTarget != null)
+                return await Spells.ZantetsukenPvp.Cast(killableTarget);
+
+            // No confirmed kill found. Kills-only mode stops here.
+            if (SamuraiSettings.Instance.Pvp_ZantetsukenForKillsOnly)
+                return false;
+
+            // Fallback: spend it as limit-break pressure on the current target sitting below the configured HP
+            // threshold.
+            if (!Core.Me.HasTarget)
+                return false;
+
             if (!Core.Me.CurrentTarget.WithinSpellRange(Spells.ZantetsukenPvp.Range))
                 return false;
 
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (Core.Me.CurrentTarget.CurrentHealthPercent > SamuraiSettings.Instance.Pvp_ZantetsukenHealthPercent && !SamuraiSettings.Instance.Pvp_ZantetsukenWithKuzushi)
+            // "Only with Kuzushi" gate applies to the HP-threshold fallback too.
+            if (SamuraiSettings.Instance.Pvp_ZantetsukenWithKuzushi && !Core.Me.CurrentTarget.HasAura(Auras.PvpKuzushi, true))
                 return false;
 
-            if (!Core.Me.CurrentTarget.HasAura(Auras.PvpKuzushi) && SamuraiSettings.Instance.Pvp_ZantetsukenWithKuzushi)
+            if (Core.Me.CurrentTarget.CurrentHealthPercent > SamuraiSettings.Instance.Pvp_ZantetsukenHealthPercent)
                 return false;
 
             // Check if too many allies are targeting the current target

--- a/Magitek/Logic/Scholar/Pvp.cs
+++ b/Magitek/Logic/Scholar/Pvp.cs
@@ -169,9 +169,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Core.Me.CurrentTarget.HasAura(Auras.PvpBiolytic))
-                return false;
-
+            // Only act on OUR Biolytic (isMyAura) with enough duration left — the looser any-owner check was redundant.
             if (!Core.Me.CurrentTarget.HasAura(Auras.PvpBiolytic, true, 10500))
                 return false;
 
@@ -231,6 +229,9 @@ namespace Magitek.Logic.Scholar
             if (Group.CastableAlliesWithin20.Count(x => x.IsValid && x.IsAlive) < ScholarSettings.Instance.Pvp_SummonSeraphNearbyAllies)
                 return false;
 
+            // The "NearbyAllies" setting is reused as the enemy-count threshold (name is a misnomer). The Seraph
+            // follow-ups (Consolation, Seraphic Halo, Accession, Seraphic Veil) fire as masked upgrades of the basic
+            // heals while the fairy is active, so they aren't implemented separately.
             if (Combat.Enemies.Count(x => x.IsValid && x.IsAlive) < ScholarSettings.Instance.Pvp_SummonSeraphNearbyAllies)
                 return false;
 
@@ -261,6 +262,7 @@ namespace Magitek.Logic.Scholar
             if (Group.CastableAlliesWithin30.Count(x => x.IsValid && x.IsAlive) < ScholarSettings.Instance.Pvp_SeraphismNearbyAllies)
                 return false;
 
+            // "NearbyAllies" setting reused as the enemy-count threshold (name is a misnomer).
             if (Combat.Enemies.Count(x => x.IsValid && x.IsAlive) < ScholarSettings.Instance.Pvp_SeraphismNearbyAllies)
                 return false;
 

--- a/Magitek/Logic/Summoner/Pvp.cs
+++ b/Magitek/Logic/Summoner/Pvp.cs
@@ -93,6 +93,7 @@ namespace Magitek.Logic.Summoner
 
         public static async Task<bool> RadiantAegisPvp()
         {
+            // Require a valid attack target so this self-shield only pops in real combat, not on incidental field damage.
             if (!Spells.RadiantAegisPvp.CanCast())
                 return false;
 

--- a/Magitek/Logic/Viper/Pvp.cs
+++ b/Magitek/Logic/Viper/Pvp.cs
@@ -83,7 +83,7 @@ namespace Magitek.Logic.Viper
         {
             var spell = Spells.UncoiledFuryPvp;
 
-            if (Core.Me.HasAura(Auras.PvpReawakened, true) && Core.Me.CurrentTarget != null && Core.Me.CurrentTarget.WithinSpellRange(Spells.UncoiledFuryPvp.Radius))
+            if (Core.Me.HasAura(Auras.PvpReawakened, true) && Core.Me.CurrentTarget != null && Core.Me.CurrentTarget.WithinSpellRange(Spells.UncoiledFuryPvp.Range))
                 return false;
 
             if (!spell.CanCast())
@@ -132,6 +132,8 @@ namespace Magitek.Logic.Viper
 
         public static async Task<bool> Bloodcoil()
         {
+            // No kill-shot gating here: Sanguine Feast (the masked form) grants a shield the player spends manually,
+            // so unlike Uncoiled Fury it's cast on availability.
             var spell = Spells.BloodcoilPvp.Masked();
 
             if (spell.Charges < 1)

--- a/Magitek/Logic/Warrior/Pvp.cs
+++ b/Magitek/Logic/Warrior/Pvp.cs
@@ -115,6 +115,8 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.Pvp_Bloodwhetting)
                 return false;
 
+            // Uses Chaotic Cyclone's radius: Bloodwhetting grants the Chaotic Cyclone follow-up, so it's only worth
+            // using with an enemy in range to spend it on.
             if (Combat.Enemies.Count(x => x.WithinSpellRange(Spells.ChaoticCyclonePvp.Radius)) < 1)
                 return false;
 

--- a/Magitek/Logic/WhiteMage/Pvp.cs
+++ b/Magitek/Logic/WhiteMage/Pvp.cs
@@ -80,9 +80,6 @@ namespace Magitek.Logic.WhiteMage
             if (Core.Me.CurrentTarget.HasAura(Auras.PvpGuard))
                 return false;
 
-            if (!Core.Me.CurrentTarget.WithinSpellRange(15))
-                return false;
-
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 

--- a/Magitek/Models/DarkKnight/DarkKnightSettings.cs
+++ b/Magitek/Models/DarkKnight/DarkKnightSettings.cs
@@ -273,10 +273,6 @@ namespace Magitek.Models.DarkKnight
         #region
         [Setting]
         [DefaultValue(true)]
-        public bool Pvp_Bloodspiller { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
         public bool Pvp_Shadowbringer { get; set; }
 
         [Setting]

--- a/Magitek/Models/Monk/MonkSettings.cs
+++ b/Magitek/Models/Monk/MonkSettings.cs
@@ -176,15 +176,7 @@ namespace Magitek.Models.Monk
 
         [Setting]
         [DefaultValue(true)]
-        public bool Pvp_SixSidedStar { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
         public bool Pvp_RisingPhoenix { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_Enlightenment { get; set; }
 
         [Setting]
         [DefaultValue(true)]
@@ -209,10 +201,6 @@ namespace Magitek.Models.Monk
         [Setting]
         [DefaultValue(50.0f)]
         public float Pvp_MeteodriveHealthPercent { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool Pvp_MeteodriveWithEnlightenment { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Models/Paladin/PaladinSettings.cs
+++ b/Magitek/Models/Paladin/PaladinSettings.cs
@@ -373,6 +373,10 @@ namespace Magitek.Models.Paladin
         public bool Pvp_Guardian { get; set; }
 
         [Setting]
+        [DefaultValue(50.0f)]
+        public float Pvp_GuardianHealthPercent { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool Pvp_HolySheltron { get; set; }
 

--- a/Magitek/Models/Reaper/ReaperSettings.cs
+++ b/Magitek/Models/Reaper/ReaperSettings.cs
@@ -249,10 +249,6 @@ namespace Magitek.Models.Reaper
 
         [Setting]
         [DefaultValue(true)]
-        public bool Pvp_SoulSlice { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
         public bool Pvp_DeathWarrant { get; set; }
 
         [Setting]

--- a/Magitek/Models/Samurai/SamuraiSettings.cs
+++ b/Magitek/Models/Samurai/SamuraiSettings.cs
@@ -212,6 +212,14 @@ namespace Magitek.Models.Samurai
         [Setting]
         [DefaultValue(true)]
         public bool Pvp_ZantetsukenWithKuzushi { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool Pvp_ZantetsukenForKillsOnly { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool Pvp_ZantetsukenAnyTarget { get; set; }
         #endregion
 
     }

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -9514,7 +9514,16 @@ namespace Magitek.Properties {
                 return ResourceManager.GetString("Paladin_Content_GoringBlade", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Guardian.
+        /// </summary>
+        public static string Paladin_Content_Guardian {
+            get {
+                return ResourceManager.GetString("Paladin_Content_Guardian", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Hallowed Ground (Invu).
         /// </summary>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2363,6 +2363,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Paladin_Content_Phalanx_LB" xml:space="preserve">
     <value>Phalanx / LB</value>
   </data>
+  <data name="Paladin_Content_Guardian" xml:space="preserve">
+    <value>Guardian</value>
+  </data>
   <data name="Paladin_Content_Holy_Sheltron" xml:space="preserve">
     <value>Holy Sheltron</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2364,6 +2364,9 @@
   <data name="Paladin_Content_Phalanx_LB" xml:space="preserve">
     <value>列阵 / LB 极限技</value>
   </data>
+  <data name="Paladin_Content_Guardian" xml:space="preserve">
+    <value>守护</value>
+  </data>
   <data name="Paladin_Content_Holy_Sheltron" xml:space="preserve">
     <value>圣盾阵</value>
   </data>

--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -193,6 +193,7 @@ namespace Magitek.Rotations
 
             // Healing
             if (await Pvp.MacrocosmosPvp()) return true;
+            if (await Pvp.MicrocosmosPvp()) return true;
             if (await Pvp.AspectedBeneficPvp()) return true;
 
             // Special Actions

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -120,7 +120,8 @@ namespace Magitek.Rotations
 
             if (await CommonPvp.CommonTasks(BlackMageSettings.Instance)) return true;
 
-            // Limit Break
+            // Limit Break. The Soul Resonance follow-up (Flare/Frost Star) is held behind GuardCheck because its
+            // consumed-buff window outlasts Guard — better to wait Guard out than waste it into 99% mitigation.
             if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(BlackMageSettings.Instance))
             {
                 if (await Pvp.SoulResonancePvp()) return true;

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -86,12 +86,13 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(DarkKnightSettings.Instance)) return true;
 
-            // BURST CHECK: Wrap everything except basic combo
+            // Defensive shield (The Blackest Night) — fires regardless of the Hold Burst toggle; pure self-mitigation.
+            if (await Pvp.BlackestNightPvp()) return true;
+
             if (CommonPvp.ShouldUseBurst())
             {
                 if (await Pvp.EventidePvp()) return true;
                 if (await Pvp.SaltAndDarkness()) return true;
-                if (await Pvp.BlackestNightPvp()) return true;
                 if (await Pvp.SaltedEarthPvp()) return true;
 
                 if (!CommonPvp.GuardCheck(DarkKnightSettings.Instance))

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -146,21 +146,21 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(DragoonSettings.Instance)) return true;
 
-            // BURST CHECK: Wrap everything except basic combo
             if (CommonPvp.ShouldUseBurst())
             {
+                // Starcross (self-centered AoE finisher) and Elusive Jump (mobility/escape) don't need the target-Guard gate
                 if (await Pvp.StarcrossPvp()) return true;
-                if (await Pvp.ChaoticSpringPvp()) return true;
-                if (await Pvp.HeavensThrustPvp()) return true;
-                if (await Pvp.WyrmwindThrustPvp()) return true;
-                if (await Pvp.NastrondPvp()) return true;
                 if (await Pvp.ElusiveJumpPvp()) return true;
 
+                // Damage abilities — don't dump them into a Guarded/invulnerable target (99% mitigated in 7.5)
                 if (!CommonPvp.GuardCheck(DragoonSettings.Instance))
                 {
+                    if (await Pvp.ChaoticSpringPvp()) return true;
+                    if (await Pvp.HeavensThrustPvp()) return true;
+                    if (await Pvp.WyrmwindThrustPvp()) return true;
+                    if (await Pvp.NastrondPvp()) return true;
                     if (await Pvp.SkyHighPvp()) return true;
                     if (await Pvp.GeirskogulPvp()) return true;
-
                     if (await Pvp.HighJumpPvp()) return true;
                     if (await Pvp.HorridRoarPvp()) return true;
                 }

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -153,7 +153,10 @@ namespace Magitek.Rotations
 
             if (await CommonPvp.CommonTasks(MonkSettings.Instance)) return true;
 
-            // BURST CHECK: Wrap everything except basic combo
+            // Gap-closer — kept outside the burst/Guard gates so it can close distance regardless of Hold Burst or
+            // the target's Guard (it self-guards via CanUseGapCloser and its own range/settings checks).
+            if (await Pvp.ThunderclapPvp()) return true;
+
             if (CommonPvp.ShouldUseBurst())
             {
                 if (await Pvp.MeteodrivePvp()) return true;
@@ -166,10 +169,7 @@ namespace Magitek.Rotations
                     if (await Pvp.FlintsReplyPvp()) return true;
 
                     if (await Pvp.WindsReplyPvp()) return true;
-                    if (await Pvp.ThunderclapPvp()) return true;
                 }
-
-                // if (await Pvp.EnlightenmentPvp()) return true;
             }
 
             // Basic Combo (ungated) - reverse order for priority

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -167,13 +167,16 @@ namespace Magitek.Rotations
             // BURST CHECK: Wrap everything except basic combo
             if (CommonPvp.ShouldUseBurst())
             {
+                // Seiton Tenchu ignores Guard and handles its own kill/target validation — it must NOT sit behind
+                // GuardCheck, or the guaranteed kill/incapacitate on a Guarded target (its best use) never fires.
+                if (await Pvp.SeitonTenchuPvp()) return true;
+
                 if (!CommonPvp.GuardCheck(NinjaSettings.Instance))
                 {
                     if (await Pvp.BunshinPvp()) return true;
                     if (await Pvp.ShukuchiPvp()) return true;
                     if (await Pvp.AssassinatePvp()) return true;
 
-                    if (await Pvp.SeitonTenchuPvp()) return true;
                     if (await Pvp.FleetingRaijuPvp()) return true;
                     if (await Pvp.DokumoriPvp()) return true;
                     if (await Pvp.ZeshoMeppoPvp()) return true;

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -127,29 +127,39 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(PaladinSettings.Instance)) return true;
 
-            // BURST CHECK: Wrap everything except FastBlade combo (the basic attack fallback)
+            // Protect a low-HP ally (Guardian) — defensive, fires regardless of burst/Guard state.
+            if (await Pvp.GuardianPvp()) return true;
+
             if (CommonPvp.ShouldUseBurst())
             {
+                // Self-targeted defensives/utility — fine regardless of the target's Guard
                 if (await Pvp.PhalanxPvp()) return true;
-                if (await Pvp.BladeofValorPvp()) return true;
-                if (await Pvp.BladeofTruthPvp()) return true;
-                if (await Pvp.BladeofFaithPvp()) return true;
                 if (await Pvp.HolySheltronPvp()) return true;
 
+                // Shield Smite has its own Guard handling (Pvp_ShieldSmiteOnlyOnGuard)
                 if (await Pvp.ShieldSmitePvp()) return true;
-                if (await Pvp.HolySpiritPvp()) return true;
 
+                // Offensive burst — don't dump into a Guarded/invulnerable target (99% mitigated in 7.5)
                 if (!CommonPvp.GuardCheck(PaladinSettings.Instance))
                 {
+                    if (await Pvp.BladeofValorPvp()) return true;
+                    if (await Pvp.BladeofTruthPvp()) return true;
+                    if (await Pvp.BladeofFaithPvp()) return true;
+                    if (await Pvp.HolySpiritPvp()) return true;
                     if (await Pvp.ImperatorPvp()) return true;
                     if (await Pvp.IntervenePvp()) return true;
                 }
             }
 
-            if (await Pvp.AtonementPvp()) return true;
-            if (await Pvp.SupplicationPvp()) return true;
-            if (await Pvp.SepulchrePvp()) return true;
-            if (await Pvp.ConfiteorPvp()) return true;
+            // Combo follow-ups stay outside ShouldUseBurst so the chain completes once started (per design),
+            // but are still skipped against a Guarded target so we don't waste them into 99% mitigation.
+            if (!CommonPvp.GuardCheck(PaladinSettings.Instance))
+            {
+                if (await Pvp.AtonementPvp()) return true;
+                if (await Pvp.SupplicationPvp()) return true;
+                if (await Pvp.SepulchrePvp()) return true;
+                if (await Pvp.ConfiteorPvp()) return true;
+            }
 
             // Basic combo fallback (ONLY ungated abilities)
             if (await Pvp.RoyalAuthorityPvp()) return true;

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -126,14 +126,12 @@ namespace Magitek.Rotations
             // Defensive abilities
             if (await Pvp.ArcaneCrestPvp()) return true;
 
-            if (CommonPvp.ShouldUseBurst())
-            {
-                if (await Pvp.PerfectioPvp()) return true;
-                if (await Pvp.GuillotinePvp()) return true;
-            }
-
             if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(ReaperSettings.Instance))
             {
+                // Perfectio and Guillotine are normal damage — gate on target Guard so they aren't wasted into 99% mitigation
+                if (await Pvp.PerfectioPvp()) return true;
+                if (await Pvp.GuillotinePvp()) return true;
+
                 // Enshrouded abilities
                 if (await Pvp.TenebraeLemurumPvp()) return true;
                 if (await Pvp.LemureSlicePvp()) return true;

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -207,13 +207,10 @@ namespace Magitek.Rotations
             if (await Pvp.AdloquiumPvp()) return true;
             if (await Pvp.ExpedientPvp()) return true;
 
-            if (CommonPvp.ShouldUseBurst())
-            {
-                if (await Pvp.ChainStratagemPvp()) return true;
-            }
-
             if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(ScholarSettings.Instance))
             {
+                // Chain Stratagem applies a damage-taken vuln — gate on target Guard so it isn't wasted into 99% mitigation (like Biolysis)
+                if (await Pvp.ChainStratagemPvp()) return true;
                 if (await Pvp.BiolysisPvp()) return true;
             }
 

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -87,6 +87,7 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(SummonerSettings.Instance)) return true;
 
+            // The whole damage block is behind ShouldUseBurst: "Hold Burst" saves these abilities for the burst window.
             if (CommonPvp.ShouldUseBurst())
             {
                 if (await Pvp.RadiantAegisPvp()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -110,14 +110,21 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(WarriorSettings.Instance)) return true;
 
-            // BURST CHECK: Wrap everything except basic combo
             if (CommonPvp.ShouldUseBurst())
             {
+                // Self-sustain — fires regardless of the target's Guard (self-cast heal/shield that also enables
+                // the Chaotic Cyclone follow-up).
+                if (await Pvp.BloodwhettingPvp()) return true;
+
+                // Don't dump the AoE burst into a Guarded primary target.
                 if (!CommonPvp.GuardCheck(WarriorSettings.Instance))
                 {
                     // Limit Break
                     if (await Pvp.PrimalScreamPvp()) return true;
                     if (await Pvp.PrimalWrathPvp()) return true;
+
+                    // Placed high so it actually fires
+                    if (await Pvp.FellCleavePvp()) return true;
 
                     // High Priority Abilities
                     if (await Pvp.PrimalRendPvp()) return true;
@@ -129,8 +136,7 @@ namespace Magitek.Rotations
                     if (await Pvp.OnslaughtPvp()) return true;
                     if (await Pvp.BlotaPvp()) return true;
 
-                    // Defensive and Healing
-                    if (await Pvp.BloodwhettingPvp()) return true;
+                    // Damage debuff
                     if (await Pvp.OrogenyPvp()) return true;
                 }
             }

--- a/Magitek/Rotations/WhiteMage.cs
+++ b/Magitek/Rotations/WhiteMage.cs
@@ -189,17 +189,14 @@ namespace Magitek.Rotations
         {
             if (await CommonPvp.CommonTasks(WhiteMageSettings.Instance)) return true;
 
-            if (CommonPvp.ShouldUseBurst())
-            {
-                if (await Pvp.AfflatusPurgationPvp()) return true;
-            }
-
             if (await Pvp.CureIIIPvp()) return true;
             if (await Pvp.AquaveilPvp()) return true;
             if (await Pvp.CureIIPvp()) return true;
 
             if (CommonPvp.ShouldUseBurst() && !CommonPvp.GuardCheck(WhiteMageSettings.Instance))
             {
+                // Afflatus Purgation is a full-gauge ~18k damage LB — gate on target Guard so it isn't wasted into 99% mitigation
+                if (await Pvp.AfflatusPurgationPvp()) return true;
                 if (await Pvp.GlareIVPvp()) return true;
                 if (await Pvp.AfflatusMiseryPvp()) return true;
                 if (await Pvp.MiracleOfNaturePvp()) return true;

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -529,6 +529,8 @@ namespace Magitek.Utilities
             PvpBunshin = 2010,
             PvpFleetingRaijuReady = 3211,
             PvpZeshoMeppoReady = 4305,
+            PvpStarcrossReady = 4302,
+            PvpNastrondReady = 4404,
             PvpLifeoftheDragon = 3177,
             PvpOgiNamikiri = 3199,
             PvpMidare = 3203,

--- a/Magitek/Utilities/Spells.cs
+++ b/Magitek/Utilities/Spells.cs
@@ -1249,7 +1249,6 @@ namespace Magitek.Utilities
         public static readonly SpellData AdloquiumPvp = DataManager.GetSpellData(29232);
         public static readonly SpellData BiolysisPvp = DataManager.GetSpellData(29233);
         public static readonly SpellData DeploymentTacticsPvp = DataManager.GetSpellData(29234);
-        public static readonly SpellData MummificationPvp = DataManager.GetSpellData(29235);
         public static readonly SpellData ExpedientPvp = DataManager.GetSpellData(29236);
         public static readonly SpellData ConsolationPvp = DataManager.GetSpellData(29238);
         public static readonly SpellData SeraphicVeil = DataManager.GetSpellData(29240);
@@ -1337,8 +1336,6 @@ namespace Magitek.Utilities
         public static readonly SpellData DragonKickPvp = DataManager.GetSpellData(29475);
         public static readonly SpellData TwinSnakesPvp = DataManager.GetSpellData(29476);
         public static readonly SpellData DemolishPvp = DataManager.GetSpellData(29477);
-        public static readonly SpellData SixSidedStarPvp = DataManager.GetSpellData(29479);
-        public static readonly SpellData EnlightenmentPvp = DataManager.GetSpellData(29480);
         public static readonly SpellData RisingPhoenixPvp = DataManager.GetSpellData(29481);
         public static readonly SpellData RiddleofEarthPvp = DataManager.GetSpellData(29482);
         public static readonly SpellData EarthReplyPvp = DataManager.GetSpellData(29483);
@@ -1431,7 +1428,6 @@ namespace Magitek.Utilities
         public static readonly SpellData ArcaneCrestPvp = DataManager.GetSpellData(29552);
         public static readonly SpellData TenebraeLemurumPvp = DataManager.GetSpellData(29553);
         public static readonly SpellData CommunioPvp = DataManager.GetSpellData(29554);
-        public static readonly SpellData SoulSlicePvp = DataManager.GetSpellData(29566);
         public static readonly SpellData GuillotinePvp = DataManager.GetSpellData(41456);
         public static readonly SpellData PerfectioPvp = DataManager.GetSpellData(41458);
         public static readonly SpellData FateSealedPvp = DataManager.GetSpellData(41457);
@@ -1493,12 +1489,9 @@ namespace Magitek.Utilities
         public static readonly SpellData GnashingFangPvp = DataManager.GetSpellData(29102);
         public static readonly SpellData SavageClawPvp = DataManager.GetSpellData(29103);
         public static readonly SpellData WickedTalonPvp = DataManager.GetSpellData(29104);
-        public static readonly SpellData DoubleDownPvp = DataManager.GetSpellData(29105);
         public static readonly SpellData ContinuationPvp = DataManager.GetSpellData(29106);
         public static readonly SpellData HypervelocityPvp = DataManager.GetSpellData(29107);
         public static readonly SpellData RoughDividePvp = DataManager.GetSpellData(29123);
-        public static readonly SpellData DrawandJunctionPvp = DataManager.GetSpellData(29124);
-        public static readonly SpellData JunctionedPvp = DataManager.GetSpellData(29125);
         public static readonly SpellData NebulaPvp = DataManager.GetSpellData(29126);
         public static readonly SpellData BlastingZonePvp = DataManager.GetSpellData(29128);
         public static readonly SpellData AuroraPvp = DataManager.GetSpellData(29129);
@@ -1513,7 +1506,6 @@ namespace Magitek.Utilities
         public static readonly SpellData HardSlashPvp = DataManager.GetSpellData(29085);
         public static readonly SpellData SyphonStrikePvp = DataManager.GetSpellData(29086);
         public static readonly SpellData SouleaterPvp = DataManager.GetSpellData(29087);
-        public static readonly SpellData BloodspillerPvp = DataManager.GetSpellData(29088);
         public static readonly SpellData ShadowbringerPvp = DataManager.GetSpellData(29091);
         public static readonly SpellData PlungePvp = DataManager.GetSpellData(29092);
         public static readonly SpellData BlackestNightPvp = DataManager.GetSpellData(29093);

--- a/Magitek/Views/UserControls/DarkKnight/Pvp.xaml
+++ b/Magitek/Views/UserControls/DarkKnight/Pvp.xaml
@@ -31,9 +31,6 @@
                                            Text="{x:Static properties:Resources.Generic_General}"/>
                                 <StackPanel Margin="5"
                                             Orientation="Horizontal">
-                                        <CheckBox Content="{x:Static properties:Resources.DarkKnight_Content_BloodSpiller}"
-                                                  IsChecked="{Binding DarkKnightSettings.Pvp_Bloodspiller, Mode=TwoWay}"
-                                                  Style="{DynamicResource CheckBoxFlat}"/>
                                         <CheckBox Content="{x:Static properties:Resources.DarkKnight_Content_Impalement}"
                                                   IsChecked="{Binding DarkKnightSettings.Pvp_Impalement, Mode=TwoWay}"
                                                   Style="{DynamicResource CheckBoxFlat}"/>

--- a/Magitek/Views/UserControls/Monk/Pvp.xaml
+++ b/Magitek/Views/UserControls/Monk/Pvp.xaml
@@ -31,18 +31,6 @@
                            Text="{x:Static properties:Resources.Generic_General}"/>
                 <StackPanel Margin="5"
                             Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Monk_Content_Six_Sided_Star}"
-                              IsChecked="{Binding MonkSettings.Pvp_SixSidedStar, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
-                </StackPanel>
-                <StackPanel Margin="5"
-                            Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Monk_Content_Enlightenment}"
-                              IsChecked="{Binding MonkSettings.Pvp_Enlightenment, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
-                </StackPanel>
-                <StackPanel Margin="5"
-                            Orientation="Horizontal">
                     <CheckBox Content="{x:Static properties:Resources.Monk_Content_Thunderclap_After_Enlightenment}"
                               IsChecked="{Binding MonkSettings.Pvp_Thunderclap, Mode=TwoWay}"
                               Style="{DynamicResource CheckBoxFlat}"/>
@@ -72,12 +60,6 @@
                                       Value="{Binding MonkSettings.Pvp_MaxAlliesTargetingLimit, Mode=TwoWay}"/>
                     <TextBlock Style="{DynamicResource TextBlockDefault}"
                                Text="{x:Static properties:Resources.Generic_Allies_Targeting_It}"/>
-                </StackPanel>
-                <StackPanel Margin="5"
-                            Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Monk_Content_Meteodrive_LB_Only_After_Enlightenmen}"
-                              IsChecked="{Binding MonkSettings.Pvp_MeteodriveWithEnlightenment, Mode=TwoWay}"
-                              Style="{DynamicResource CheckBoxFlat}"/>
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>

--- a/Magitek/Views/UserControls/Paladin/Pvp.xaml
+++ b/Magitek/Views/UserControls/Paladin/Pvp.xaml
@@ -66,6 +66,12 @@
             <StackPanel Margin="5">
                 <TextBlock Margin="0,0,0,5" Style="{DynamicResource TextBlockSection}" Text="{x:Static properties:Resources.Generic_Buffs}" />
                 <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Paladin_Content_Guardian}" IsChecked="{Binding PaladinSettings.Pvp_Guardian, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Below}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding PaladinSettings.Pvp_GuardianHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Hp}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
                     <CheckBox Content="{x:Static properties:Resources.Paladin_Content_Holy_Sheltron}" IsChecked="{Binding PaladinSettings.Pvp_HolySheltron, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>

--- a/Magitek/Views/UserControls/Reaper/Pvp.xaml
+++ b/Magitek/Views/UserControls/Reaper/Pvp.xaml
@@ -35,7 +35,6 @@
                     <CheckBox Content="{x:Static properties:Resources.Reaper_Content_Void_and_Cross_Reaping}" IsChecked="{Binding ReaperSettings.Pvp_VoidReapingNCrossReaping, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Reaper_Content_Soul_Slice}" IsChecked="{Binding ReaperSettings.Pvp_SoulSlice, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <CheckBox Content="{x:Static properties:Resources.Reaper_Content_Plentiful_Harvest}" IsChecked="{Binding ReaperSettings.Pvp_PlentifulHarvest, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5" Orientation="Horizontal">

--- a/Magitek/Views/UserControls/Samurai/Pvp.xaml
+++ b/Magitek/Views/UserControls/Samurai/Pvp.xaml
@@ -85,6 +85,20 @@
                               IsChecked="{Binding SamuraiSettings.Pvp_ZantetsukenWithKuzushi, Mode=TwoWay}"
                               Style="{DynamicResource CheckBoxFlat}"/>
                 </StackPanel>
+                <StackPanel Margin="5"
+                            Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Generic_Use_For_Kills_Only}"
+                              Margin="20,0,0,0"
+                              IsChecked="{Binding SamuraiSettings.Pvp_ZantetsukenForKillsOnly, Mode=TwoWay}"
+                              Style="{DynamicResource CheckBoxFlat}"/>
+                </StackPanel>
+                <StackPanel Margin="5"
+                            Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Generic_LB_Any_Enemy_below_the_threshold}"
+                              Margin="20,0,0,0"
+                              IsChecked="{Binding SamuraiSettings.Pvp_ZantetsukenAnyTarget, Mode=TwoWay}"
+                              Style="{DynamicResource CheckBoxFlat}"/>
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
## Summary
- Fix rotation returning true when no action was taken (caused PvE fallthrough on PvP maps)
- Prevent PvE behavior from ever running on PvP maps
- Fix guard checks, range checks, and targeting across all PvP jobs
- Honor previously-ignored PvP settings
- Remove abilities cut from PvP in recent patches
- Fix isMyAura flags in WouldKill calculator (Debana, Noxious Gnash, Kuzushi)
- Fix DRG Starcross inverted range check
- Fix MCH Wildfire detonating another player's Wildfire
- Add PLD Guardian and SAM Zantetsuken config options with UI/i18n

## Test plan
- [ ] Verify PvE rotations are unaffected (no PvP code runs outside PvP maps)
- [ ] Test PvP on at least one job per role in Crystalline Conflict
- [ ] Confirm Guard check prevents wasting abilities into 99% mitigation
- [ ] Confirm new PLD/SAM settings appear in Magitek Settings UI