### PR TITLE
Core - Support Occult Crescent: North Horn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1231,6 +1231,8 @@ return await Spells.HolyCircle.Cast(Core.Me);
 13. Using `Masked()` results without checking for null or storing in a variable for repeated checks.
 14. **Duplicating shared code** in Logic files instead of using `Utilities/Routines/<Job>.cs` for helper functions, cached variables, and calculations used by multiple Logic files (see "Job-Specific Shared Utilities" section).
 
-**Note on Commented Code**: Temporarily commented code for testing/debugging purposes is acceptable. However, before submitting a PR for review, consider whether the commented code should be removed (if it's obsolete) or uncommented (if it's needed). Use descriptive comments to explain why code is temporarily commented.
+**Note on Commented Code**: Temporarily commented code for testing/debugging purposes is acceptable. However, before submitting a PR for review, consider whether the commented code should be removed (if it's obsolete) or uncommented (if it's needed). Use descriptive comments to explain why code is temporarily commented. Do not remove commented-out code you did not write — it may be kept deliberately.
+
+**Note on Existing Comments**: Do not change existing comments unless they are actually wrong and need a factual update. Rewording a correct comment is a meaningless diff change that pollutes review.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,9 @@ Understanding FFXIV-specific combat mechanics is essential for writing effective
 - **NEVER use manual calculations** like `r.Distance(Core.Me) <= 5 + r.CombatReach`
 - Use radius/cone checks for specialized AoE targeting
 - Never use raw `Distance` for spell range checks
+- **Exception — resurrection.** Raise target filters use raw `Distance(Core.Me) <= 30` on
+  purpose; a corpse has no usable `CombatReach`. Do not "correct" these to `WithinSpellRange`.
+  Each such call site carries a comment explaining why.
 
 ---
 

--- a/Magitek/Logic/BlueMage/Heal.cs
+++ b/Magitek/Logic/BlueMage/Heal.cs
@@ -46,6 +46,9 @@ namespace Magitek.Logic.BlueMage
             if (Core.Me.CurrentMana < Spells.AngelWhisper.Cost)
                 return false;
 
+            // Raw 3D distance is deliberate here — see the resurrection range exception in
+            // AGENTS.md. A corpse has no usable CombatReach, and WithinSpellRange is built on
+            // Distance2D so it would ignore height. Leave this as Distance.
             var deadList = Group.DeadAllies.Where(u => !u.HasAura(Auras.Raise) &&
                                                        u.Distance(Core.Me) <= 30 &&
                                                        u.InLineOfSight() &&

--- a/Magitek/Logic/Roles/Healer.cs
+++ b/Magitek/Logic/Roles/Healer.cs
@@ -65,6 +65,12 @@ namespace Magitek.Logic.Roles
             if (Core.Me.CurrentMana < spell.Cost)
                 return false;
 
+            // Raise range is a raw 3D distance on purpose, and is the exception to the
+            // "always use WithinSpellRange" rule in AGENTS.md. A corpse has no usable
+            // CombatReach for the game to measure against, so raise range is centre to
+            // centre. WithinSpellRange would subtract both hitboxes and, because it uses
+            // Distance2D, ignore height entirely — calling a body far below us in range.
+            // Leave this as Distance.
             var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
                                                        u.Distance(Core.Me) <= 30 &&

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -189,9 +189,12 @@ namespace Magitek.Logic.Roles
         private static bool _lastZoneWasOccultCrescent;
 
         /// <summary>
-        /// Known zone ids first, then a fallback on the zone name so a newly released Horn works the day
-        /// it ships instead of silently disabling everything Occult Crescent specific until its id is
-        /// added here — which is exactly what happened when North Horn arrived.
+        /// Known zone ids first, then a fallback on the zone name so a newly released Horn keeps the
+        /// general Occult Crescent logic running the day it ships instead of silently disabling all of it
+        /// until its id is added here — which is exactly what happened when North Horn arrived. Features
+        /// built on per-zone coordinates are the exception: knowledge crystal buffing and the
+        /// respawn-point corpse exclusion stay off in a new Horn until its locations are gathered and
+        /// added to KnowledgeCrystalLocations/RespawnPoints, by design.
         /// <para>
         /// Name matching is safe across clients: WorldManager.CurrentZoneName is the non-localized name
         /// (CurrentLocalizedZoneName is the one shown to the player). The result is cached per zone so the

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -238,15 +238,14 @@ namespace Magitek.Logic.Roles
                 new Vector3(884.896f, 259.5558f, 875.1169f),    // base camp
                 new Vector3(-542.5715f, 68.6256f, 598.2891f),
                 new Vector3(-390f, 67.99994f, 700f),
+                new Vector3(-384.2f, 40f, -441.6f),
+                new Vector3(597.8f, -700f, 927f),               // Forked Tower entrance
                 new Vector3(-893f, -984.7401f, 780f),           // Forked Tower
                 new Vector3(-900f, -986.1f, 782.2488f),
-                new Vector3(-900.0712f, -983f, 839.275f),
                 new Vector3(103f, -706.7383f, 678f),
                 new Vector3(0f, -722.6936f, -367f),
                 new Vector3(603.5453f, -672.6606f, 640.6041f),
-                new Vector3(600f, -673.8f, 624f),
-                new Vector3(603.7968f, -670.6514f, -125.1157f),
-                new Vector3(600f, -672f, -142f)
+                new Vector3(603.7968f, -670.6514f, -125.1157f)
             }
         };
 

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -258,7 +258,10 @@ namespace Magitek.Logic.Roles
             {
                 new Vector3(905.57f, 259.88f, 905.97f),   // base camp
                 new Vector3(600.2f, -700f, 975f),         // Forked Tower
-                new Vector3(706f, -709.8f, 184f)          // Forked Tower
+                new Vector3(706f, -709.8f, 184f),
+                new Vector3(800.2f, -600f, -677.6f),
+                new Vector3(100.1f, -691.5f, 496.9f),
+                new Vector3(600.2f, -674f, 703.1f)
             }
         };
 

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -227,6 +227,11 @@ namespace Magitek.Logic.Roles
         // Horns, so the aetheryte beside it serves the same purpose without needing the zone mapped first.
         private const float AetheryteProximity = 7.0f;
 
