### PR TITLE
SMN - Fix Enkindle never firing and add boss whitelist for summon throttle

### DIFF
--- a/Magitek/Logic/Summoner/Pets.cs
+++ b/Magitek/Logic/Summoner/Pets.cs
@@ -64,7 +64,9 @@ namespace Magitek.Logic.Summoner
             if ((SmnResources.PetTimer + SmnResources.TranceTimer) > 0)
                 return false;
 
-            if (SummonerSettings.Instance.ThrottleTranceSummonsWithTTL && Combat.CombatTotalTimeLeft < 15)
+            if (SummonerSettings.Instance.ThrottleTranceSummonsWithTTL
+                && !(SummonerSettings.Instance.SummonThrottleIgnoreBosses && Core.Me.CurrentTarget.IsBoss())
+                && Combat.CombatTotalTimeLeft < 15)
                 return false;
 
             return await Spells.SummonPhoenix.Cast(Core.Me.CurrentTarget);
@@ -107,7 +109,9 @@ namespace Magitek.Logic.Summoner
             if (Core.Me.SummonedPet() != SmnPets.Carbuncle)
                 return false;
 
-            if (SummonerSettings.Instance.ThrottleTranceSummonsWithTTL && Combat.CombatTotalTimeLeft < 15)
+            if (SummonerSettings.Instance.ThrottleTranceSummonsWithTTL
+                && !(SummonerSettings.Instance.SummonThrottleIgnoreBosses && Core.Me.CurrentTarget.IsBoss())
+                && Combat.CombatTotalTimeLeft < 15)
                 return false;
 
             if (!SummonerSettings.Instance.SearingLight)
@@ -139,7 +143,9 @@ namespace Magitek.Logic.Summoner
             if ((SmnResources.PetTimer + SmnResources.TranceTimer) > 0)
                 return false;
 
-            if (SummonerSettings.Instance.ThrottleEgiSummonsWithTTL && Combat.CombatTotalTimeLeft < 30)
+            if (SummonerSettings.Instance.ThrottleEgiSummonsWithTTL
+                && !(SummonerSettings.Instance.SummonThrottleIgnoreBosses && Core.Me.CurrentTarget.IsBoss())
+                && Combat.CombatTotalTimeLeft < 30)
                 return false;
 
             if (SummonerSettings.Instance.SummonTopazTitan)

--- a/Magitek/Logic/Summoner/SingleTarget.cs
+++ b/Magitek/Logic/Summoner/SingleTarget.cs
@@ -126,9 +126,9 @@ namespace Magitek.Logic.Summoner
             if (!Core.Me.InCombat)
                 return false;
 
-            if (!Spells.Enkindle.IsKnown())
-                return false;
-
+            // No top-level Enkindle known-check: base action 184 is the removed Stormblood egi-command
+            // (no current job owns it), so IsKnown()/HasSpell is always false and would dead-gate this
+            // dispatcher. Each per-pet method guards on its real demi-enkindle (7429/16516/36998) below.
             if (Core.Me.SummonedPet() == SmnPets.Bahamut) return await EnkindleBahamut();
             if (Core.Me.SummonedPet() == SmnPets.SolarBahamut) return await EnkindleSolarBahamut();
             if (Core.Me.SummonedPet() == SmnPets.Phoenix) return await EnkindlePhoenix();

--- a/Magitek/Models/Summoner/SummonerSettings.cs
+++ b/Magitek/Models/Summoner/SummonerSettings.cs
@@ -224,6 +224,10 @@ namespace Magitek.Models.Summoner
         [DefaultValue(false)]
         public bool ThrottleTranceSummonsWithTTL { get; set; }
 
