### PR TITLE
SMN - Add adjustable summon throttle cutoffs and skip egis less aggressively

### DIFF
--- a/Magitek/Logic/Summoner/Pets.cs
+++ b/Magitek/Logic/Summoner/Pets.cs
@@ -66,7 +66,7 @@ namespace Magitek.Logic.Summoner
 
             if (SummonerSettings.Instance.ThrottleTranceSummonsWithTTL
                 && !(SummonerSettings.Instance.SummonThrottleIgnoreBosses && Core.Me.CurrentTarget.IsBoss())
-                && Combat.CombatTotalTimeLeft < 15)
+                && Combat.CombatTotalTimeLeft < SummonerSettings.Instance.ThrottleTranceSummonsSeconds)
                 return false;
 
             return await Spells.SummonPhoenix.Cast(Core.Me.CurrentTarget);
@@ -111,7 +111,7 @@ namespace Magitek.Logic.Summoner
 
             if (SummonerSettings.Instance.ThrottleTranceSummonsWithTTL
                 && !(SummonerSettings.Instance.SummonThrottleIgnoreBosses && Core.Me.CurrentTarget.IsBoss())
-                && Combat.CombatTotalTimeLeft < 15)
+                && Combat.CombatTotalTimeLeft < SummonerSettings.Instance.ThrottleTranceSummonsSeconds)
                 return false;
 
             if (!SummonerSettings.Instance.SearingLight)
@@ -145,7 +145,7 @@ namespace Magitek.Logic.Summoner
 
             if (SummonerSettings.Instance.ThrottleEgiSummonsWithTTL
                 && !(SummonerSettings.Instance.SummonThrottleIgnoreBosses && Core.Me.CurrentTarget.IsBoss())
-                && Combat.CombatTotalTimeLeft < 30)
+                && Combat.CombatTotalTimeLeft < SummonerSettings.Instance.ThrottleEgiSummonsSeconds)
                 return false;
 
             if (SummonerSettings.Instance.SummonTopazTitan)

--- a/Magitek/Models/Summoner/SummonerSettings.cs
+++ b/Magitek/Models/Summoner/SummonerSettings.cs
@@ -228,6 +228,14 @@ namespace Magitek.Models.Summoner
         [DefaultValue(false)]
         public bool SummonThrottleIgnoreBosses { get; set; }
 
+        [Setting]
+        [DefaultValue(10)]
+        public int ThrottleEgiSummonsSeconds { get; set; }
+
+        [Setting]
+        [DefaultValue(15)]
+        public int ThrottleTranceSummonsSeconds { get; set; }
+
         #endregion
 
         #region PVP

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -13949,6 +13949,15 @@ namespace Magitek.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Heals:.
         /// </summary>
+        public static string Summoner_Text_Egi_Summon_Throttle_Seconds {
+            get {
+                return ResourceManager.GetString("Summoner_Text_Egi_Summon_Throttle_Seconds", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Heals.
+        /// </summary>
         public static string Summoner_Text_Heals {
             get {
                 return ResourceManager.GetString("Summoner_Text_Heals", resourceCulture);
@@ -14056,6 +14065,15 @@ namespace Magitek.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to Trances:.
+        /// </summary>
+        public static string Summoner_Text_Trance_Summon_Throttle_Seconds {
+            get {
+                return ResourceManager.GetString("Summoner_Text_Trance_Summon_Throttle_Seconds", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Trances.
         /// </summary>
         public static string Summoner_Text_Trances {
             get {

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -3332,6 +3332,12 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Summoner_Content_Throttle_Egi_Summons_with_TTL" xml:space="preserve">
     <value>Throttle Egi Summons with TTL</value>
   </data>
+  <data name="Summoner_Text_Egi_Summon_Throttle_Seconds" xml:space="preserve">
+    <value>Stop summoning egis with this long left:</value>
+  </data>
+  <data name="Summoner_Text_Trance_Summon_Throttle_Seconds" xml:space="preserve">
+    <value>Stop summoning demis with this long left:</value>
+  </data>
   <data name="Summoner_Content_Throttle_Ignore_Bosses" xml:space="preserve">
     <value>Summon Throttle Ignores Bosses</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -3333,6 +3333,12 @@
   <data name="Summoner_Content_Throttle_Egi_Summons_with_TTL" xml:space="preserve">
     <value>根据存活时间(TTL)限制宝宝召唤</value>
   </data>
+  <data name="Summoner_Text_Egi_Summon_Throttle_Seconds" xml:space="preserve">
+    <value>剩余时间低于此秒数时停止召唤宝宝：</value>
+  </data>
+  <data name="Summoner_Text_Trance_Summon_Throttle_Seconds" xml:space="preserve">
+    <value>剩余时间低于此秒数时停止召唤神龙：</value>
+  </data>
   <data name="Summoner_Content_Throttle_Ignore_Bosses" xml:space="preserve">
     <value>召唤限制忽略Boss</value>
   </data>

--- a/Magitek/Views/UserControls/Summoner/General.xaml
+++ b/Magitek/Views/UserControls/Summoner/General.xaml
@@ -126,6 +126,14 @@
                     <CheckBox Margin="5,3" Content="{x:Static properties:Resources.Summoner_Content_Throttle_Trance_Summons_with_TTL}" IsChecked="{Binding SummonerSettings.ThrottleTranceSummonsWithTTL, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                     <CheckBox Margin="5,3" Content="{x:Static properties:Resources.Summoner_Content_Throttle_Ignore_Bosses}" IsChecked="{Binding SummonerSettings.SummonThrottleIgnoreBosses, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="5,3" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Summoner_Text_Egi_Summon_Throttle_Seconds}" />
+                    <controls:Numeric Margin="5,3" MaxValue="60" MinValue="0" Value="{Binding SummonerSettings.ThrottleEgiSummonsSeconds, Mode=TwoWay}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="5,3" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Summoner_Text_Trance_Summon_Throttle_Seconds}" />
+                    <controls:Numeric Margin="5,3" MaxValue="60" MinValue="0" Value="{Binding SummonerSettings.ThrottleTranceSummonsSeconds, Mode=TwoWay}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>        
 


### PR DESCRIPTION
Follow-up to your note on #189. Egi cutoff 30s -> 10s (roughly the four egi GCDs a summon buys), demi stays 15s, both now settings instead of hardcoded. Still opt-in, so nothing changes unless the throttle is enabled.

Noticed while in here, not addressed:

- The cutoffs compare against `CombatTotalTimeLeft`, which sums time-to-death across all tracked enemies rather than the current target's. Reads as intended on a lone boss; in a pack, five mobs at 8s each sum to 40s and the throttle never fires. `CurrentTargetCombatTimeLeft` sits right beside it.
- `Buff.cs` DreadwyrmTrance has a fourth hardcoded 15s cutoff that isn't gated by `ThrottleTranceSummonsWithTTL` at all, so it applies whether or not the user opted in.

Not tested in game yet — only reproducible on a boss that actually dies.