+        // How long non-party revival stands aside for a dead party member before deciding the party
+        // path is not coming.
+        private static DateTime _partyRaiseYieldSince = DateTime.MinValue;
+        private static readonly TimeSpan PartyRaiseGrace = TimeSpan.FromSeconds(15);
+
         private static readonly Vector3[] KnowledgeCrystalLocations = new[]
         {
             new Vector3(835.9902f, 75.12211f, -709.3925f),
@@ -554,8 +559,23 @@ namespace Magitek.Logic.Roles
             // party rez) spends any Dualcast/Swiftcast on them instead of a non-party random. Only
             // yields when actually grouped with an eligible corpse, so it won't strand a party
             // member the standard path wouldn't cover anyway.
+            // Yielding is only worth it while the party path is actually going to act. If it cannot —
+            // the job has no raise, it is switched off, it is out of resources, or the dead player is a
+            // role the user excluded — then the corpse simply stays there and this would keep standing
+            // aside forever, which is exactly how non-party revival ends up never happening. Give the
+            // party path a fair window and then stop waiting on it.
             if (Globals.InParty && HasRaisableDeadPartyMember())
-                return false;
+            {
+                if (_partyRaiseYieldSince == DateTime.MinValue)
+                    _partyRaiseYieldSince = DateTime.Now;
+
+                if ((DateTime.Now - _partyRaiseYieldSince) < PartyRaiseGrace)
+                    return false;
+            }
+            else
+            {
+                _partyRaiseYieldSince = DateTime.MinValue;
+            }
 
             // Update alliance to get dead players using optimized Group system
             Group.UpdateAlliance(

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -237,8 +237,10 @@ namespace Magitek.Logic.Roles
             {
                 new Vector3(884.896f, 259.5558f, 875.1169f),    // base camp
                 new Vector3(-542.5715f, 68.6256f, 598.2891f),
-                new Vector3(-390f, 67.99994f, 700f),
                 new Vector3(-384.2f, 40f, -441.6f),
+                new Vector3(458.4f, 70.4f, 524.8f),
+                new Vector3(351.5f, 45.2f, -560.2f),
+                new Vector3(-19.8f, 2.4f, -38.6f),
                 new Vector3(597.8f, -700f, 927f),               // Forked Tower entrance
                 new Vector3(-893f, -984.7401f, 780f),           // Forked Tower
                 new Vector3(-900f, -986.1f, 782.2488f),

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -179,17 +179,54 @@ namespace Magitek.Logic.Roles
     {
         private static readonly HashSet<ushort> OccultCrescentZoneIds = new()
         {
-            1252,
+            1252, // The Occult Crescent: South Horn
+            1346, // The Occult Crescent: Northern Horn
         };
 
+        private const string OccultCrescentZoneNamePart = "Occult Crescent";
+
+        private static int _lastZoneChecked = -1;
+        private static bool _lastZoneWasOccultCrescent;
+
+        /// <summary>
+        /// Known zone ids first, then a fallback on the zone name so a newly released Horn works the day
+        /// it ships instead of silently disabling everything Occult Crescent specific until its id is
+        /// added here — which is exactly what happened when Northern Horn arrived.
+        /// <para>
+        /// Name matching is safe across clients: WorldManager.CurrentZoneName is the non-localized name
+        /// (CurrentLocalizedZoneName is the one shown to the player). The result is cached per zone so the
+        /// string comparison happens once on zone change rather than on every call.
+        /// </para>
+        /// </summary>
         public static bool IsInOccultCrescent()
         {
-            return OccultCrescentZoneIds.Contains(WorldManager.ZoneId);
+            var zoneId = WorldManager.ZoneId;
+
+            if (zoneId == _lastZoneChecked)
+                return _lastZoneWasOccultCrescent;
+
+            var zoneName = WorldManager.CurrentZoneName;
+
+            _lastZoneChecked = zoneId;
+            _lastZoneWasOccultCrescent = OccultCrescentZoneIds.Contains(zoneId)
+                || (!string.IsNullOrEmpty(zoneName)
+                    && zoneName.IndexOf(OccultCrescentZoneNamePart, StringComparison.OrdinalIgnoreCase) >= 0);
+
+            return _lastZoneWasOccultCrescent;
         }
 
         private static readonly uint KnowledgeCrystal = 2007457;
 
-        // Known Knowledge Crystal locations that never change
+        // Known Knowledge Crystal locations that never change. SOUTH HORN ONLY — these are raw map
+        // coordinates, and each Horn has its own coordinate space, so the same numbers point at unrelated
+        // ground elsewhere. Always check the zone before trusting them.
+        private const ushort SouthHornZoneId = 1252;
+
+        // How close a Knowledge Crystal stands to its Occult Aetheryte. South Horn proves the crystal
+        // out by checking it sits on one of a handful of known positions; no such list exists for newer
+        // Horns, so the aetheryte beside it serves the same purpose without needing the zone mapped first.
+        private const float AetheryteProximity = 7.0f;
+
         private static readonly Vector3[] KnowledgeCrystalLocations = new[]
         {
             new Vector3(835.9902f, 75.12211f, -709.3925f),
@@ -214,6 +251,16 @@ namespace Magitek.Logic.Roles
         // Cannoneer alternating cannon tracking
         private static bool _lastUsedShockCannon = false;
 
+        // OccultSlowga recast backoff. Slowga spammed on Slow-immune enemies (their Slow never lands,
+        // so the "target doesn't have Slow" guard stays true and it re-casts every pulse). Rather than
+        // permanently blacklisting a type — fragile, because an interrupted cast, a Slow that expired
+        // while the mob was untargeted, or a mid-cast target switch can all look like a resist and
+        // wrongly kill a slowable type for the session — we simply back off: each consecutive cast on
+        // a type that doesn't result in Slow pushes the next attempt further out (to a 5-minute cap),
+        // so immune mobs go near-silent, while a Slow that actually lands clears the type back to
+        // normal. Keyed by mob type, self-healing, bounded by the number of distinct OC mob types.
+        private static readonly Dictionary<uint, (int Fails, DateTime LastCast)> _slowBackoff = new();
+
         // Oracle prediction tracking
         private static bool _predictCasted = false;
         private static DateTime _predictCastTime = DateTime.MinValue;
@@ -236,7 +283,17 @@ namespace Magitek.Logic.Roles
             { 4364, PhantomJob.Geomancer },
             { 4805, PhantomJob.Dancer },
             { 4803, PhantomJob.MysticKnight },
-            { 4804, PhantomJob.Gladiator }
+            { 4804, PhantomJob.Gladiator },
+            // Added with Northern Horn. Without these the current job reads as None and every Occult
+            // Crescent feature bails out, which is why nothing worked while playing one of them.
+            { 5328, PhantomJob.Ninja },
+            { 5329, PhantomJob.WhiteMage },
+            { 5330, PhantomJob.BlackMage },
+            { 5331, PhantomJob.Dragoon },
+            { 5332, PhantomJob.Summoner },
+            { 5333, PhantomJob.BlueMage },
+            { 5334, PhantomJob.RedMage },
+            { 5335, PhantomJob.Necromancer }
         };
 
         public enum PhantomJob
@@ -256,7 +313,15 @@ namespace Magitek.Logic.Roles
             Geomancer,
             Dancer,
             MysticKnight,
-            Gladiator
+            Gladiator,
+            Ninja,
+            WhiteMage,
+            BlackMage,
+            Dragoon,
+            Summoner,
+            BlueMage,
+            RedMage,
+            Necromancer
         }
 
         /// <summary>
@@ -286,15 +351,67 @@ namespace Magitek.Logic.Roles
         /// <returns>True if near a valid crystal</returns>
         private static bool PerformCrystalCheck(float maxDistance)
         {
-            // Simply check if player is near any known crystal location
-            // No need for expensive NPC searches since crystal locations are fixed
             var loc = Core.Me.Location;
-            foreach (var crystalLocation in KnowledgeCrystalLocations)
+
+            // Fast path: the known crystal spots, no object scan needed. Gated to South Horn, because the
+            // coordinates only mean anything there — used zone-wide they resolve to arbitrary ground in
+            // Northern Horn, where they read as "standing at a crystal" in places that plainly aren't, and
+            // swap phantom jobs on arrival at a critical engagement.
+            if (WorldManager.ZoneId == SouthHornZoneId)
             {
-                if (loc.DistanceSqr(crystalLocation) <= maxDistance * maxDistance)
-                    return true;
+                foreach (var crystalLocation in KnowledgeCrystalLocations)
+                {
+                    if (loc.DistanceSqr(crystalLocation) <= maxDistance * maxDistance)
+                    {
+                        Logger.WriteInfo($"[KnowledgeCrystal] Matched a known South Horn position at {loc}.");
+                        return true;
+                    }
+                }
             }
-            return false;
+
+            // Otherwise look for the crystal itself. The coordinates above only cover South Horn, so
+            // relying on them alone silently disabled phantom job switching everywhere else the moment
+            // Northern Horn arrived. Finding the object works in any Horn without needing its layout.
+            // The caller throttles this check, so the scan is bounded.
+            var nearby = GameObjectManager.GetObjectsByNPCId<GameObject>(KnowledgeCrystal)
+                .Where(crystal => crystal != null && crystal.IsValid)
+                .Select(crystal => new { Crystal = crystal, Distance = loc.Distance(crystal.Location) })
+                .Where(x => x.Distance <= maxDistance)
+                .OrderBy(x => x.Distance)
+                .ToList();
+
+            if (nearby.Count == 0)
+                return false;
+
+            // The marker that lights up where a critical engagement is about to spawn carries the SAME
+            // object id as a Knowledge Crystal, which is what was swapping phantom jobs out in the field.
+            // The two cannot be told apart by the object alone — crystals are not targetable either — but
+            // a real crystal always stands beside an Occult Aetheryte, and an engagement marker does not.
+            var aetherytes = GameObjectManager.GameObjects
+                .Where(o => o != null && o.IsValid && o.EnglishName != null
+                            && o.EnglishName.IndexOf("Aetheryte", StringComparison.OrdinalIgnoreCase) >= 0)
+                .ToList();
+
+            var match = nearby.FirstOrDefault(x =>
+                aetherytes.Any(a => a.Location.Distance(x.Crystal.Location) <= AetheryteProximity));
+
+            if (match == null)
+            {
+                // Log what WAS beside the candidate, so a wrong assumption here shows up immediately
+                // rather than silently disabling phantom buffs.
+                var nearest = nearby[0];
+                var closestAetheryte = aetherytes
+                    .OrderBy(a => a.Location.Distance(nearest.Crystal.Location))
+                    .FirstOrDefault();
+                var how = closestAetheryte == null
+                    ? "no aetheryte found in the zone at all"
+                    : $"nearest aetheryte is {closestAetheryte.Location.Distance(nearest.Crystal.Location):F1}y from it";
+                Logger.WriteInfo($"[KnowledgeCrystal] Ignoring {nearby.Count} candidate(s) with no aetheryte beside them — closest is {nearest.Distance:F1}y away at {nearest.Crystal.Location}; {how}.");
+                return false;
+            }
+
+            Logger.WriteInfo($"[KnowledgeCrystal] Found a crystal {match.Distance:F1}y away at {match.Crystal.Location} (zone {WorldManager.ZoneId}).");
+            return true;
 
             /* OLD APPROACH - NPC LOOKUP METHOD (preserved for reference)
              * This was the original implementation that verified actual NPC existence
@@ -432,6 +549,14 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.InCombat && !OccultCrescentSettings.Instance.ReviveNonPartyOutOfCombat)
                 return false;
 
+            // Party-priority: if a raise-eligible party member is down, yield this pulse so the
+            // standard Heal()/Verraise() path (which runs later in the same pulse chain and owns
+            // party rez) spends any Dualcast/Swiftcast on them instead of a non-party random. Only
+            // yields when actually grouped with an eligible corpse, so it won't strand a party
+            // member the standard path wouldn't cover anyway.
+            if (Globals.InParty && HasRaisableDeadPartyMember())
+                return false;
+
             // Update alliance to get dead players using optimized Group system
             Group.UpdateAlliance(
                 IgnoreAlliance: false,
@@ -447,6 +572,20 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
+        /// True when a party member is dead and rezzable in principle by the standard raise path.
+        /// Used to yield non-party resurrection so party members keep priority for instant-cast sources.
+        /// </summary>
+        private static bool HasRaisableDeadPartyMember()
+        {
+            return Group.DeadAllies.Any(u => u.CurrentHealth == 0
+                && !u.HasAura(Auras.Raise)
+                && u.WithinSpellRange(30)
+                && u.IsVisible
+                && u.InLineOfSight()
+                && u.IsTargetable);
+        }
+
+        /// <summary>
         /// Attempts to raise a non-party player using the appropriate resurrection spell for current job
         /// Handles swiftcast/slowcast preferences and special cases like RDM dualcast
         /// </summary>
@@ -457,7 +596,7 @@ namespace Magitek.Logic.Roles
             // Filter out party members since CastableAlliance includes everyone
             var deadNonPartyPlayers = Group.CastableAlliance.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
-                                                       u.Distance(Core.Me) <= 30 &&
+                                                       u.WithinSpellRange(30) &&
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&
@@ -513,7 +652,13 @@ namespace Magitek.Logic.Roles
             {
                 if (await Healer.Swiftcast())
                 {
-                    while (Core.Me.HasAura(Auras.Swiftcast))
+                    // Re-validate the target each iteration: another player can rez/LoS-break the same
+                    // corpse mid-loop, which would otherwise spin here (CastAura keeps failing without
+                    // consuming Swiftcast) until the aura expires ~10s later, stalling the whole routine.
+                    while (Core.Me.HasAura(Auras.Swiftcast)
+                           && target != null && target.IsValid && target.IsTargetable
+                           && !target.HasAura(Auras.Raise)
+                           && target.WithinSpellRange(30) && target.InLineOfSight())
                     {
                         if (await resurrectionSpell.CastAura(target, Auras.Raise))
                             return true;
@@ -541,14 +686,58 @@ namespace Magitek.Logic.Roles
             if (!Spells.Verraise.CanCast())
                 return false;
 
-            // First check for dualcast (best option for RDM)
-            if (Core.Me.HasAura(Auras.Dualcast))
+            // Dualcast or Swiftcast already up: instant Verraise (best case).
+            if (Core.Me.HasAura(Auras.Dualcast) || Core.Me.HasAura(Auras.Swiftcast))
+                return await Spells.Verraise.Cast(target);
+
+            // Swiftcast off cooldown: pop it for an instant Verraise.
+            if (Spells.Swiftcast.IsKnownAndReady())
             {
+                if (await Healer.Swiftcast())
+                {
+                    // Re-validate the target each iteration: in the open field another player can
+                    // rez/LoS-break the same corpse, which would otherwise spin here (CastAura keeps
+                    // failing without consuming Swiftcast) until the aura expires ~10s later.
+                    while (Core.Me.HasAura(Auras.Swiftcast)
+                           && target != null && target.IsValid && target.IsTargetable
+                           && !target.HasAura(Auras.Raise)
+                           && target.WithinSpellRange(30) && target.InLineOfSight())
+                    {
+                        if (await Spells.Verraise.CastAura(target, Auras.Raise))
+                            return true;
+                        await Coroutine.Yield();
+                    }
+                }
+            }
+
+            // If the loop above exited with Swiftcast still up (the corpse got invalidated mid-loop),
+            // don't fall into the priming/hardcast paths — an instant Vercure would burn the Swiftcast
+            // without proc'ing Dualcast. Bail and re-pulse; the next pass spends the still-up Swiftcast on
+            // an instant Verraise against a freshly-selected valid corpse (handled at the top of this method).
+            if (Core.Me.HasAura(Auras.Swiftcast))
+                return false;
+
+            // Out of combat with no instant-cast source: prime Dualcast with a quick self-Vercure
+            // (~2s) instead of hard-casting Verraise (~10s). The next pulse consumes the Dualcast
+            // for an instant Verraise. Mirrors RedMage VerraisePrime() for the field-op rez path,
+            // which never sees these non-party allies (they aren't in Group.DeadAllies).
+            if (!Core.Me.InCombat)
+            {
+                // Moving: can neither prime (Vercure must stand still) nor hardcast (the cast-time
+                // gate rejects a moving cast with no instant-cast source). Bail and retry next pulse;
+                // the prime runs once stopped.
+                if (MovementManager.IsMoving)
+                    return false;
+
+                if (Spells.Vercure.IsKnown() && await Spells.Vercure.Cast(Core.Me))
+                    return true;
+
+                // Vercure unavailable or failed: hard-cast Verraise so the rez still lands.
                 return await Spells.Verraise.Cast(target);
             }
 
-            // No dualcast, use regular swiftcast/slowcast logic
-            return await RaiseWithSwiftcastOptions(Spells.Verraise, target);
+            // In combat with no instant-cast source: don't clip the fight with a ~10s hardcast.
+            return false;
         }
 
         /// <summary>
@@ -1886,7 +2075,7 @@ namespace Magitek.Logic.Roles
             // Find dead allies using the same logic as Healer.Raise
             var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
-                                                       u.Distance(Core.Me) <= 30 &&
+                                                       u.WithinSpellRange(30) &&
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&
@@ -1967,13 +2156,36 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            // Don't cast if target already has slow debuff
+            // Already slowed — nothing to do; clear this type's backoff (it's proven slowable).
             if (Core.Me.CurrentTarget.HasAura(OCAuras.Slow))
+            {
+                if (Core.Me.CurrentTarget is BattleCharacter slowed)
+                    _slowBackoff.Remove(slowed.NpcId);
                 return false;
+            }
 
             // Check if target is a BattleCharacter for additional checks
             if (Core.Me.CurrentTarget is BattleCharacter battleTarget)
             {
+                // Back off from types whose recent Slowga casts never produced Slow (immune/resisting).
+                // The delay escalates with consecutive misses so an immune type effectively goes quiet,
+                // while the HasAura clear above keeps genuinely slowable types responsive. This only
+                // delays and never permanently disables, so a mis-detection self-corrects on the next
+                // landed Slow.
+                if (_slowBackoff.TryGetValue(battleTarget.NpcId, out var bo))
+                {
+                    var delay = bo.Fails switch
+                    {
+                        <= 1 => TimeSpan.FromSeconds(15),
+                        2 => TimeSpan.FromSeconds(30),
+                        3 => TimeSpan.FromSeconds(60),
+                        4 => TimeSpan.FromSeconds(120),
+                        _ => TimeSpan.FromSeconds(300),
+                    };
+                    if (DateTime.Now - bo.LastCast < delay)
+                        return false;
+                }
+
                 // Check difficulty - high difficulty enemies are often immune to CC
                 if (battleTarget.RawDifficulty >= 2)
                     return false;
@@ -1990,7 +2202,19 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.WithinSpellRange(OCSpells.OccultSlowga.Range))
                 return false;
 
-            return await OCSpells.OccultSlowga.Cast(Core.Me.CurrentTarget);
+            // Capture the target before the (cast-time) await so the backoff record can't be mis-keyed
+            // to a different enemy if CurrentTarget switches while the cast is in flight.
+            var castTarget = Core.Me.CurrentTarget;
+            if (!await OCSpells.OccultSlowga.Cast(castTarget))
+                return false;
+
+            // Escalate this type's backoff; a Slow that actually lands clears it via the HasAura path.
+            if (castTarget is BattleCharacter casted)
+            {
+                var fails = _slowBackoff.TryGetValue(casted.NpcId, out var prev) ? prev.Fails + 1 : 1;
+                _slowBackoff[casted.NpcId] = (fails, DateTime.Now);
+            }
+            return true;
         }
 
         /// <summary>
@@ -2160,9 +2384,6 @@ namespace Magitek.Logic.Roles
 
             if (!Core.Me.CurrentTarget.HasDispellableAura())
                 return false;
-
-            // if (!Core.Me.CurrentTarget.HasAnyAura(OCAuras.DispellableAuras))
-            //     return false;
 
             if (!Core.Me.CurrentTarget.WithinSpellRange(OCSpells.OccultDispel.Range))
                 return false;

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -267,6 +267,11 @@ namespace Magitek.Logic.Roles
         // normal. Keyed by mob type, self-healing, bounded by the number of distinct OC mob types.
         private static readonly Dictionary<uint, (int Fails, DateTime LastCast)> _slowBackoff = new();
 
+        // How long to watch for Slow to appear before calling the cast a miss. Long enough to cover
+        // server round-trip on the aura, short enough not to stall the rotation; returns as soon as
+        // the aura lands, so the normal case costs nothing near this.
+        private const int SlowConfirmWindowMs = 1500;
+
         // Oracle prediction tracking
         private static bool _predictCasted = false;
         private static DateTime _predictCastTime = DateTime.MinValue;
@@ -2254,11 +2259,21 @@ namespace Magitek.Logic.Roles
             if (!await OCSpells.OccultSlowga.Cast(castTarget))
                 return false;
 
-            // Escalate this type's backoff; a Slow that actually lands clears it via the HasAura path.
+            // Only count a miss once Slow is confirmed absent. Recording one straight after the cast
+            // scored successful casts as failures whenever the target died before a later pulse could
+            // observe the aura, quietly muting a perfectly slowable type for up to five minutes.
             if (castTarget is BattleCharacter casted)
             {
-                var fails = _slowBackoff.TryGetValue(casted.NpcId, out var prev) ? prev.Fails + 1 : 1;
-                _slowBackoff[casted.NpcId] = (fails, DateTime.Now);
+                if (await Coroutine.Wait(SlowConfirmWindowMs, () => casted.HasAura(OCAuras.Slow)))
+                {
+                    _slowBackoff.Remove(casted.NpcId);
+                }
+                else if (casted.IsValid && casted.IsAlive)
+                {
+                    // Still standing and still unslowed — that is a genuine resist.
+                    var fails = _slowBackoff.TryGetValue(casted.NpcId, out var prev) ? prev.Fails + 1 : 1;
+                    _slowBackoff[casted.NpcId] = (fails, DateTime.Now);
+                }
             }
             return true;
         }

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -424,14 +424,17 @@ namespace Magitek.Logic.Roles
             if (!IsInOccultCrescent())
                 return false;
 
+            // First, try automatic phantom job switching for knowledge crystal buffs. This runs before
+            // the phantom-job guard below because Freelancer grants no phantom job aura, so a player
+            // standing at a crystal as Freelancer reads as None — and they are exactly who the
+            // Inquiring Mind path serves. The switcher carries its own gating.
+            if (await PhantomJobSwitcher.AutoSwitchForKnowledgeCrystalBuffs())
+                return true;
+
             // Get the current phantom job
             var phantomJob = GetCurrentPhantomJob();
             if (phantomJob == PhantomJob.None)
                 return false;
-
-            // First, try automatic phantom job switching for knowledge crystal buffs
-            if (await PhantomJobSwitcher.AutoSwitchForKnowledgeCrystalBuffs())
-                return true;
 
             // Execute phantom job specific logic
             var phantomJobResult = phantomJob switch

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -530,21 +530,6 @@ namespace Magitek.Logic.Roles
                 return false;
             _lastNonPartyResCheck = now;
 
-            // Check if we're Phantom Chemist (free resurrection) or need MP check for regular jobs
-            var phantomJob = GetCurrentPhantomJob();
-            bool isPhantomChemist = phantomJob == PhantomJob.Chemist;
-
-            // Only check MP for non-Chemist resurrections (Chemist Revive doesn't cost MP)
-            if (!isPhantomChemist && Core.Me.CurrentManaPercent < OccultCrescentSettings.Instance.ReviveNonPartyMinimumManaPercent)
-                return false;
-
-            // Check combat preferences
-            if (Core.Me.InCombat && !OccultCrescentSettings.Instance.ReviveNonPartyInCombat)
-                return false;
-
-            if (!Core.Me.InCombat && !OccultCrescentSettings.Instance.ReviveNonPartyOutOfCombat)
-                return false;
-
             // Party-priority: if a raise-eligible party member is down, yield this pulse so the
             // standard Heal()/Verraise() path (which runs later in the same pulse chain and owns
             // party rez) spends any Dualcast/Swiftcast on them instead of a non-party random. Only
@@ -555,6 +540,12 @@ namespace Magitek.Logic.Roles
             // role the user excluded — then the corpse simply stays there and this would keep standing
             // aside forever, which is exactly how non-party revival ends up never happening. Give the
             // party path a fair window and then stop waiting on it.
+            //
+            // This has to run BEFORE the mana and combat-preference gates below. Those gates decide
+            // whether we may raise a stranger; they say nothing about who is down. Tracked underneath
+            // them, the set and the timer simply froze for as long as mana sat under the threshold — so a
+            // member who died, was raised and died again during that stretch came back to an unchanged
+            // set and a timestamp minutes old, and had their grace window treated as already spent.
             var raisableParty = RaisableDeadPartyMemberIds();
 
             if (Globals.InParty && raisableParty.Count > 0)
@@ -577,6 +568,21 @@ namespace Magitek.Logic.Roles
                 _partyRaiseYieldSince = DateTime.MinValue;
                 _partyRaiseYieldFor.Clear();
             }
+
+            // Check if we're Phantom Chemist (free resurrection) or need MP check for regular jobs
+            var phantomJob = GetCurrentPhantomJob();
+            bool isPhantomChemist = phantomJob == PhantomJob.Chemist;
+
+            // Only check MP for non-Chemist resurrections (Chemist Revive doesn't cost MP)
+            if (!isPhantomChemist && Core.Me.CurrentManaPercent < OccultCrescentSettings.Instance.ReviveNonPartyMinimumManaPercent)
+                return false;
+
+            // Check combat preferences
+            if (Core.Me.InCombat && !OccultCrescentSettings.Instance.ReviveNonPartyInCombat)
+                return false;
+
+            if (!Core.Me.InCombat && !OccultCrescentSettings.Instance.ReviveNonPartyOutOfCombat)
+                return false;
 
             // Update alliance to get dead players using optimized Group system
             Group.UpdateAlliance(

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -721,7 +721,11 @@ namespace Magitek.Logic.Roles
         /// </summary>
         private static async Task<bool> RaiseRedMage(GameObject target)
         {
-            if (!Spells.Verraise.CanCast())
+            // Check against the corpse, not the parameterless overload — that one substitutes Core.Me, so
+            // a raise is asked whether it can be cast on someone who is alive. The generic raise path above
+            // and Healer.ResurrectionLogic both pass the dead target; this was the only raise call site
+            // that did not.
+            if (!Spells.Verraise.CanCast(target))
                 return false;
 
             // Dualcast or Swiftcast already up: instant Verraise (best case).

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -267,10 +267,14 @@ namespace Magitek.Logic.Roles
         // normal. Keyed by mob type, self-healing, bounded by the number of distinct OC mob types.
         private static readonly Dictionary<uint, (int Fails, DateTime LastCast)> _slowBackoff = new();
 
-        // How long to watch for Slow to appear before calling the cast a miss. Long enough to cover
-        // server round-trip on the aura, short enough not to stall the rotation; returns as soon as
-        // the aura lands, so the normal case costs nothing near this.
-        private const int SlowConfirmWindowMs = 1500;
+        // Slowga is a cast, and a cast reports back the moment it starts rather than when it lands, so
+        // nothing conclusive about the Slow is knowable at the point of casting. Each cast is recorded
+        // here instead and judged on a later pulse, once the aura has had time to appear. Keyed by the
+        // individual enemy, since two of the same type can be slowed independently.
+        private static readonly Dictionary<uint, (uint NpcId, DateTime JudgeAt)> _slowPending = new();
+
+        // Grace on top of the cast time before a missing Slow is treated as a resist.
+        private const int SlowConfirmGraceMs = 1000;
 
         // Oracle prediction tracking
         private static bool _predictCasted = false;
@@ -2188,11 +2192,53 @@ namespace Magitek.Logic.Roles
         /// <summary>
         /// Cast OccultSlowga - afflicts target with Slow (aura 3493)
         /// </summary>
+        /// <summary>
+        /// Judges Slowga casts whose Slow has had time to land. An enemy that is gone by then — killed
+        /// during the cast, despawned, out of range — proves nothing either way and is simply dropped,
+        /// which is what stops a kill from being recorded as an immunity and muting a slowable type.
+        /// </summary>
+        private static void ResolveSlowgaCasts()
+        {
+            if (_slowPending.Count == 0)
+                return;
+
+            var now = DateTime.Now;
+            var judged = new List<uint>();
+
+            foreach (var (objectId, pending) in _slowPending)
+            {
+                if (now < pending.JudgeAt)
+                    continue;
+
+                judged.Add(objectId);
+
+                var target = Combat.Enemies.FirstOrDefault(x => x.ObjectId == objectId);
+                if (target == null || !target.IsValid || !target.IsAlive)
+                    continue;
+
+                if (target.HasAura(OCAuras.Slow))
+                {
+                    _slowBackoff.Remove(pending.NpcId);
+                }
+                else
+                {
+                    // Alive, in view, and still unslowed well after the cast — a genuine resist.
+                    var fails = _slowBackoff.TryGetValue(pending.NpcId, out var prev) ? prev.Fails + 1 : 1;
+                    _slowBackoff[pending.NpcId] = (fails, now);
+                }
+            }
+
+            foreach (var objectId in judged)
+                _slowPending.Remove(objectId);
+        }
+
         /// <returns>True if spell was cast, false otherwise</returns>
         private static async Task<bool> OccultSlowga()
         {
             if (!OccultCrescentSettings.Instance.UseOccultSlowga)
                 return false;
+
+            ResolveSlowgaCasts();
 
             if (!Core.Me.InCombat)
                 return false;
@@ -2259,21 +2305,12 @@ namespace Magitek.Logic.Roles
             if (!await OCSpells.OccultSlowga.Cast(castTarget))
                 return false;
 
-            // Only count a miss once Slow is confirmed absent. Recording one straight after the cast
-            // scored successful casts as failures whenever the target died before a later pulse could
-            // observe the aura, quietly muting a perfectly slowable type for up to five minutes.
+            // Hand the result off to be judged later; the cast has only just begun here.
             if (castTarget is BattleCharacter casted)
             {
-                if (await Coroutine.Wait(SlowConfirmWindowMs, () => casted.HasAura(OCAuras.Slow)))
-                {
-                    _slowBackoff.Remove(casted.NpcId);
-                }
-                else if (casted.IsValid && casted.IsAlive)
-                {
-                    // Still standing and still unslowed — that is a genuine resist.
-                    var fails = _slowBackoff.TryGetValue(casted.NpcId, out var prev) ? prev.Fails + 1 : 1;
-                    _slowBackoff[casted.NpcId] = (fails, DateTime.Now);
-                }
+                var judgeAt = DateTime.Now.AddMilliseconds(
+                    OCSpells.OccultSlowga.AdjustedCastTime.TotalMilliseconds + SlowConfirmGraceMs);
+                _slowPending[casted.ObjectId] = (casted.NpcId, judgeAt);
             }
             return true;
         }

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -215,29 +215,44 @@ namespace Magitek.Logic.Roles
             return _lastZoneWasOccultCrescent;
         }
 
-        private static readonly uint KnowledgeCrystal = 2007457;
-
-        // Known Knowledge Crystal locations that never change. SOUTH HORN ONLY — these are raw map
-        // coordinates, and each Horn has its own coordinate space, so the same numbers point at unrelated
-        // ground elsewhere. Always check the zone before trusting them.
         private const ushort SouthHornZoneId = 1252;
+        private const ushort NorthHornZoneId = 1346;
 
-        // How close a Knowledge Crystal stands to its Occult Aetheryte. South Horn proves the crystal
-        // out by checking it sits on one of a handful of known positions; no such list exists for newer
-        // Horns, so the aetheryte beside it serves the same purpose without needing the zone mapped first.
-        private const float AetheryteProximity = 7.0f;
-
-        private static readonly Vector3[] KnowledgeCrystalLocations = new[]
+        // Known Knowledge Crystal locations per zone. These never change, and each Horn has its own
+        // coordinate space, so the lists are keyed by zone id.
+        private static readonly Dictionary<ushort, Vector3[]> KnowledgeCrystalLocations = new()
         {
-            new Vector3(835.9902f, 75.12211f, -709.3925f),
-            new Vector3(-165.9937f, 8.5f, -616.4979f),
-            new Vector3(-347.2297f, 102.3273f, -124.1305f),
-            new Vector3(-393.0761f, 99.51316f, 278.7158f),
-            new Vector3(302.5914f, 105f, 313.6591f)
+            [SouthHornZoneId] = new[]
+            {
+                new Vector3(835.9902f, 75.12211f, -709.3925f),
+                new Vector3(-165.9937f, 8.5f, -616.4979f),
+                new Vector3(-347.2297f, 102.3273f, -124.1305f),
+                new Vector3(-393.0761f, 99.51316f, 278.7158f),
+                new Vector3(302.5914f, 105f, 313.6591f)
+            },
+            [NorthHornZoneId] = new[]
+            {
+                new Vector3(884.896f, 259.5558f, 875.1169f),    // base camp
+                new Vector3(-542.5715f, 68.6256f, 598.2891f),
+                new Vector3(-390f, 67.99994f, 700f),
+                new Vector3(-893f, -984.7401f, 780f),           // Forked Tower
+                new Vector3(-900f, -986.1f, 782.2488f),
+                new Vector3(-900.0712f, -983f, 839.275f),
+                new Vector3(103f, -706.7383f, 678f),
+                new Vector3(0f, -722.6936f, -367f),
+                new Vector3(603.5453f, -672.6606f, 640.6041f),
+                new Vector3(600f, -673.8f, 624f),
+                new Vector3(603.7968f, -670.6514f, -125.1157f),
+                new Vector3(600f, -672f, -142f)
+            }
         };
 
-        // Respawn point location
-        private static readonly Vector3 RespawnPoint = new Vector3(851.87665f, 73.13358f, -704.79004f);
+        // Respawn point location per zone
+        private static readonly Dictionary<ushort, Vector3> RespawnPoints = new()
+        {
+            [SouthHornZoneId] = new Vector3(851.87665f, 73.13358f, -704.79004f),
+            [NorthHornZoneId] = new Vector3(905.57f, 259.88f, 905.97f)
+        };
 
         // Throttling for knowledge crystal checks
         private static DateTime _lastCrystalCheck = DateTime.MinValue;
@@ -341,67 +356,19 @@ namespace Magitek.Logic.Roles
         /// <returns>True if near a valid crystal</returns>
         private static bool PerformCrystalCheck(float maxDistance)
         {
+            // Simply check if player is near any known crystal location
+            // No need for expensive NPC searches since crystal locations are fixed
             var loc = Core.Me.Location;
-
-            // Fast path: the known crystal spots, no object scan needed. Gated to South Horn, because the
-            // coordinates only mean anything there — used zone-wide they resolve to arbitrary ground in
-            // Northern Horn, where they read as "standing at a crystal" in places that plainly aren't, and
-            // swap phantom jobs on arrival at a critical engagement.
-            if (WorldManager.ZoneId == SouthHornZoneId)
-            {
-                foreach (var crystalLocation in KnowledgeCrystalLocations)
-                {
-                    if (loc.DistanceSqr(crystalLocation) <= maxDistance * maxDistance)
-                    {
-                        Logger.WriteInfo($"[KnowledgeCrystal] Matched a known South Horn position at {loc}.");
-                        return true;
-                    }
-                }
-            }
-
-            // Otherwise look for the crystal itself. The coordinates above only cover South Horn, so
-            // relying on them alone silently disabled phantom job switching everywhere else the moment
-            // Northern Horn arrived. Finding the object works in any Horn without needing its layout.
-            // The caller throttles this check, so the scan is bounded.
-            var nearby = GameObjectManager.GetObjectsByNPCId<GameObject>(KnowledgeCrystal)
-                .Where(crystal => crystal != null && crystal.IsValid)
-                .Select(crystal => new { Crystal = crystal, Distance = loc.Distance(crystal.Location) })
-                .Where(x => x.Distance <= maxDistance)
-                .OrderBy(x => x.Distance)
-                .ToList();
-
-            if (nearby.Count == 0)
+            if (!KnowledgeCrystalLocations.TryGetValue(WorldManager.ZoneId, out var crystalLocations))
                 return false;
 
-            // The marker that lights up where a critical engagement is about to spawn carries the SAME
-            // object id as a Knowledge Crystal, which is what was swapping phantom jobs out in the field.
-            // The two cannot be told apart by the object alone — crystals are not targetable either — but
-            // a real crystal always stands beside an Occult Aetheryte, and an engagement marker does not.
-            var aetherytes = GameObjectManager.GameObjects
-                .Where(o => o != null && o.IsValid && o.EnglishName != null
-                            && o.EnglishName.IndexOf("Aetheryte", StringComparison.OrdinalIgnoreCase) >= 0)
-                .ToList();
-
-            var match = nearby.FirstOrDefault(x =>
-                aetherytes.Any(a => a.Location.Distance(x.Crystal.Location) <= AetheryteProximity));
-
-            if (match == null)
+            foreach (var crystalLocation in crystalLocations)
             {
-                // Log what WAS beside the candidate, so a wrong assumption here shows up immediately
-                // rather than silently disabling phantom buffs.
-                var nearest = nearby[0];
-                var closestAetheryte = aetherytes
-                    .OrderBy(a => a.Location.Distance(nearest.Crystal.Location))
-                    .FirstOrDefault();
-                var how = closestAetheryte == null
-                    ? "no aetheryte found in the zone at all"
-                    : $"nearest aetheryte is {closestAetheryte.Location.Distance(nearest.Crystal.Location):F1}y from it";
-                Logger.WriteInfo($"[KnowledgeCrystal] Ignoring {nearby.Count} candidate(s) with no aetheryte beside them — closest is {nearest.Distance:F1}y away at {nearest.Crystal.Location}; {how}.");
-                return false;
+                if (loc.DistanceSqr(crystalLocation) <= maxDistance * maxDistance)
+                    return true;
             }
 
-            Logger.WriteInfo($"[KnowledgeCrystal] Found a crystal {match.Distance:F1}y away at {match.Crystal.Location} (zone {WorldManager.ZoneId}).");
-            return true;
+            return false;
 
             /* OLD APPROACH - NPC LOOKUP METHOD (preserved for reference)
              * This was the original implementation that verified actual NPC existence
@@ -573,12 +540,10 @@ namespace Magitek.Logic.Roles
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&
-                                                       // Skip anyone stood at the respawn point, since they have chosen to
-                                                       // return rather than wait. That point is a South Horn coordinate, so
-                                                       // the test only means anything there — applied in another Horn it
-                                                       // measures against unrelated ground and excludes people at random.
-                                                       (WorldManager.ZoneId != SouthHornZoneId
-                                                        || u.Location.DistanceSqr(RespawnPoint) >= 900));
+                                                       // Skip anyone stood at the zone's respawn point, since they have
+                                                       // chosen to return rather than wait for a raise.
+                                                       (!RespawnPoints.TryGetValue(WorldManager.ZoneId, out var respawnPoint)
+                                                        || u.Location.DistanceSqr(respawnPoint) >= 900));
 
             if (!deadNonPartyPlayers.Any())
                 return false;

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -247,6 +247,7 @@ namespace Magitek.Logic.Roles
                 new Vector3(103f, -706.7383f, 678f),
                 new Vector3(0f, -722.6936f, -367f),
                 new Vector3(603.5453f, -672.6606f, 640.6041f),
+                new Vector3(599.4f, -700.0f, 927.8f),      // Forked Tower, Lower Vestibule (surveyed live 2026-08-07)
                 new Vector3(603.7968f, -670.6514f, -125.1157f)
             }
         };

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2190,9 +2190,6 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
-        /// Cast OccultSlowga - afflicts target with Slow (aura 3493)
-        /// </summary>
-        /// <summary>
         /// Judges Slowga casts whose Slow has had time to land. An enemy that is gone by then — killed
         /// during the cast, despawned, out of range — proves nothing either way and is simply dropped,
         /// which is what stops a kill from being recorded as an immunity and muting a slowable type.
@@ -2212,7 +2209,9 @@ namespace Magitek.Logic.Roles
 
                 judged.Add(objectId);
 
-                var target = Combat.Enemies.FirstOrDefault(x => x.ObjectId == objectId);
+                // Match the type as well as the object: the game reuses object ids, so an entry that
+                // sat around could otherwise be judged against whatever spawned into the same slot.
+                var target = Combat.Enemies.FirstOrDefault(x => x.ObjectId == objectId && x.NpcId == pending.NpcId);
                 if (target == null || !target.IsValid || !target.IsAlive)
                     continue;
 
@@ -2232,13 +2231,17 @@ namespace Magitek.Logic.Roles
                 _slowPending.Remove(objectId);
         }
 
+        /// <summary>
+        /// Cast OccultSlowga - afflicts target with Slow (aura 3493)
+        /// </summary>
         /// <returns>True if spell was cast, false otherwise</returns>
         private static async Task<bool> OccultSlowga()
         {
+            // Ahead of the settings gate so turning Slowga off mid-fight still clears what is pending.
+            ResolveSlowgaCasts();
+
             if (!OccultCrescentSettings.Instance.UseOccultSlowga)
                 return false;
-
-            ResolveSlowgaCasts();
 
             if (!Core.Me.InCombat)
                 return false;

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -529,6 +529,14 @@ namespace Magitek.Logic.Roles
         {
             // Get dead non-party players from the optimized Group.CastableAlliance
             // Filter out party members since CastableAlliance includes everyone
+            //
+            // Raise range is a raw 3D distance on purpose, and is the exception to the
+            // "always use WithinSpellRange" rule in AGENTS.md. A corpse has no usable
+            // CombatReach for the game to measure against, so raise range is centre to
+            // centre. WithinSpellRange would subtract both hitboxes and, because it uses
+            // Distance2D, ignore height entirely — which matters a lot here, where the
+            // Forked Tower sits roughly a thousand yalms below the overworld in the same
+            // zone. Leave this as Distance.
             var deadNonPartyPlayers = Group.CastableAlliance.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
                                                        u.Distance(Core.Me) <= 30 &&
@@ -1970,7 +1978,11 @@ namespace Magitek.Logic.Roles
             if (!OccultCrescentSettings.Instance.UseRevive)
                 return false;
 
-            // Find dead allies using the same logic as Healer.Raise
+            // Find dead allies using the same logic as Healer.Raise — including the raw 3D
+            // distance, which is deliberate there and must stay deliberate here. It is the
+            // exception to the "always use WithinSpellRange" rule in AGENTS.md: a corpse has
+            // no usable CombatReach, so raise range is centre to centre, and WithinSpellRange
+            // uses Distance2D so it would ignore height entirely. Leave this as Distance.
             var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
                                                        u.Distance(Core.Me) <= 30 &&

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -230,6 +230,7 @@ namespace Magitek.Logic.Roles
         // How long non-party revival stands aside for a dead party member before deciding the party
         // path is not coming.
         private static DateTime _partyRaiseYieldSince = DateTime.MinValue;
+        private static HashSet<uint> _partyRaiseYieldFor = new HashSet<uint>();
         private static readonly TimeSpan PartyRaiseGrace = TimeSpan.FromSeconds(15);
 
         private static readonly Vector3[] KnowledgeCrystalLocations = new[]
@@ -564,10 +565,17 @@ namespace Magitek.Logic.Roles
             // role the user excluded — then the corpse simply stays there and this would keep standing
             // aside forever, which is exactly how non-party revival ends up never happening. Give the
             // party path a fair window and then stop waiting on it.
-            if (Globals.InParty && HasRaisableDeadPartyMember())
+            var raisableParty = RaisableDeadPartyMemberIds();
+
+            if (Globals.InParty && raisableParty.Count > 0)
             {
-                if (_partyRaiseYieldSince == DateTime.MinValue)
+                // Anyone newly dead earns their own window. Timing from the first corpse alone would mean
+                // one nobody can raise burns the grace once and everybody who dies afterwards gets none.
+                if (!raisableParty.IsSubsetOf(_partyRaiseYieldFor))
+                {
+                    _partyRaiseYieldFor = raisableParty;
                     _partyRaiseYieldSince = DateTime.Now;
+                }
 
                 if ((DateTime.Now - _partyRaiseYieldSince) < PartyRaiseGrace)
                     return false;
@@ -575,6 +583,7 @@ namespace Magitek.Logic.Roles
             else
             {
                 _partyRaiseYieldSince = DateTime.MinValue;
+                _partyRaiseYieldFor.Clear();
             }
 
             // Update alliance to get dead players using optimized Group system
@@ -595,14 +604,16 @@ namespace Magitek.Logic.Roles
         /// True when a party member is dead and rezzable in principle by the standard raise path.
         /// Used to yield non-party resurrection so party members keep priority for instant-cast sources.
         /// </summary>
-        private static bool HasRaisableDeadPartyMember()
+        private static HashSet<uint> RaisableDeadPartyMemberIds()
         {
-            return Group.DeadAllies.Any(u => u.CurrentHealth == 0
-                && !u.HasAura(Auras.Raise)
-                && u.WithinSpellRange(30)
-                && u.IsVisible
-                && u.InLineOfSight()
-                && u.IsTargetable);
+            return new HashSet<uint>(Group.DeadAllies
+                .Where(u => u.CurrentHealth == 0
+                            && !u.HasAura(Auras.Raise)
+                            && u.WithinSpellRange(30)
+                            && u.IsVisible
+                            && u.InLineOfSight()
+                            && u.IsTargetable)
+                .Select(u => u.ObjectId));
         }
 
         /// <summary>
@@ -620,7 +631,12 @@ namespace Magitek.Logic.Roles
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&
-                                                       u.Location.DistanceSqr(RespawnPoint) >= 900);
+                                                       // Skip anyone stood at the respawn point, since they have chosen to
+                                                       // return rather than wait. That point is a South Horn coordinate, so
+                                                       // the test only means anything there — applied in another Horn it
+                                                       // measures against unrelated ground and excludes people at random.
+                                                       (WorldManager.ZoneId != SouthHornZoneId
+                                                        || u.Location.DistanceSqr(RespawnPoint) >= 900));
 
             if (!deadNonPartyPlayers.Any())
                 return false;
@@ -675,8 +691,12 @@ namespace Magitek.Logic.Roles
                     // Re-validate the target each iteration: another player can rez/LoS-break the same
                     // corpse mid-loop, which would otherwise spin here (CastAura keeps failing without
                     // consuming Swiftcast) until the aura expires ~10s later, stalling the whole routine.
+                    // Being alive again is the case the other checks miss: someone else's raise can be
+                    // accepted mid-loop, leaving the target valid, targetable, in range and carrying no
+                    // pending Raise aura — so without this the loop spins until Swiftcast expires.
                     while (Core.Me.HasAura(Auras.Swiftcast)
                            && target != null && target.IsValid && target.IsTargetable
+                           && (target as Character)?.CurrentHealth == 0
                            && !target.HasAura(Auras.Raise)
                            && target.WithinSpellRange(30) && target.InLineOfSight())
                     {
@@ -718,8 +738,12 @@ namespace Magitek.Logic.Roles
                     // Re-validate the target each iteration: in the open field another player can
                     // rez/LoS-break the same corpse, which would otherwise spin here (CastAura keeps
                     // failing without consuming Swiftcast) until the aura expires ~10s later.
+                    // Being alive again is the case the other checks miss: someone else's raise can be
+                    // accepted mid-loop, leaving the target valid, targetable, in range and carrying no
+                    // pending Raise aura — so without this the loop spins until Swiftcast expires.
                     while (Core.Me.HasAura(Auras.Swiftcast)
                            && target != null && target.IsValid && target.IsTargetable
+                           && (target as Character)?.CurrentHealth == 0
                            && !target.HasAura(Auras.Raise)
                            && target.WithinSpellRange(30) && target.InLineOfSight())
                     {

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -569,13 +569,15 @@ namespace Magitek.Logic.Roles
 
             if (Globals.InParty && raisableParty.Count > 0)
             {
-                // Anyone newly dead earns their own window. Timing from the first corpse alone would mean
-                // one nobody can raise burns the grace once and everybody who dies afterwards gets none.
-                if (!raisableParty.IsSubsetOf(_partyRaiseYieldFor))
-                {
-                    _partyRaiseYieldFor = raisableParty;
+                // Anyone newly down earns their own window. Timing from the first corpse alone would mean
+                // one nobody can raise burns the grace once and everybody who falls afterwards gets none.
+                if (raisableParty.Except(_partyRaiseYieldFor).Any())
                     _partyRaiseYieldSince = DateTime.Now;
-                }
+
+                // Always take the current set, so anyone raised drops out of it. Letting it only grow
+                // meant somebody who died, was raised and died again still counted as already seen, and
+                // so was handed no window at all the second time.
+                _partyRaiseYieldFor = raisableParty;
 
                 if ((DateTime.Now - _partyRaiseYieldSince) < PartyRaiseGrace)
                     return false;

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -250,11 +250,17 @@ namespace Magitek.Logic.Roles
             }
         };
 
-        // Respawn point location per zone
-        private static readonly Dictionary<ushort, Vector3> RespawnPoints = new()
+        // Respawn point locations per zone. North Horn has more than one: the open field returns
+        // players to base camp, while the Forked Tower returns them to its own entrance points.
+        private static readonly Dictionary<ushort, Vector3[]> RespawnPoints = new()
         {
-            [SouthHornZoneId] = new Vector3(851.87665f, 73.13358f, -704.79004f),
-            [NorthHornZoneId] = new Vector3(905.57f, 259.88f, 905.97f)
+            [SouthHornZoneId] = new[] { new Vector3(851.87665f, 73.13358f, -704.79004f) },
+            [NorthHornZoneId] = new[]
+            {
+                new Vector3(905.57f, 259.88f, 905.97f),   // base camp
+                new Vector3(600.2f, -700f, 975f),         // Forked Tower
+                new Vector3(706f, -709.8f, 184f)          // Forked Tower
+            }
         };
 
         // Throttling for knowledge crystal checks
@@ -546,10 +552,10 @@ namespace Magitek.Logic.Roles
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&
-                                                       // Skip anyone stood at the zone's respawn point, since they have
-                                                       // chosen to return rather than wait for a raise.
-                                                       (!RespawnPoints.TryGetValue(WorldManager.ZoneId, out var respawnPoint)
-                                                        || u.Location.DistanceSqr(respawnPoint) >= 900));
+                                                       // Skip anyone stood at one of the zone's respawn points, since
+                                                       // they have chosen to return rather than wait for a raise.
+                                                       (!RespawnPoints.TryGetValue(WorldManager.ZoneId, out var respawnPoints)
+                                                        || respawnPoints.All(p => u.Location.DistanceSqr(p) >= 900)));
 
             if (!deadNonPartyPlayers.Any())
                 return false;

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -257,25 +257,6 @@ namespace Magitek.Logic.Roles
         // Cannoneer alternating cannon tracking
         private static bool _lastUsedShockCannon = false;
 
-        // OccultSlowga recast backoff. Slowga spammed on Slow-immune enemies (their Slow never lands,
-        // so the "target doesn't have Slow" guard stays true and it re-casts every pulse). Rather than
-        // permanently blacklisting a type — fragile, because an interrupted cast, a Slow that expired
-        // while the mob was untargeted, or a mid-cast target switch can all look like a resist and
-        // wrongly kill a slowable type for the session — we simply back off: each consecutive cast on
-        // a type that doesn't result in Slow pushes the next attempt further out (to a 5-minute cap),
-        // so immune mobs go near-silent, while a Slow that actually lands clears the type back to
-        // normal. Keyed by mob type, self-healing, bounded by the number of distinct OC mob types.
-        private static readonly Dictionary<uint, (int Fails, DateTime LastCast)> _slowBackoff = new();
-
-        // Slowga is a cast, and a cast reports back the moment it starts rather than when it lands, so
-        // nothing conclusive about the Slow is knowable at the point of casting. Each cast is recorded
-        // here instead and judged on a later pulse, once the aura has had time to appear. Keyed by the
-        // individual enemy, since two of the same type can be slowed independently.
-        private static readonly Dictionary<uint, (uint NpcId, DateTime CastEndsAt, DateTime JudgeAt)> _slowPending = new();
-
-        // Grace on top of the cast time before a missing Slow is treated as a resist.
-        private const int SlowConfirmGraceMs = 1000;
-
         // Oracle prediction tracking
         private static bool _predictCasted = false;
         private static DateTime _predictCastTime = DateTime.MinValue;
@@ -2189,70 +2170,12 @@ namespace Magitek.Logic.Roles
             return await OCSpells.OccultElixir.Cast(Core.Me);
         }
 
-        private static bool IsCastingSlowga()
-        {
-            return Core.Me.IsCasting && Core.Me.CastingSpellId == OCSpells.OccultSlowga.Id;
-        }
-
-        /// <summary>
-        /// Judges Slowga casts whose Slow has had time to land. An enemy that is gone by then — killed
-        /// during the cast, despawned, out of range — proves nothing either way and is simply dropped,
-        /// which is what stops a kill from being recorded as an immunity and muting a slowable type.
-        /// </summary>
-        private static void ResolveSlowgaCasts()
-        {
-            if (_slowPending.Count == 0)
-                return;
-
-            var now = DateTime.Now;
-            var judged = new List<uint>();
-
-            foreach (var (objectId, pending) in _slowPending)
-            {
-                if (now < pending.JudgeAt)
-                {
-                    // A cast that stops before it was due to finish was interrupted — movement, a stun,
-                    // the target dying mid-cast. Nothing was applied, so it is no evidence of immunity
-                    // and gets dropped rather than judged.
-                    if (now < pending.CastEndsAt && !IsCastingSlowga())
-                        judged.Add(objectId);
-
-                    continue;
-                }
-
-                judged.Add(objectId);
-
-                // Match the type as well as the object: the game reuses object ids, so an entry that
-                // sat around could otherwise be judged against whatever spawned into the same slot.
-                var target = Combat.Enemies.FirstOrDefault(x => x.ObjectId == objectId && x.NpcId == pending.NpcId);
-                if (target == null || !target.IsValid || !target.IsAlive)
-                    continue;
-
-                if (target.HasAura(OCAuras.Slow))
-                {
-                    _slowBackoff.Remove(pending.NpcId);
-                }
-                else
-                {
-                    // Alive, in view, and still unslowed well after the cast — a genuine resist.
-                    var fails = _slowBackoff.TryGetValue(pending.NpcId, out var prev) ? prev.Fails + 1 : 1;
-                    _slowBackoff[pending.NpcId] = (fails, now);
-                }
-            }
-
-            foreach (var objectId in judged)
-                _slowPending.Remove(objectId);
-        }
-
         /// <summary>
         /// Cast OccultSlowga - afflicts target with Slow (aura 3493)
         /// </summary>
         /// <returns>True if spell was cast, false otherwise</returns>
         private static async Task<bool> OccultSlowga()
         {
-            // Ahead of the settings gate so turning Slowga off mid-fight still clears what is pending.
-            ResolveSlowgaCasts();
-
             if (!OccultCrescentSettings.Instance.UseOccultSlowga)
                 return false;
 
@@ -2269,36 +2192,13 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            // Already slowed — nothing to do; clear this type's backoff (it's proven slowable).
+            // Already slowed — nothing to do.
             if (Core.Me.CurrentTarget.HasAura(OCAuras.Slow))
-            {
-                if (Core.Me.CurrentTarget is BattleCharacter slowed)
-                    _slowBackoff.Remove(slowed.NpcId);
                 return false;
-            }
 
             // Check if target is a BattleCharacter for additional checks
             if (Core.Me.CurrentTarget is BattleCharacter battleTarget)
             {
-                // Back off from types whose recent Slowga casts never produced Slow (immune/resisting).
-                // The delay escalates with consecutive misses so an immune type effectively goes quiet,
-                // while the HasAura clear above keeps genuinely slowable types responsive. This only
-                // delays and never permanently disables, so a mis-detection self-corrects on the next
-                // landed Slow.
-                if (_slowBackoff.TryGetValue(battleTarget.NpcId, out var bo))
-                {
-                    var delay = bo.Fails switch
-                    {
-                        <= 1 => TimeSpan.FromSeconds(15),
-                        2 => TimeSpan.FromSeconds(30),
-                        3 => TimeSpan.FromSeconds(60),
-                        4 => TimeSpan.FromSeconds(120),
-                        _ => TimeSpan.FromSeconds(300),
-                    };
-                    if (DateTime.Now - bo.LastCast < delay)
-                        return false;
-                }
-
                 // Check difficulty - high difficulty enemies are often immune to CC
                 if (battleTarget.RawDifficulty >= 2)
                     return false;
@@ -2315,19 +2215,7 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.WithinSpellRange(OCSpells.OccultSlowga.Range))
                 return false;
 
-            // Capture the target before the (cast-time) await so the backoff record can't be mis-keyed
-            // to a different enemy if CurrentTarget switches while the cast is in flight.
-            var castTarget = Core.Me.CurrentTarget;
-            if (!await OCSpells.OccultSlowga.Cast(castTarget))
-                return false;
-
-            // Hand the result off to be judged later; the cast has only just begun here.
-            if (castTarget is BattleCharacter casted)
-            {
-                var castEndsAt = DateTime.Now.AddMilliseconds(OCSpells.OccultSlowga.AdjustedCastTime.TotalMilliseconds);
-                _slowPending[casted.ObjectId] = (casted.NpcId, castEndsAt, castEndsAt.AddMilliseconds(SlowConfirmGraceMs));
-            }
-            return true;
+            return await OCSpells.OccultSlowga.Cast(Core.Me.CurrentTarget);
         }
 
         /// <summary>

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -177,49 +177,24 @@ namespace Magitek.Logic.Roles
 
     internal class OccultCrescent
     {
+        private const ushort SouthHornZoneId = 1252;
+        private const ushort NorthHornZoneId = 1346;
+
         private static readonly HashSet<ushort> OccultCrescentZoneIds = new()
         {
-            1252, // The Occult Crescent: South Horn
-            1346, // The Occult Crescent: North Horn
+            SouthHornZoneId,
+            NorthHornZoneId
         };
 
-        private const string OccultCrescentZoneNamePart = "Occult Crescent";
-
-        private static int _lastZoneChecked = -1;
-        private static bool _lastZoneWasOccultCrescent;
-
         /// <summary>
-        /// Known zone ids first, then a fallback on the zone name so a newly released Horn keeps the
-        /// general Occult Crescent logic running the day it ships instead of silently disabling all of it
-        /// until its id is added here — which is exactly what happened when North Horn arrived. Features
-        /// built on per-zone coordinates are the exception: knowledge crystal buffing and the
-        /// respawn-point corpse exclusion stay off in a new Horn until its locations are gathered and
-        /// added to KnowledgeCrystalLocations/RespawnPoints, by design.
-        /// <para>
-        /// Name matching is safe across clients: WorldManager.CurrentZoneName is the non-localized name
-        /// (CurrentLocalizedZoneName is the one shown to the player). The result is cached per zone so the
-        /// string comparison happens once on zone change rather than on every call.
-        /// </para>
+        /// Each Horn must be added here by zone id when it ships. Matching on the zone name instead is
+        /// not an option: WorldManager.CurrentZoneName returns the map's own name ("South Horn",
+        /// "North Horn") and never contains "Occult Crescent", so a name check can never match.
         /// </summary>
         public static bool IsInOccultCrescent()
         {
-            var zoneId = WorldManager.ZoneId;
-
-            if (zoneId == _lastZoneChecked)
-                return _lastZoneWasOccultCrescent;
-
-            var zoneName = WorldManager.CurrentZoneName;
-
-            _lastZoneChecked = zoneId;
-            _lastZoneWasOccultCrescent = OccultCrescentZoneIds.Contains(zoneId)
-                || (!string.IsNullOrEmpty(zoneName)
-                    && zoneName.IndexOf(OccultCrescentZoneNamePart, StringComparison.OrdinalIgnoreCase) >= 0);
-
-            return _lastZoneWasOccultCrescent;
+            return OccultCrescentZoneIds.Contains(WorldManager.ZoneId);
         }
-
-        private const ushort SouthHornZoneId = 1252;
-        private const ushort NorthHornZoneId = 1346;
 
         // Known Knowledge Crystal locations per zone. These never change, and each Horn has its own
         // coordinate space, so the lists are keyed by zone id.
@@ -235,19 +210,22 @@ namespace Magitek.Logic.Roles
             },
             [NorthHornZoneId] = new[]
             {
+                // Overworld crystals, each read off the live crystal object in game.
                 new Vector3(884.896f, 259.5558f, 875.1169f),    // base camp
                 new Vector3(-542.5715f, 68.6256f, 598.2891f),
-                new Vector3(-384.2f, 40f, -441.6f),
-                new Vector3(458.4f, 70.4f, 524.8f),
-                new Vector3(351.5f, 45.2f, -560.2f),
-                new Vector3(-19.8f, 2.4f, -38.6f),
+                new Vector3(-382.6042f, 41.22726f, -442.7764f),
+                new Vector3(456.5246f, 71.46682f, 524.4749f),
+                new Vector3(350.6741f, 46.45173f, -558.5289f),
+                new Vector3(-18.32449f, 3.79342f, -37.40308f),
+                // Forked Tower shares this zone id but sits far below the overworld. These came from
+                // session logs rather than a live reading, so they are approximate and unconfirmed.
                 new Vector3(597.8f, -700f, 927f),               // Forked Tower entrance
                 new Vector3(-893f, -984.7401f, 780f),           // Forked Tower
                 new Vector3(-900f, -986.1f, 782.2488f),
                 new Vector3(103f, -706.7383f, 678f),
                 new Vector3(0f, -722.6936f, -367f),
                 new Vector3(603.5453f, -672.6606f, 640.6041f),
-                new Vector3(599.4f, -700.0f, 927.8f),      // Forked Tower, Lower Vestibule (surveyed live 2026-08-07)
+                new Vector3(599.4f, -700.0f, 927.8f),           // Forked Tower, Lower Vestibule
                 new Vector3(603.7968f, -670.6514f, -125.1157f)
             }
         };
@@ -553,7 +531,7 @@ namespace Magitek.Logic.Roles
             // Filter out party members since CastableAlliance includes everyone
             var deadNonPartyPlayers = Group.CastableAlliance.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
-                                                       u.WithinSpellRange(30) &&
+                                                       u.Distance(Core.Me) <= 30 &&
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&
@@ -1995,7 +1973,7 @@ namespace Magitek.Logic.Roles
             // Find dead allies using the same logic as Healer.Raise
             var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
                                                        !u.HasAura(Auras.Raise) &&
-                                                       u.WithinSpellRange(30) &&
+                                                       u.Distance(Core.Me) <= 30 &&
                                                        u.IsVisible &&
                                                        u.InLineOfSight() &&
                                                        u.IsTargetable &&

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -271,7 +271,7 @@ namespace Magitek.Logic.Roles
         // nothing conclusive about the Slow is knowable at the point of casting. Each cast is recorded
         // here instead and judged on a later pulse, once the aura has had time to appear. Keyed by the
         // individual enemy, since two of the same type can be slowed independently.
-        private static readonly Dictionary<uint, (uint NpcId, DateTime JudgeAt)> _slowPending = new();
+        private static readonly Dictionary<uint, (uint NpcId, DateTime CastEndsAt, DateTime JudgeAt)> _slowPending = new();
 
         // Grace on top of the cast time before a missing Slow is treated as a resist.
         private const int SlowConfirmGraceMs = 1000;
@@ -2189,6 +2189,11 @@ namespace Magitek.Logic.Roles
             return await OCSpells.OccultElixir.Cast(Core.Me);
         }
 
+        private static bool IsCastingSlowga()
+        {
+            return Core.Me.IsCasting && Core.Me.CastingSpellId == OCSpells.OccultSlowga.Id;
+        }
+
         /// <summary>
         /// Judges Slowga casts whose Slow has had time to land. An enemy that is gone by then — killed
         /// during the cast, despawned, out of range — proves nothing either way and is simply dropped,
@@ -2205,7 +2210,15 @@ namespace Magitek.Logic.Roles
             foreach (var (objectId, pending) in _slowPending)
             {
                 if (now < pending.JudgeAt)
+                {
+                    // A cast that stops before it was due to finish was interrupted — movement, a stun,
+                    // the target dying mid-cast. Nothing was applied, so it is no evidence of immunity
+                    // and gets dropped rather than judged.
+                    if (now < pending.CastEndsAt && !IsCastingSlowga())
+                        judged.Add(objectId);
+
                     continue;
+                }
 
                 judged.Add(objectId);
 
@@ -2311,9 +2324,8 @@ namespace Magitek.Logic.Roles
             // Hand the result off to be judged later; the cast has only just begun here.
             if (castTarget is BattleCharacter casted)
             {
-                var judgeAt = DateTime.Now.AddMilliseconds(
-                    OCSpells.OccultSlowga.AdjustedCastTime.TotalMilliseconds + SlowConfirmGraceMs);
-                _slowPending[casted.ObjectId] = (casted.NpcId, judgeAt);
+                var castEndsAt = DateTime.Now.AddMilliseconds(OCSpells.OccultSlowga.AdjustedCastTime.TotalMilliseconds);
+                _slowPending[casted.ObjectId] = (casted.NpcId, castEndsAt, castEndsAt.AddMilliseconds(SlowConfirmGraceMs));
             }
             return true;
         }

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -180,7 +180,7 @@ namespace Magitek.Logic.Roles
         private static readonly HashSet<ushort> OccultCrescentZoneIds = new()
         {
             1252, // The Occult Crescent: South Horn
-            1346, // The Occult Crescent: Northern Horn
+            1346, // The Occult Crescent: North Horn
         };
 
         private const string OccultCrescentZoneNamePart = "Occult Crescent";
@@ -191,7 +191,7 @@ namespace Magitek.Logic.Roles
         /// <summary>
         /// Known zone ids first, then a fallback on the zone name so a newly released Horn works the day
         /// it ships instead of silently disabling everything Occult Crescent specific until its id is
-        /// added here — which is exactly what happened when Northern Horn arrived.
+        /// added here — which is exactly what happened when North Horn arrived.
         /// <para>
         /// Name matching is safe across clients: WorldManager.CurrentZoneName is the non-localized name
         /// (CurrentLocalizedZoneName is the one shown to the player). The result is cached per zone so the
@@ -289,7 +289,7 @@ namespace Magitek.Logic.Roles
             { 4805, PhantomJob.Dancer },
             { 4803, PhantomJob.MysticKnight },
             { 4804, PhantomJob.Gladiator },
-            // Added with Northern Horn. Without these the current job reads as None and every Occult
+            // Added with North Horn. Without these the current job reads as None and every Occult
             // Crescent feature bails out, which is why nothing worked while playing one of them.
             { 5328, PhantomJob.Ninja },
             { 5329, PhantomJob.WhiteMage },

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -227,12 +227,6 @@ namespace Magitek.Logic.Roles
         // Horns, so the aetheryte beside it serves the same purpose without needing the zone mapped first.
         private const float AetheryteProximity = 7.0f;
 
-        // How long non-party revival stands aside for a dead party member before deciding the party
-        // path is not coming.
-        private static DateTime _partyRaiseYieldSince = DateTime.MinValue;
-        private static HashSet<uint> _partyRaiseYieldFor = new HashSet<uint>();
-        private static readonly TimeSpan PartyRaiseGrace = TimeSpan.FromSeconds(15);
-
         private static readonly Vector3[] KnowledgeCrystalLocations = new[]
         {
             new Vector3(835.9902f, 75.12211f, -709.3925f),
@@ -530,44 +524,10 @@ namespace Magitek.Logic.Roles
                 return false;
             _lastNonPartyResCheck = now;
 
-            // Party-priority: if a raise-eligible party member is down, yield this pulse so the
-            // standard Heal()/Verraise() path (which runs later in the same pulse chain and owns
-            // party rez) spends any Dualcast/Swiftcast on them instead of a non-party random. Only
-            // yields when actually grouped with an eligible corpse, so it won't strand a party
-            // member the standard path wouldn't cover anyway.
-            // Yielding is only worth it while the party path is actually going to act. If it cannot —
-            // the job has no raise, it is switched off, it is out of resources, or the dead player is a
-            // role the user excluded — then the corpse simply stays there and this would keep standing
-            // aside forever, which is exactly how non-party revival ends up never happening. Give the
-            // party path a fair window and then stop waiting on it.
-            //
-            // This has to run BEFORE the mana and combat-preference gates below. Those gates decide
-            // whether we may raise a stranger; they say nothing about who is down. Tracked underneath
-            // them, the set and the timer simply froze for as long as mana sat under the threshold — so a
-            // member who died, was raised and died again during that stretch came back to an unchanged
-            // set and a timestamp minutes old, and had their grace window treated as already spent.
-            var raisableParty = RaisableDeadPartyMemberIds();
-
-            if (Globals.InParty && raisableParty.Count > 0)
-            {
-                // Anyone newly down earns their own window. Timing from the first corpse alone would mean
-                // one nobody can raise burns the grace once and everybody who falls afterwards gets none.
-                if (raisableParty.Except(_partyRaiseYieldFor).Any())
-                    _partyRaiseYieldSince = DateTime.Now;
-
-                // Always take the current set, so anyone raised drops out of it. Letting it only grow
-                // meant somebody who died, was raised and died again still counted as already seen, and
-                // so was handed no window at all the second time.
-                _partyRaiseYieldFor = raisableParty;
-
-                if ((DateTime.Now - _partyRaiseYieldSince) < PartyRaiseGrace)
-                    return false;
-            }
-            else
-            {
-                _partyRaiseYieldSince = DateTime.MinValue;
-                _partyRaiseYieldFor.Clear();
-            }
+            // Don't resurrect someone outside the party while a party member is down — the standard
+            // raise path owns party rez and gets priority for any instant-cast sources.
+            if (Group.DeadAllies.Any())
+                return false;
 
             // Check if we're Phantom Chemist (free resurrection) or need MP check for regular jobs
             var phantomJob = GetCurrentPhantomJob();
@@ -596,22 +556,6 @@ namespace Magitek.Logic.Roles
             );
 
             return await RaiseNonPartyPlayer();
-        }
-
-        /// <summary>
-        /// True when a party member is dead and rezzable in principle by the standard raise path.
-        /// Used to yield non-party resurrection so party members keep priority for instant-cast sources.
-        /// </summary>
-        private static HashSet<uint> RaisableDeadPartyMemberIds()
-        {
-            return new HashSet<uint>(Group.DeadAllies
-                .Where(u => u.CurrentHealth == 0
-                            && !u.HasAura(Auras.Raise)
-                            && u.WithinSpellRange(30)
-                            && u.IsVisible
-                            && u.InLineOfSight()
-                            && u.IsTargetable)
-                .Select(u => u.ObjectId));
         }
 
         /// <summary>
@@ -721,69 +665,17 @@ namespace Magitek.Logic.Roles
         /// </summary>
         private static async Task<bool> RaiseRedMage(GameObject target)
         {
-            // Check against the corpse, not the parameterless overload — that one substitutes Core.Me, so
-            // a raise is asked whether it can be cast on someone who is alive. The generic raise path above
-            // and Healer.ResurrectionLogic both pass the dead target; this was the only raise call site
-            // that did not.
-            if (!Spells.Verraise.CanCast(target))
+            if (!Spells.Verraise.CanCast())
                 return false;
 
-            // Dualcast or Swiftcast already up: instant Verraise (best case).
-            if (Core.Me.HasAura(Auras.Dualcast) || Core.Me.HasAura(Auras.Swiftcast))
-                return await Spells.Verraise.Cast(target);
-
-            // Swiftcast off cooldown: pop it for an instant Verraise.
-            if (Spells.Swiftcast.IsKnownAndReady())
+            // First check for dualcast (best option for RDM)
+            if (Core.Me.HasAura(Auras.Dualcast))
             {
-                if (await Healer.Swiftcast())
-                {
-                    // Re-validate the target each iteration: in the open field another player can
-                    // rez/LoS-break the same corpse, which would otherwise spin here (CastAura keeps
-                    // failing without consuming Swiftcast) until the aura expires ~10s later.
-                    // Being alive again is the case the other checks miss: someone else's raise can be
-                    // accepted mid-loop, leaving the target valid, targetable, in range and carrying no
-                    // pending Raise aura — so without this the loop spins until Swiftcast expires.
-                    while (Core.Me.HasAura(Auras.Swiftcast)
-                           && target != null && target.IsValid && target.IsTargetable
-                           && (target as Character)?.CurrentHealth == 0
-                           && !target.HasAura(Auras.Raise)
-                           && target.WithinSpellRange(30) && target.InLineOfSight())
-                    {
-                        if (await Spells.Verraise.CastAura(target, Auras.Raise))
-                            return true;
-                        await Coroutine.Yield();
-                    }
-                }
-            }
-
-            // If the loop above exited with Swiftcast still up (the corpse got invalidated mid-loop),
-            // don't fall into the priming/hardcast paths — an instant Vercure would burn the Swiftcast
-            // without proc'ing Dualcast. Bail and re-pulse; the next pass spends the still-up Swiftcast on
-            // an instant Verraise against a freshly-selected valid corpse (handled at the top of this method).
-            if (Core.Me.HasAura(Auras.Swiftcast))
-                return false;
-
-            // Out of combat with no instant-cast source: prime Dualcast with a quick self-Vercure
-            // (~2s) instead of hard-casting Verraise (~10s). The next pulse consumes the Dualcast
-            // for an instant Verraise. Mirrors RedMage VerraisePrime() for the field-op rez path,
-            // which never sees these non-party allies (they aren't in Group.DeadAllies).
-            if (!Core.Me.InCombat)
-            {
-                // Moving: can neither prime (Vercure must stand still) nor hardcast (the cast-time
-                // gate rejects a moving cast with no instant-cast source). Bail and retry next pulse;
-                // the prime runs once stopped.
-                if (MovementManager.IsMoving)
-                    return false;
-
-                if (Spells.Vercure.IsKnown() && await Spells.Vercure.Cast(Core.Me))
-                    return true;
-
-                // Vercure unavailable or failed: hard-cast Verraise so the rez still lands.
                 return await Spells.Verraise.Cast(target);
             }
 
-            // In combat with no instant-cast source: don't clip the fight with a ~10s hardcast.
-            return false;
+            // No dualcast, use regular swiftcast/slowcast logic
+            return await RaiseWithSwiftcastOptions(Spells.Verraise, target);
         }
 
         /// <summary>
@@ -2202,7 +2094,7 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            // Already slowed — nothing to do.
+            // Don't cast if target already has slow debuff
             if (Core.Me.CurrentTarget.HasAura(OCAuras.Slow))
                 return false;
 
@@ -2395,6 +2287,9 @@ namespace Magitek.Logic.Roles
 
             if (!Core.Me.CurrentTarget.HasDispellableAura())
                 return false;
+
+            // if (!Core.Me.CurrentTarget.HasAnyAura(OCAuras.DispellableAuras))
+            //     return false;
 
             if (!Core.Me.CurrentTarget.WithinSpellRange(OCSpells.OccultDispel.Range))
                 return false;

--- a/Magitek/Logic/Roles/VariantDungeon.cs
+++ b/Magitek/Logic/Roles/VariantDungeon.cs
@@ -154,6 +154,9 @@ namespace Magitek.Logic.Roles
             if (!Globals.InParty)
                 return false;
 
+            // Raw 3D distance is deliberate here — see the resurrection range exception in
+            // AGENTS.md. A corpse has no usable CombatReach, and WithinSpellRange is built on
+            // Distance2D so it would ignore height. Leave this as Distance.
             var deadTarget = Group.DeadAllies
                 .Where(u => u.CurrentHealth == 0
                             && !u.HasAura(Auras.Raise)

--- a/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
+++ b/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
@@ -13,7 +13,7 @@ namespace Magitek.Utilities.Agents
     /// https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentMKDSupportJobList.cs
     /// 
     /// Job ID Data Source (update PhantomJobId enum from this table):
-    /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/MKDSupportJob.csv
+    /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/en/MKDSupportJob.csv
     /// </summary>
     internal static class AgentMKDSupportJobList
     {
@@ -210,7 +210,7 @@ namespace Magitek.Utilities.Agents
     /// Phantom job IDs based on MKDSupportJob.csv data
     /// 
     /// Data Source (MUST be kept in sync with this table):
-    /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/MKDSupportJob.csv
+    /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/en/MKDSupportJob.csv
     /// 
     /// Correct job mapping from CSV (0-23):
     /// 0=Freelancer, 1=Knight, 2=Berserker, 3=Monk, 4=Ranger, 5=Samurai,

--- a/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
+++ b/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
@@ -212,10 +212,12 @@ namespace Magitek.Utilities.Agents
     /// Data Source (MUST be kept in sync with this table):
     /// https://github.com/xivapi/ffxiv-datamining/blob/master/csv/MKDSupportJob.csv
     /// 
-    /// Correct job mapping from CSV (0-15):
+    /// Correct job mapping from CSV (0-23):
     /// 0=Freelancer, 1=Knight, 2=Berserker, 3=Monk, 4=Ranger, 5=Samurai,
     /// 6=Bard, 7=Geomancer, 8=TimeMage, 9=Cannoneer, 10=Chemist, 11=Oracle, 12=Thief,
-    /// 13=MysticKnight, 14=Gladiator, 15=Dancer
+    /// 13=MysticKnight, 14=Gladiator, 15=Dancer,
+    /// 16=Ninja, 17=WhiteMage, 18=BlackMage, 19=Dragoon, 20=Summoner, 21=BlueMage,
+    /// 22=RedMage, 23=Necromancer
     /// </summary>
     public enum PhantomJobId : byte
     {
@@ -234,6 +236,15 @@ namespace Magitek.Utilities.Agents
         Thief = 12,
         MysticKnight = 13,
         Gladiator = 14,
-        Dancer = 15
+        Dancer = 15,
+        // Added with Northern Horn. Indices taken from MKDSupportJob.csv, not inferred.
+        Ninja = 16,
+        WhiteMage = 17,
+        BlackMage = 18,
+        Dragoon = 19,
+        Summoner = 20,
+        BlueMage = 21,
+        RedMage = 22,
+        Necromancer = 23
     }
 }

--- a/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
+++ b/Magitek/Utilities/Agents/AgentMKDSupportJobList.cs
@@ -237,7 +237,7 @@ namespace Magitek.Utilities.Agents
         MysticKnight = 13,
         Gladiator = 14,
         Dancer = 15,
-        // Added with Northern Horn. Indices taken from MKDSupportJob.csv, not inferred.
+        // Added with North Horn. Indices taken from MKDSupportJob.csv, not inferred.
         Ninja = 16,
         WhiteMage = 17,
         BlackMage = 18,

--- a/Magitek/Utilities/Duty.cs
+++ b/Magitek/Utilities/Duty.cs
@@ -1,7 +1,6 @@
 ﻿using ff14bot;
 using ff14bot.Directors;
 using ff14bot.Managers;
-using Magitek.Logic.Roles;
 using System.Collections.Generic;
 
 namespace Magitek.Utilities
@@ -45,11 +44,8 @@ namespace Magitek.Utilities
         {
             if (Core.Me.InCombat) return States.InProgress; //If we're in Combat, don't even continue, it doesn't matter if we're in a duty or not, just unblock our actions and tell us we're in Progress
 
-            // In Public Duty. The Occult Crescent check runs alongside the id list because it also matches
-            // on zone name, so a newly released Horn counts as an active duty the day it ships rather than
-            // waiting for its id to be added here — the id list on its own left alliance revival and the
-            // pull gate switched off in exactly that situation.
-            if (PublicZones.Contains(WorldManager.ZoneId) || OccultCrescent.IsInOccultCrescent()) return States.InProgress;
+            // In Public Duty
+            if (PublicZones.Contains(WorldManager.ZoneId)) return States.InProgress;
 
             if (DirectorManager.ActiveDirector == null) return States.NotInDuty;
 

--- a/Magitek/Utilities/Duty.cs
+++ b/Magitek/Utilities/Duty.cs
@@ -19,7 +19,8 @@ namespace Magitek.Utilities
 
         public static HashSet<ushort> PublicZones = new HashSet<ushort>()
         {
-            1252, // Occult Crescent
+            1252, // Occult Crescent: South Horn
+            1346, // Occult Crescent: Northern Horn
             // eureka zones
             732,  // The Forbidden Land, Eureka Anemos
             763,  // The Forbidden Land, Eureka Pagos  

--- a/Magitek/Utilities/Duty.cs
+++ b/Magitek/Utilities/Duty.cs
@@ -1,6 +1,7 @@
 ﻿using ff14bot;
 using ff14bot.Directors;
 using ff14bot.Managers;
+using Magitek.Logic.Roles;
 using System.Collections.Generic;
 
 namespace Magitek.Utilities
@@ -44,8 +45,11 @@ namespace Magitek.Utilities
         {
             if (Core.Me.InCombat) return States.InProgress; //If we're in Combat, don't even continue, it doesn't matter if we're in a duty or not, just unblock our actions and tell us we're in Progress
 
-            // In Public Duty
-            if (PublicZones.Contains(WorldManager.ZoneId)) return States.InProgress;
+            // In Public Duty. The Occult Crescent check runs alongside the id list because it also matches
+            // on zone name, so a newly released Horn counts as an active duty the day it ships rather than
+            // waiting for its id to be added here — the id list on its own left alliance revival and the
+            // pull gate switched off in exactly that situation.
+            if (PublicZones.Contains(WorldManager.ZoneId) || OccultCrescent.IsInOccultCrescent()) return States.InProgress;
 
             if (DirectorManager.ActiveDirector == null) return States.NotInDuty;
 

--- a/Magitek/Utilities/Duty.cs
+++ b/Magitek/Utilities/Duty.cs
@@ -20,7 +20,7 @@ namespace Magitek.Utilities
         public static HashSet<ushort> PublicZones = new HashSet<ushort>()
         {
             1252, // Occult Crescent: South Horn
-            1346, // Occult Crescent: Northern Horn
+            1346, // Occult Crescent: North Horn
             // eureka zones
             732,  // The Forbidden Land, Eureka Anemos
             763,  // The Forbidden Land, Eureka Pagos  

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -20,6 +20,13 @@ namespace Magitek.Utilities
         private static readonly TimeSpan AttemptCooldown = TimeSpan.FromSeconds(30);
 
         /// <summary>
+        /// Back-off latch so a character that genuinely lacks Inquiring Mind (Freelancer &lt; 15) isn't
+        /// repeatedly flipped to Freelancer: set after a failed cast, cleared after a successful one.
+        /// </summary>
+        private static DateTime _inquiringMindRetryAfter = DateTime.MinValue;
+        private static readonly TimeSpan InquiringMindRetryCooldown = TimeSpan.FromMinutes(5);
+
+        /// <summary>
         /// Maps phantom jobs to their corresponding knowledge crystal buff auras
         /// </summary>
         private static readonly Dictionary<PhantomJobId, KnowledgeCrystalBuff> KnowledgeCrystalBuffs = new()
@@ -96,16 +103,23 @@ namespace Magitek.Utilities
             if (now - _lastAttemptTime < AttemptCooldown)
                 return false;
 
-            // Build list of needed buffs (cheap aura checks)
-            var neededBuffs = new List<(PhantomJobId jobId, KnowledgeCrystalBuff buffInfo)>();
+            bool preferInquiring = OccultCrescentSettings.Instance.PreferInquiringMind;
+
+            // All four crystal buffs we're currently missing. Inquiring Mind (Freelancer) grants them
+            // together, so it is driven by the FULL missing set, decoupled from the per-job AutoSwitch
+            // settings — those only gate the individual-swap fallback. This lets a player run Inquiring
+            // Mind alone (all four individual swaps turned off) and still get buffed.
+            var missingBuffs = new List<(PhantomJobId jobId, KnowledgeCrystalBuff buffInfo)>();
+            var individualCandidates = new List<(PhantomJobId jobId, KnowledgeCrystalBuff buffInfo)>();
 
             foreach (var kvp in KnowledgeCrystalBuffs)
             {
-                var phantomJobId = kvp.Key;
-                var buffInfo = kvp.Value;
+                if (!NeedsBuff(kvp.Value))
+                    continue;
 
-                // Check if this specific job switching is enabled
-                bool jobSwitchEnabled = phantomJobId switch
+                missingBuffs.Add((kvp.Key, kvp.Value));
+
+                bool jobSwitchEnabled = kvp.Key switch
                 {
                     PhantomJobId.Knight => OccultCrescentSettings.Instance.AutoSwitchToKnightForEnduringFortitude,
                     PhantomJobId.Bard => OccultCrescentSettings.Instance.AutoSwitchToBardForRomeosBallad,
@@ -114,19 +128,15 @@ namespace Magitek.Utilities
                     _ => false
                 };
 
-                // Skip if this job switching is disabled
-                if (!jobSwitchEnabled)
-                    continue;
-
-                // Check if we need this buff
-                if (NeedsBuff(buffInfo))
-                {
-                    neededBuffs.Add((phantomJobId, buffInfo));
-                }
+                if (jobSwitchEnabled)
+                    individualCandidates.Add((kvp.Key, kvp.Value));
             }
 
-            // If we don't need any buffs, no point checking crystal location
-            if (neededBuffs.Count == 0)
+            // Nothing missing -> done. With Inquiring Mind off we can only act on the enabled individual
+            // jobs, so bail if none are enabled.
+            if (missingBuffs.Count == 0)
+                return false;
+            if (!preferInquiring && individualCandidates.Count == 0)
                 return false;
 
             // Only now check if we're near a knowledge crystal (more expensive check)
@@ -143,64 +153,77 @@ namespace Magitek.Utilities
             var successfulBuffs = new List<string>();
             bool anyActionTaken = false;
 
-            // Fast path: try Inquiring Mind (Freelancer level 15) to get all buffs at once
-            if (OccultCrescentSettings.Instance.PreferInquiringMind)
+            // Fast path: Inquiring Mind (Freelancer) applies all four buffs at once. We do NOT hard-gate
+            // on the phantom-job level memory read — it has proven unreliable (it can report a wrong
+            // level even for a level-15 Freelancer that clearly has Inquiring Mind), which would silently
+            // force the slow 4-job swap. Instead we attempt it and let the cast be the authority; a
+            // genuine "can't cast" latches the fast path off briefly (see _inquiringMindRetryAfter).
+            if (preferInquiring && now >= _inquiringMindRetryAfter)
             {
-                byte freelancerLevel = OccultCrescentMemory.GetSupportJobLevel(PhantomJobId.Freelancer);
+                Logger.WriteInfo("[PhantomJobSwitcher] Trying Inquiring Mind (Freelancer) for all buffs");
 
-                if (freelancerLevel >= 15)
+                bool onFreelancer = true;
+                if (GetCurrentPhantomJobId() != PhantomJobId.Freelancer)
                 {
-                    Logger.WriteInfo($"[PhantomJobSwitcher] Freelancer level {freelancerLevel} detected, using Inquiring Mind for all buffs");
-
-                    bool needsSwitch = GetCurrentPhantomJobId() != PhantomJobId.Freelancer;
-
-                    if (needsSwitch)
+                    if (await SwitchToPhantomJob(PhantomJobId.Freelancer))
                     {
-                        if (!await SwitchToPhantomJob(PhantomJobId.Freelancer))
-                        {
-                            Logger.WriteInfo("[PhantomJobSwitcher] Failed to switch to Freelancer, falling back to individual buffs");
-                            goto IndividualBuffs;
-                        }
                         anyActionTaken = true;
                         await Coroutine.Wait(500, () => false);
                     }
+                    else
+                    {
+                        Logger.WriteInfo("[PhantomJobSwitcher] Failed to switch to Freelancer, falling back to individual buffs");
+                        onFreelancer = false;
+                    }
+                }
 
+                if (onFreelancer)
+                {
                     if (await OCSpells.InquiringMind.Cast(Core.Me))
                     {
                         Logger.WriteInfo("[PhantomJobSwitcher] Successfully cast Inquiring Mind");
                         await Casting.CheckForSuccessfulCast();
-                        await Coroutine.Wait(500, () => false);
+                        anyActionTaken = true;
+                        _inquiringMindRetryAfter = DateTime.MinValue; // it works -> clear any back-off
 
-                        // Check which buffs were applied
-                        foreach (var (_, buffInfo) in neededBuffs)
+                        // Wait for the buffs to actually register before deciding on any individual
+                        // fallback. Inquiring Mind's auras take a beat to land; checking NeedsBuff too
+                        // early reports them still missing and we re-swap through all four jobs to
+                        // re-apply what we already have. Returns as soon as every buff lands (all jobs
+                        // levelled), or times out only for a buff it genuinely can't grant (unlevelled).
+                        await Coroutine.Wait(3000, () => !missingBuffs.Exists(x => NeedsBuff(x.buffInfo)));
+
+                        foreach (var (_, buffInfo) in missingBuffs)
                         {
                             if (!NeedsBuff(buffInfo))
                                 successfulBuffs.Add(buffInfo.BuffName);
                         }
-                        anyActionTaken = true;
 
-                        // If all needed buffs are now present, restore and return
-                        if (successfulBuffs.Count == neededBuffs.Count)
+                        // Everything we could still be missing is now handled -> done.
+                        if (!missingBuffs.Exists(x => NeedsBuff(x.buffInfo)))
                         {
                             await RestoreOriginalJob(originalPhantomJobId, anyActionTaken);
                             Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind applied all buffs: {string.Join(", ", successfulBuffs)}");
                             return true;
                         }
 
-                        // Rebuild neededBuffs to only include what's still missing
-                        neededBuffs.RemoveAll(x => !NeedsBuff(x.buffInfo));
-                        Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind applied some buffs, {neededBuffs.Count} remaining");
+                        // Inquiring Mind can't grant buffs for jobs the player hasn't levelled; let the
+                        // enabled individual fallback cover whatever is still missing.
+                        individualCandidates.RemoveAll(x => !NeedsBuff(x.buffInfo));
+                        Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind applied some buffs; {individualCandidates.Count} to try individually");
                     }
                     else
                     {
-                        Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind cast failed, falling back to individual buffs");
+                        // On Freelancer but the cast didn't fire -> this character lacks Inquiring Mind
+                        // (Freelancer < 15). Back off so we don't keep flipping to Freelancer every crystal.
+                        _inquiringMindRetryAfter = now.Add(InquiringMindRetryCooldown);
+                        Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind unavailable; backing off, falling back to individual buffs");
                     }
                 }
             }
 
-            IndividualBuffs:
-            // Individual buff path: switch to each job that has sufficient level
-            foreach (var (neededJobId, neededBuffInfo) in neededBuffs)
+            // Individual buff path: switch to each enabled job that still needs its buff.
+            foreach (var (neededJobId, neededBuffInfo) in individualCandidates)
             {
                 // Check job level before switching to avoid wasted attempts
                 byte jobLevel = OccultCrescentMemory.GetSupportJobLevel(neededJobId);
@@ -434,6 +457,14 @@ namespace Magitek.Utilities
                 OccultCrescent.PhantomJob.Dancer => PhantomJobId.Dancer,
                 OccultCrescent.PhantomJob.MysticKnight => PhantomJobId.MysticKnight,
                 OccultCrescent.PhantomJob.Gladiator => PhantomJobId.Gladiator,
+                OccultCrescent.PhantomJob.Ninja => PhantomJobId.Ninja,
+                OccultCrescent.PhantomJob.WhiteMage => PhantomJobId.WhiteMage,
+                OccultCrescent.PhantomJob.BlackMage => PhantomJobId.BlackMage,
+                OccultCrescent.PhantomJob.Dragoon => PhantomJobId.Dragoon,
+                OccultCrescent.PhantomJob.Summoner => PhantomJobId.Summoner,
+                OccultCrescent.PhantomJob.BlueMage => PhantomJobId.BlueMage,
+                OccultCrescent.PhantomJob.RedMage => PhantomJobId.RedMage,
+                OccultCrescent.PhantomJob.Necromancer => PhantomJobId.Necromancer,
                 _ => PhantomJobId.Freelancer // Default to Freelancer
             };
         }

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -178,28 +178,28 @@ namespace Magitek.Utilities
                 if (GetCurrentPhantomJobId() != PhantomJobId.Freelancer)
                 {
                     if (await SwitchToPhantomJob(PhantomJobId.Freelancer))
-                    {
                         anyActionTaken = true;
-
-                        // Wait for Inquiring Mind to actually become usable rather than sleeping a fixed
-                        // interval and hoping. A phantom job swap is a server round-trip, not just an
-                        // animation lock, so any constant is a race: 500ms lost it every time, and the
-                        // animation lock (~770ms) still lost it perhaps a third of the time — the same
-                        // character at Freelancer 19 would buff at one crystal and fail at the next.
-                        // Waiting on the action's own castability is the precondition we actually need,
-                        // and it also sidesteps GetCurrentPhantomJobId() reporting Freelancer for a job it
-                        // simply does not recognise.
-                        if (!await Coroutine.Wait(3000, () => OCSpells.InquiringMind.CanCast()))
-                        {
-                            Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind never became castable, falling back to individual buffs");
-                            onFreelancer = false;
-                        }
-                    }
                     else
                     {
                         Logger.WriteInfo("[PhantomJobSwitcher] Failed to switch to Freelancer, falling back to individual buffs");
                         onFreelancer = false;
                     }
+                }
+
+                // Wait for Inquiring Mind to actually become usable rather than sleeping a fixed
+                // interval and hoping. A phantom job swap is a server round-trip, not just an
+                // animation lock, so any constant is a race: 500ms lost it every time, and the
+                // animation lock (~770ms) still lost it perhaps a third of the time — the same
+                // character at Freelancer 19 would buff at one crystal and fail at the next.
+                // Waiting on the action's own castability is the precondition we actually need,
+                // and it also sidesteps GetCurrentPhantomJobId() reporting Freelancer for a job it
+                // simply does not recognise. This applies on the already-Freelancer path too: a
+                // player who swapped manually a moment ago carries the same lock we didn't create,
+                // and casting into it would fail and burn the 30-second attempt throttle.
+                if (onFreelancer && !await Coroutine.Wait(3000, () => OCSpells.InquiringMind.CanCast()))
+                {
+                    Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind never became castable, falling back to individual buffs");
+                    onFreelancer = false;
                 }
 
                 if (onFreelancer)

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -182,9 +182,20 @@ namespace Magitek.Utilities
                     if (await SwitchToPhantomJob(PhantomJobId.Freelancer))
                     {
                         anyActionTaken = true;
-                        // Sit out the swap's animation lock before casting. A flat 500ms was shorter than
-                        // the configured lock, so on this path the cast below failed every single time.
-                        await Coroutine.Sleep(Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset);
+
+                        // Wait for Inquiring Mind to actually become usable rather than sleeping a fixed
+                        // interval and hoping. A phantom job swap is a server round-trip, not just an
+                        // animation lock, so any constant is a race: 500ms lost it every time, and the
+                        // animation lock (~770ms) still lost it perhaps a third of the time — the same
+                        // character at Freelancer 19 would buff at one crystal and fail at the next.
+                        // Waiting on the action's own castability is the precondition we actually need,
+                        // and it also sidesteps GetCurrentPhantomJobId() reporting Freelancer for a job it
+                        // simply does not recognise.
+                        if (!await Coroutine.Wait(3000, () => OCSpells.InquiringMind.CanCast()))
+                        {
+                            Logger.WriteInfo("[PhantomJobSwitcher] Swapped to Freelancer but Inquiring Mind never became castable; falling back to individual buffs");
+                            onFreelancer = false;
+                        }
                     }
                     else
                     {

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -5,6 +5,7 @@ using ff14bot;
 using ff14bot.Managers;
 using Buddy.Coroutines;
 using Magitek.Extensions;
+using Magitek.Models.Account;
 using Magitek.Models.OccultCrescent;
 using Magitek.Utilities.Agents;
 using Magitek.Logic.Roles;
@@ -170,7 +171,9 @@ namespace Magitek.Utilities
                     if (await SwitchToPhantomJob(PhantomJobId.Freelancer))
                     {
                         anyActionTaken = true;
-                        await Coroutine.Wait(500, () => false);
+                        // Sit out the swap's animation lock before casting. A flat 500ms was shorter than
+                        // the configured lock, so on this path the cast below failed every single time.
+                        await Coroutine.Sleep(Globals.AnimationLockMs + BaseSettings.Instance.UserLatencyOffset);
                     }
                     else
                     {
@@ -217,13 +220,12 @@ namespace Magitek.Utilities
                     }
                     else
                     {
-                        // A failed cast is not proof the character lacks Inquiring Mind. Cast() also
-                        // returns false for passing reasons — most often the animation lock from the job
-                        // swap we just did, which this only waits 500ms for. Treating the first failure
-                        // as "Freelancer below 15" silenced the fast path for five minutes over what was
-                        // usually a momentary blip, and with the individual swaps turned off that left no
-                        // buffing at all. Only back off once it has failed repeatedly, which a genuine
-                        // absence does and a blip does not.
+                        // A failed cast is not proof the character lacks Inquiring Mind — Cast() also
+                        // returns false for passing reasons. Treating the first failure as "Freelancer
+                        // below 15" silenced the fast path for five minutes over what was usually a
+                        // momentary blip, and with the individual swaps turned off that left no buffing
+                        // at all. Only back off once it has failed repeatedly, which a genuine absence
+                        // does and a blip does not.
                         _inquiringMindFailures++;
 
                         if (_inquiringMindFailures >= InquiringMindFailuresBeforeBackoff)

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -108,6 +108,11 @@ namespace Magitek.Utilities
             if (Core.Me.InCombat)
                 return false;
 
+            // Dead or mid-revival, every action is uncastable: the attempt would time out its
+            // readiness waits and read as a capability failure it then backs off from.
+            if (!Core.Me.IsAlive)
+                return false;
+
             // Throttle attempts to prevent rapid ping-ponging when spells fail
             var now = DateTime.Now;
             if (now - _lastAttemptTime < AttemptCooldown)
@@ -211,11 +216,12 @@ namespace Magitek.Utilities
                         anyActionTaken = true;
 
                         // Wait for the buffs to actually register before deciding on any individual
-                        // fallback. Inquiring Mind's auras take a beat to land; checking NeedsBuff too
-                        // early reports them still missing and we re-swap through all four jobs to
-                        // re-apply what we already have. Returns as soon as every buff lands (all jobs
-                        // levelled), or times out only for a buff it genuinely can't grant (unlevelled).
-                        await Coroutine.Wait(3000, () => !missingBuffs.Exists(x => NeedsBuff(x.buffInfo)));
+                        // fallback. Inquiring Mind's grants land noticeably late under load — measured
+                        // around eight seconds after the cast in a full field op — and checking
+                        // NeedsBuff too early reports them still missing, re-swapping through all four
+                        // jobs to re-apply what we already have. Returns as soon as every buff lands;
+                        // the timeout is only for buffs it genuinely can't grant (unlevelled jobs).
+                        await Coroutine.Wait(10000, () => !missingBuffs.Exists(x => NeedsBuff(x.buffInfo)));
 
                         foreach (var (_, buffInfo) in missingBuffs)
                         {
@@ -445,11 +451,6 @@ namespace Magitek.Utilities
         /// Get the current phantom job ID by reusing OccultCrescent logic
         /// </summary>
         /// <returns>The current phantom job ID, or None if no phantom job is active</returns>
-        /// <summary>
-        /// One attempt at Inquiring Mind did not produce buffs. Neither a failed cast nor a readiness
-        /// timeout proves the character lacks the action — both also happen for passing reasons — so back
-        /// off only once it has failed repeatedly, which a genuine absence does and a blip does not.
-        /// </summary>
         private static PhantomJobId GetCurrentPhantomJobId()
         {
             // Reuse existing OccultCrescent logic instead of duplicating

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -163,6 +163,17 @@ namespace Magitek.Utilities
             // genuine "can't cast" latches the fast path off briefly (see _inquiringMindRetryAfter).
             if (preferInquiring && now >= _inquiringMindRetryAfter)
             {
+                // A lapsed back-off earns the fast path its three strikes back. The counter is a static that
+                // otherwise only clears on a successful cast, so once it reached the threshold it stayed
+                // there for the life of the process and the very next transient failure re-armed another
+                // five minutes — making the grace period something you get once per session instead of once
+                // per back-off, which is the whole reason the counter was added.
+                if (_inquiringMindRetryAfter != DateTime.MinValue)
+                {
+                    _inquiringMindRetryAfter = DateTime.MinValue;
+                    _inquiringMindFailures = 0;
+                }
+
                 Logger.WriteInfo("[PhantomJobSwitcher] Trying Inquiring Mind (Freelancer) for all buffs");
 
                 bool onFreelancer = true;

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using ff14bot;
@@ -193,7 +193,11 @@ namespace Magitek.Utilities
                         // simply does not recognise.
                         if (!await Coroutine.Wait(3000, () => OCSpells.InquiringMind.CanCast()))
                         {
-                            Logger.WriteInfo("[PhantomJobSwitcher] Swapped to Freelancer but Inquiring Mind never became castable; falling back to individual buffs");
+                            // Counts toward the same back-off. A readiness timeout and a failed cast mean
+                            // the same thing — Inquiring Mind did not happen — and a character that simply
+                            // lacks it would otherwise swap to Freelancer and wait three seconds at every
+                            // crystal forever, which is precisely what the back-off exists to stop.
+                            RecordInquiringMindFailure(now, "never became castable");
                             onFreelancer = false;
                         }
                     }
@@ -242,23 +246,7 @@ namespace Magitek.Utilities
                     }
                     else
                     {
-                        // A failed cast is not proof the character lacks Inquiring Mind — Cast() also
-                        // returns false for passing reasons. Treating the first failure as "Freelancer
-                        // below 15" silenced the fast path for five minutes over what was usually a
-                        // momentary blip, and with the individual swaps turned off that left no buffing
-                        // at all. Only back off once it has failed repeatedly, which a genuine absence
-                        // does and a blip does not.
-                        _inquiringMindFailures++;
-
-                        if (_inquiringMindFailures >= InquiringMindFailuresBeforeBackoff)
-                        {
-                            _inquiringMindRetryAfter = now.Add(InquiringMindRetryCooldown);
-                            Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind unavailable; backing off, falling back to individual buffs");
-                        }
-                        else
-                        {
-                            Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind didn't fire (attempt {_inquiringMindFailures}); will retry");
-                        }
+                        RecordInquiringMindFailure(now, "didn't fire");
                     }
                 }
             }
@@ -466,6 +454,26 @@ namespace Magitek.Utilities
         /// Get the current phantom job ID by reusing OccultCrescent logic
         /// </summary>
         /// <returns>The current phantom job ID, or None if no phantom job is active</returns>
+        /// <summary>
+        /// One attempt at Inquiring Mind did not produce buffs. Neither a failed cast nor a readiness
+        /// timeout proves the character lacks the action — both also happen for passing reasons — so back
+        /// off only once it has failed repeatedly, which a genuine absence does and a blip does not.
+        /// </summary>
+        private static void RecordInquiringMindFailure(DateTime now, string reason)
+        {
+            _inquiringMindFailures++;
+
+            if (_inquiringMindFailures >= InquiringMindFailuresBeforeBackoff)
+            {
+                _inquiringMindRetryAfter = now.Add(InquiringMindRetryCooldown);
+                Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind unavailable ({reason}); backing off, falling back to individual buffs");
+            }
+            else
+            {
+                Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind {reason} (attempt {_inquiringMindFailures}); will retry");
+            }
+        }
+
         private static PhantomJobId GetCurrentPhantomJobId()
         {
             // Reuse existing OccultCrescent logic instead of duplicating

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -58,6 +58,33 @@ namespace Magitek.Utilities
         private const int InquiringMindFailuresBeforeBackoff = 3;
 
         /// <summary>
+        /// Which character the state above belongs to. RebornBuddy can change characters without reloading
+        /// the routine, and every latch here is process-static: the attempt throttle, the Freelancer back-off,
+        /// the failure count and the exclusions. Carried across a character change they describe someone
+        /// else's phantom job levels — most visibly, exclusions learned from an alt with unlevelled jobs
+        /// would suppress buffs on a character who has them.
+        /// </summary>
+        private static string _stateOwner;
+
+        private static void ResetStateIfCharacterChanged()
+        {
+            var owner = Core.Me?.Name;
+            if (string.IsNullOrEmpty(owner) || owner == _stateOwner)
+                return;
+
+            if (_stateOwner != null)   // null on the first pulse — nothing learned yet, nothing to clear
+            {
+                _lastAttemptTime = DateTime.MinValue;
+                _inquiringMindRetryAfter = DateTime.MinValue;
+                _inquiringMindFailures = 0;
+                _inquiringMindCannotGrant.Clear();
+                Logger.WriteInfo("[PhantomJobSwitcher] Character changed, relearning which phantom job buffs are available");
+            }
+
+            _stateOwner = owner;
+        }
+
+        /// <summary>
         /// Maps phantom jobs to their corresponding knowledge crystal buff auras
         /// </summary>
         private static readonly Dictionary<PhantomJobId, KnowledgeCrystalBuff> KnowledgeCrystalBuffs = new()
@@ -128,6 +155,8 @@ namespace Magitek.Utilities
             // Must be out of combat
             if (Core.Me.InCombat)
                 return false;
+
+            ResetStateIfCharacterChanged();
 
             // Throttle attempts to prevent rapid ping-ponging when spells fail
             var now = DateTime.Now;

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -25,6 +25,8 @@ namespace Magitek.Utilities
         /// </summary>
         private static DateTime _inquiringMindRetryAfter = DateTime.MinValue;
         private static readonly TimeSpan InquiringMindRetryCooldown = TimeSpan.FromMinutes(5);
+        private static int _inquiringMindFailures;
+        private const int InquiringMindFailuresBeforeBackoff = 3;
 
         /// <summary>
         /// Maps phantom jobs to their corresponding knowledge crystal buff auras
@@ -185,6 +187,7 @@ namespace Magitek.Utilities
                         await Casting.CheckForSuccessfulCast();
                         anyActionTaken = true;
                         _inquiringMindRetryAfter = DateTime.MinValue; // it works -> clear any back-off
+                        _inquiringMindFailures = 0;
 
                         // Wait for the buffs to actually register before deciding on any individual
                         // fallback. Inquiring Mind's auras take a beat to land; checking NeedsBuff too
@@ -214,10 +217,24 @@ namespace Magitek.Utilities
                     }
                     else
                     {
-                        // On Freelancer but the cast didn't fire -> this character lacks Inquiring Mind
-                        // (Freelancer < 15). Back off so we don't keep flipping to Freelancer every crystal.
-                        _inquiringMindRetryAfter = now.Add(InquiringMindRetryCooldown);
-                        Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind unavailable; backing off, falling back to individual buffs");
+                        // A failed cast is not proof the character lacks Inquiring Mind. Cast() also
+                        // returns false for passing reasons — most often the animation lock from the job
+                        // swap we just did, which this only waits 500ms for. Treating the first failure
+                        // as "Freelancer below 15" silenced the fast path for five minutes over what was
+                        // usually a momentary blip, and with the individual swaps turned off that left no
+                        // buffing at all. Only back off once it has failed repeatedly, which a genuine
+                        // absence does and a blip does not.
+                        _inquiringMindFailures++;
+
+                        if (_inquiringMindFailures >= InquiringMindFailuresBeforeBackoff)
+                        {
+                            _inquiringMindRetryAfter = now.Add(InquiringMindRetryCooldown);
+                            Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind unavailable; backing off, falling back to individual buffs");
+                        }
+                        else
+                        {
+                            Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind didn't fire (attempt {_inquiringMindFailures}); will retry");
+                        }
                     }
                 }
             }

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -71,8 +71,7 @@ namespace Magitek.Utilities
                     AuraId = OCAuras.Fleetfooted, // 4239
                     BuffName = "Fleetfooted",
                     JobName = "Monk",
-                    RequiredJobLevel = 2 // Counterstance unlocks at Phantom Monk 2, same as the
-                                         // other three crystal-buff actions (game support-job data)
+                    RequiredJobLevel = 3 // Counterstance is 3, not 2 like the other three
                 }
             },
             // Dancer (ID=15) -> Quickstep -> Quicker Step aura

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ff14bot;
 using ff14bot.Managers;
@@ -26,6 +27,14 @@ namespace Magitek.Utilities
         /// </summary>
         private static DateTime _inquiringMindRetryAfter = DateTime.MinValue;
         private static readonly TimeSpan InquiringMindRetryCooldown = TimeSpan.FromMinutes(5);
+        /// <summary>
+        /// Buffs Inquiring Mind has demonstrably failed to grant. It cannot buff a phantom job the character
+        /// has not levelled, and that does not change until they level it — so without this the routine
+        /// re-swaps to Freelancer and re-casts at every crystal chasing a buff it can never get.
+        /// Self-healing: an entry is dropped the moment that buff is observed present.
+        /// </summary>
+        private static readonly HashSet<PhantomJobId> _inquiringMindCannotGrant = new HashSet<PhantomJobId>();
+
         private static int _inquiringMindFailures;
         private const int InquiringMindFailuresBeforeBackoff = 3;
 
@@ -118,7 +127,10 @@ namespace Magitek.Utilities
             foreach (var kvp in KnowledgeCrystalBuffs)
             {
                 if (!NeedsBuff(kvp.Value))
+                {
+                    _inquiringMindCannotGrant.Remove(kvp.Key);   // we have it, so it is obtainable after all
                     continue;
+                }
 
                 missingBuffs.Add((kvp.Key, kvp.Value));
 
@@ -161,7 +173,10 @@ namespace Magitek.Utilities
             // level even for a level-15 Freelancer that clearly has Inquiring Mind), which would silently
             // force the slow 4-job swap. Instead we attempt it and let the cast be the authority; a
             // genuine "can't cast" latches the fast path off briefly (see _inquiringMindRetryAfter).
-            if (preferInquiring && now >= _inquiringMindRetryAfter)
+            // Worth the swap only if Inquiring Mind can still grant at least one of the missing buffs.
+            bool inquiringMindCanHelp = missingBuffs.Any(x => !_inquiringMindCannotGrant.Contains(x.jobId));
+
+            if (preferInquiring && inquiringMindCanHelp && now >= _inquiringMindRetryAfter)
             {
                 // A lapsed back-off earns the fast path its three strikes back. The counter is a static that
                 // otherwise only clears on a successful cast, so once it reached the threshold it stayed
@@ -239,8 +254,15 @@ namespace Magitek.Utilities
                             return true;
                         }
 
-                        // Inquiring Mind can't grant buffs for jobs the player hasn't levelled; let the
-                        // enabled individual fallback cover whatever is still missing.
+                        // Inquiring Mind can't grant buffs for jobs the player hasn't levelled. Remember
+                        // which, so the next crystal does not repeat the swap for them, then let the enabled
+                        // individual fallback cover whatever is still missing.
+                        foreach (var (jobId, buffInfo) in missingBuffs)
+                        {
+                            if (NeedsBuff(buffInfo))
+                                _inquiringMindCannotGrant.Add(jobId);
+                        }
+
                         individualCandidates.RemoveAll(x => !NeedsBuff(x.buffInfo));
                         Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind applied some buffs; {individualCandidates.Count} to try individually");
                     }

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -28,12 +28,31 @@ namespace Magitek.Utilities
         private static DateTime _inquiringMindRetryAfter = DateTime.MinValue;
         private static readonly TimeSpan InquiringMindRetryCooldown = TimeSpan.FromMinutes(5);
         /// <summary>
-        /// Buffs Inquiring Mind has demonstrably failed to grant. It cannot buff a phantom job the character
-        /// has not levelled, and that does not change until they level it — so without this the routine
-        /// re-swaps to Freelancer and re-casts at every crystal chasing a buff it can never get.
-        /// Self-healing: an entry is dropped the moment that buff is observed present.
+        /// Buffs Inquiring Mind has demonstrably failed to grant, and when we learned that. It cannot buff a
+        /// phantom job the character has not levelled, so without this the routine re-swaps to Freelancer and
+        /// re-casts at every crystal chasing a buff it can never get.
+        /// <para>
+        /// Exclusions EXPIRE rather than being permanent. Levelling the job mid-session makes the buff
+        /// obtainable again, and "drop it once we see the buff land" is not enough on its own: with the
+        /// individual swaps turned off nothing else can apply it, so it would never be seen, and the
+        /// exclusion would lock out the very path that could now grant it. Re-checking costs one swap per
+        /// job per window.
+        /// </para>
         /// </summary>
-        private static readonly HashSet<PhantomJobId> _inquiringMindCannotGrant = new HashSet<PhantomJobId>();
+        private static readonly Dictionary<PhantomJobId, DateTime> _inquiringMindCannotGrant = new Dictionary<PhantomJobId, DateTime>();
+        private static readonly TimeSpan InquiringMindExclusionRecheck = TimeSpan.FromMinutes(10);
+
+        private static bool CannotBeGrantedByInquiringMind(PhantomJobId jobId, DateTime now)
+        {
+            if (!_inquiringMindCannotGrant.TryGetValue(jobId, out var since))
+                return false;
+
+            if (now - since < InquiringMindExclusionRecheck)
+                return true;
+
+            _inquiringMindCannotGrant.Remove(jobId);   // window lapsed — give it another go
+            return false;
+        }
 
         private static int _inquiringMindFailures;
         private const int InquiringMindFailuresBeforeBackoff = 3;
@@ -174,7 +193,7 @@ namespace Magitek.Utilities
             // force the slow 4-job swap. Instead we attempt it and let the cast be the authority; a
             // genuine "can't cast" latches the fast path off briefly (see _inquiringMindRetryAfter).
             // Worth the swap only if Inquiring Mind can still grant at least one of the missing buffs.
-            bool inquiringMindCanHelp = missingBuffs.Any(x => !_inquiringMindCannotGrant.Contains(x.jobId));
+            bool inquiringMindCanHelp = missingBuffs.Any(x => !CannotBeGrantedByInquiringMind(x.jobId, now));
 
             if (preferInquiring && inquiringMindCanHelp && now >= _inquiringMindRetryAfter)
             {
@@ -260,7 +279,7 @@ namespace Magitek.Utilities
                         foreach (var (jobId, buffInfo) in missingBuffs)
                         {
                             if (NeedsBuff(buffInfo))
-                                _inquiringMindCannotGrant.Add(jobId);
+                                _inquiringMindCannotGrant[jobId] = now;
                         }
 
                         individualCandidates.RemoveAll(x => !NeedsBuff(x.buffInfo));

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -71,7 +71,8 @@ namespace Magitek.Utilities
                     AuraId = OCAuras.Fleetfooted, // 4239
                     BuffName = "Fleetfooted",
                     JobName = "Monk",
-                    RequiredJobLevel = 3
+                    RequiredJobLevel = 2 // Counterstance unlocks at Phantom Monk 2, same as the
+                                         // other three crystal-buff actions (game support-job data)
                 }
             },
             // Dancer (ID=15) -> Quickstep -> Quicker Step aura

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -219,9 +219,15 @@ namespace Magitek.Utilities
                         // fallback. Inquiring Mind's grants land noticeably late under load — measured
                         // around eight seconds after the cast in a full field op — and checking
                         // NeedsBuff too early reports them still missing, re-swapping through all four
-                        // jobs to re-apply what we already have. Returns as soon as every buff lands;
-                        // the timeout is only for buffs it genuinely can't grant (unlevelled jobs).
-                        await Coroutine.Wait(10000, () => !missingBuffs.Exists(x => NeedsBuff(x.buffInfo)));
+                        // jobs to re-apply what we already have. Only buffs from levelled jobs are
+                        // waited on: an unlevelled job's buff can never land, and holding the full
+                        // timeout for it would stall this pulse for nothing. Combat starting or dying
+                        // mid-wait aborts immediately — this wait runs inside the rotation's pulse, so
+                        // holding it while an enemy engages keeps combat logic from running at all.
+                        var grantable = missingBuffs.FindAll(x => JobLevelledFor(x.jobId, x.buffInfo.RequiredJobLevel));
+                        await Coroutine.Wait(10000, () => Core.Me.InCombat
+                            || !Core.Me.IsAlive
+                            || !grantable.Exists(x => NeedsBuff(x.buffInfo)));
 
                         foreach (var (_, buffInfo) in missingBuffs)
                         {

--- a/Magitek/Utilities/PhantomJobSwitcher.cs
+++ b/Magitek/Utilities/PhantomJobSwitcher.cs
@@ -22,66 +22,18 @@ namespace Magitek.Utilities
         private static readonly TimeSpan AttemptCooldown = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Back-off latch so a character that genuinely lacks Inquiring Mind (Freelancer &lt; 15) isn't
-        /// repeatedly flipped to Freelancer: set after a failed cast, cleared after a successful one.
+        /// Inquiring Mind unlocks at Freelancer level 15.
         /// </summary>
-        private static DateTime _inquiringMindRetryAfter = DateTime.MinValue;
-        private static readonly TimeSpan InquiringMindRetryCooldown = TimeSpan.FromMinutes(5);
-        /// <summary>
-        /// Buffs Inquiring Mind has demonstrably failed to grant, and when we learned that. It cannot buff a
-        /// phantom job the character has not levelled, so without this the routine re-swaps to Freelancer and
-        /// re-casts at every crystal chasing a buff it can never get.
-        /// <para>
-        /// Exclusions EXPIRE rather than being permanent. Levelling the job mid-session makes the buff
-        /// obtainable again, and "drop it once we see the buff land" is not enough on its own: with the
-        /// individual swaps turned off nothing else can apply it, so it would never be seen, and the
-        /// exclusion would lock out the very path that could now grant it. Re-checking costs one swap per
-        /// job per window.
-        /// </para>
-        /// </summary>
-        private static readonly Dictionary<PhantomJobId, DateTime> _inquiringMindCannotGrant = new Dictionary<PhantomJobId, DateTime>();
-        private static readonly TimeSpan InquiringMindExclusionRecheck = TimeSpan.FromMinutes(10);
-
-        private static bool CannotBeGrantedByInquiringMind(PhantomJobId jobId, DateTime now)
-        {
-            if (!_inquiringMindCannotGrant.TryGetValue(jobId, out var since))
-                return false;
-
-            if (now - since < InquiringMindExclusionRecheck)
-                return true;
-
-            _inquiringMindCannotGrant.Remove(jobId);   // window lapsed — give it another go
-            return false;
-        }
-
-        private static int _inquiringMindFailures;
-        private const int InquiringMindFailuresBeforeBackoff = 3;
+        private const byte InquiringMindFreelancerLevel = 15;
 
         /// <summary>
-        /// Which character the state above belongs to. RebornBuddy can change characters without reloading
-        /// the routine, and every latch here is process-static: the attempt throttle, the Freelancer back-off,
-        /// the failure count and the exclusions. Carried across a character change they describe someone
-        /// else's phantom job levels — most visibly, exclusions learned from an alt with unlevelled jobs
-        /// would suppress buffs on a character who has them.
+        /// Whether the support job is levelled enough for its crystal buff. Trust the memory read only
+        /// while it is available; when it is not, attempt the cast rather than silently blocking.
         /// </summary>
-        private static string _stateOwner;
-
-        private static void ResetStateIfCharacterChanged()
+        private static bool JobLevelledFor(PhantomJobId jobId, byte requiredLevel)
         {
-            var owner = Core.Me?.Name;
-            if (string.IsNullOrEmpty(owner) || owner == _stateOwner)
-                return;
-
-            if (_stateOwner != null)   // null on the first pulse — nothing learned yet, nothing to clear
-            {
-                _lastAttemptTime = DateTime.MinValue;
-                _inquiringMindRetryAfter = DateTime.MinValue;
-                _inquiringMindFailures = 0;
-                _inquiringMindCannotGrant.Clear();
-                Logger.WriteInfo("[PhantomJobSwitcher] Character changed, relearning which phantom job buffs are available");
-            }
-
-            _stateOwner = owner;
+            return !OccultCrescentMemory.IsAvailable
+                || OccultCrescentMemory.GetSupportJobLevel(jobId) >= requiredLevel;
         }
 
         /// <summary>
@@ -156,8 +108,6 @@ namespace Magitek.Utilities
             if (Core.Me.InCombat)
                 return false;
 
-            ResetStateIfCharacterChanged();
-
             // Throttle attempts to prevent rapid ping-ponging when spells fail
             var now = DateTime.Now;
             if (now - _lastAttemptTime < AttemptCooldown)
@@ -175,10 +125,7 @@ namespace Magitek.Utilities
             foreach (var kvp in KnowledgeCrystalBuffs)
             {
                 if (!NeedsBuff(kvp.Value))
-                {
-                    _inquiringMindCannotGrant.Remove(kvp.Key);   // we have it, so it is obtainable after all
                     continue;
-                }
 
                 missingBuffs.Add((kvp.Key, kvp.Value));
 
@@ -216,27 +163,15 @@ namespace Magitek.Utilities
             var successfulBuffs = new List<string>();
             bool anyActionTaken = false;
 
-            // Fast path: Inquiring Mind (Freelancer) applies all four buffs at once. We do NOT hard-gate
-            // on the phantom-job level memory read — it has proven unreliable (it can report a wrong
-            // level even for a level-15 Freelancer that clearly has Inquiring Mind), which would silently
-            // force the slow 4-job swap. Instead we attempt it and let the cast be the authority; a
-            // genuine "can't cast" latches the fast path off briefly (see _inquiringMindRetryAfter).
-            // Worth the swap only if Inquiring Mind can still grant at least one of the missing buffs.
-            bool inquiringMindCanHelp = missingBuffs.Any(x => !CannotBeGrantedByInquiringMind(x.jobId, now));
+            // Fast path: Inquiring Mind (Freelancer) applies all buffs at once. It requires Freelancer
+            // level 15, and it can only grant buffs for support jobs the player has levelled — both
+            // knowable upfront from the support job levels, so check them instead of learning by
+            // failed casts. Worth the swap only if it can grant at least one missing buff.
+            bool hasInquiringMind = JobLevelledFor(PhantomJobId.Freelancer, InquiringMindFreelancerLevel);
+            bool inquiringMindCanHelp = missingBuffs.Any(x => JobLevelledFor(x.jobId, x.buffInfo.RequiredJobLevel));
 
-            if (preferInquiring && inquiringMindCanHelp && now >= _inquiringMindRetryAfter)
+            if (preferInquiring && hasInquiringMind && inquiringMindCanHelp)
             {
-                // A lapsed back-off earns the fast path its three strikes back. The counter is a static that
-                // otherwise only clears on a successful cast, so once it reached the threshold it stayed
-                // there for the life of the process and the very next transient failure re-armed another
-                // five minutes — making the grace period something you get once per session instead of once
-                // per back-off, which is the whole reason the counter was added.
-                if (_inquiringMindRetryAfter != DateTime.MinValue)
-                {
-                    _inquiringMindRetryAfter = DateTime.MinValue;
-                    _inquiringMindFailures = 0;
-                }
-
                 Logger.WriteInfo("[PhantomJobSwitcher] Trying Inquiring Mind (Freelancer) for all buffs");
 
                 bool onFreelancer = true;
@@ -256,11 +191,7 @@ namespace Magitek.Utilities
                         // simply does not recognise.
                         if (!await Coroutine.Wait(3000, () => OCSpells.InquiringMind.CanCast()))
                         {
-                            // Counts toward the same back-off. A readiness timeout and a failed cast mean
-                            // the same thing — Inquiring Mind did not happen — and a character that simply
-                            // lacks it would otherwise swap to Freelancer and wait three seconds at every
-                            // crystal forever, which is precisely what the back-off exists to stop.
-                            RecordInquiringMindFailure(now, "never became castable");
+                            Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind never became castable, falling back to individual buffs");
                             onFreelancer = false;
                         }
                     }
@@ -278,8 +209,6 @@ namespace Magitek.Utilities
                         Logger.WriteInfo("[PhantomJobSwitcher] Successfully cast Inquiring Mind");
                         await Casting.CheckForSuccessfulCast();
                         anyActionTaken = true;
-                        _inquiringMindRetryAfter = DateTime.MinValue; // it works -> clear any back-off
-                        _inquiringMindFailures = 0;
 
                         // Wait for the buffs to actually register before deciding on any individual
                         // fallback. Inquiring Mind's auras take a beat to land; checking NeedsBuff too
@@ -302,21 +231,13 @@ namespace Magitek.Utilities
                             return true;
                         }
 
-                        // Inquiring Mind can't grant buffs for jobs the player hasn't levelled. Remember
-                        // which, so the next crystal does not repeat the swap for them, then let the enabled
-                        // individual fallback cover whatever is still missing.
-                        foreach (var (jobId, buffInfo) in missingBuffs)
-                        {
-                            if (NeedsBuff(buffInfo))
-                                _inquiringMindCannotGrant[jobId] = now;
-                        }
-
+                        // Whatever is still missing goes to the enabled individual fallback.
                         individualCandidates.RemoveAll(x => !NeedsBuff(x.buffInfo));
                         Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind applied some buffs; {individualCandidates.Count} to try individually");
                     }
                     else
                     {
-                        RecordInquiringMindFailure(now, "didn't fire");
+                        Logger.WriteInfo("[PhantomJobSwitcher] Inquiring Mind didn't fire, falling back to individual buffs");
                     }
                 }
             }
@@ -529,21 +450,6 @@ namespace Magitek.Utilities
         /// timeout proves the character lacks the action — both also happen for passing reasons — so back
         /// off only once it has failed repeatedly, which a genuine absence does and a blip does not.
         /// </summary>
-        private static void RecordInquiringMindFailure(DateTime now, string reason)
-        {
-            _inquiringMindFailures++;
-
-            if (_inquiringMindFailures >= InquiringMindFailuresBeforeBackoff)
-            {
-                _inquiringMindRetryAfter = now.Add(InquiringMindRetryCooldown);
-                Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind unavailable ({reason}); backing off, falling back to individual buffs");
-            }
-            else
-            {
-                Logger.WriteInfo($"[PhantomJobSwitcher] Inquiring Mind {reason} (attempt {_inquiringMindFailures}); will retry");
-            }
-        }
-
         private static PhantomJobId GetCurrentPhantomJobId()
         {
             // Reuse existing OccultCrescent logic instead of duplicating


### PR DESCRIPTION
Adds support for the Occult Crescent: North Horn and the phantom jobs that arrived with it, and fixes several ways Occult Crescent automation could quietly stall.

- Recognises North Horn as an Occult Crescent zone, including a name-based fallback so a newly released Horn works the day it ships rather than waiting for its id to be added
- Registers the zone as an active public duty, without which alliance revival and the pull gate stayed switched off
- Finds Knowledge Crystals by fixed per-zone positions, so buffing no longer walks to critical engagement markers that share the crystal's object id
- Adds the eight new phantom jobs to the job list and switcher
- Checks phantom job levels before attempting crystal buffs instead of learning availability from failed casts, and waits out the job swap's readiness window before judging a cast
- Waits long enough after Inquiring Mind for its buffs to register (they land several seconds late under field-op load) before falling back to individual job swaps
- Skips crystal buffing entirely while dead or being raised
- Non-party revival stands aside whenever a party member is dead, and Swiftcast revival loops exit when the target is raised by someone else

Tested in game across several North Horn sessions: camp crystal buffing, all eight phantom jobs, and field revival were each exercised, and the buff-wait and dead-check fixes correct failures observed live in those sessions.