+        [Setting]
+        [DefaultValue(false)]
+        public bool SummonThrottleIgnoreBosses { get; set; }
+
         #endregion
 
         #region PVP

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -13844,7 +13844,16 @@ namespace Magitek.Properties {
                 return ResourceManager.GetString("Summoner_Content_Throttle_Egi_Summons_with_TTL", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Summon Throttle Ignores Bosses.
+        /// </summary>
+        public static string Summoner_Content_Throttle_Ignore_Bosses {
+            get {
+                return ResourceManager.GetString("Summoner_Content_Throttle_Ignore_Bosses", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Throttle Trance Summons with TTL.
         /// </summary>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -3326,6 +3326,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Summoner_Content_Throttle_Egi_Summons_with_TTL" xml:space="preserve">
     <value>Throttle Egi Summons with TTL</value>
   </data>
+  <data name="Summoner_Content_Throttle_Ignore_Bosses" xml:space="preserve">
+    <value>Summon Throttle Ignores Bosses</value>
+  </data>
   <data name="Summoner_Content_Throttle_Trance_Summons_with_TTL" xml:space="preserve">
     <value>Throttle Trance Summons with TTL</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -3327,6 +3327,9 @@
   <data name="Summoner_Content_Throttle_Egi_Summons_with_TTL" xml:space="preserve">
     <value>根据存活时间(TTL)限制宝宝召唤</value>
   </data>
+  <data name="Summoner_Content_Throttle_Ignore_Bosses" xml:space="preserve">
+    <value>召唤限制忽略Boss</value>
+  </data>
   <data name="Summoner_Content_Throttle_Trance_Summons_with_TTL" xml:space="preserve">
     <value>根据存活时间(TTL)限制附体召唤</value>
   </data>

--- a/Magitek/Views/UserControls/Summoner/General.xaml
+++ b/Magitek/Views/UserControls/Summoner/General.xaml
@@ -124,6 +124,7 @@
                 <StackPanel Orientation="Horizontal">
                     <CheckBox Margin="5,3" Content="{x:Static properties:Resources.Summoner_Content_Throttle_Egi_Summons_with_TTL}" IsChecked="{Binding SummonerSettings.ThrottleEgiSummonsWithTTL, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <CheckBox Margin="5,3" Content="{x:Static properties:Resources.Summoner_Content_Throttle_Trance_Summons_with_TTL}" IsChecked="{Binding SummonerSettings.ThrottleTranceSummonsWithTTL, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Margin="5,3" Content="{x:Static properties:Resources.Summoner_Content_Throttle_Ignore_Bosses}" IsChecked="{Binding SummonerSettings.SummonThrottleIgnoreBosses, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>        


### PR DESCRIPTION
Two Summoner fixes, both built on Release and verified in-game.

## 1. Fix Enkindle never firing

`Enkindle()` gated on `Spells.Enkindle.IsKnown()`, where `Spells.Enkindle` is action **184** — the removed Stormblood egi-command that no current job learns (XIVAPI `ClassJob: -1`). `IsKnown()` calls `ActionManager.HasSpell(184)`, which is always false for a modern Summoner, so the dispatcher returned early on every pulse and Enkindle Bahamut / Solar Bahamut / Phoenix could never fire.

Removed the dead guard. Each per-pet method already checks its real demi-enkindle (7429 / 36998 / 16516) and `SummonedPet()` routing selects which one runs, so nothing else is needed to gate it.

## 2. Boss whitelist for the summon throttle

`ThrottleEgiSummonsWithTTL` / `ThrottleTranceSummonsWithTTL` hold egi/demi summons when `CombatTotalTimeLeft` drops below 30s / 15s, with no boss exclusion. On a boss's final stretch this stops re-summoning and falls through to Ruin filler, costing damage on the kill.

Added an opt-in `SummonThrottleIgnoreBosses` toggle (default off) that exempts boss targets from both throttles, matching the `!IsBoss()` guard BlackMage and Sage already use. Includes the setting, a checkbox in Summoner > General, and EN/zh strings.

## Testing

Built Release and ran on Summoner in-game: Enkindle now weaves during demi windows; with the throttle enabled and the new toggle on, demis/egis keep firing through a boss's end instead of Ruin-spamming. Default-off keeps existing behavior unchanged.
