### PR TITLE
Core - Stop attacking enemies our damage cannot reach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,7 +560,7 @@ namespace Magitek.Logic.BlackMage
   - `HasAnyAura(uint[]/List<uint> auras, bool isMyAura = false, int msLeft = 0)`: Check if unit has any of the specified auras
   - `HasAllAuras(List<uint> auras, bool areMyAuras = false, int msLeft = 0)`: Check if unit has all specified auras
   - `CountAuras(List<uint> auras, bool isMyAura = false, int msLeft = 0)`: Count matching auras on unit
-  - `HasDispellableAura()`: Check if unit has a dispellable debuff
+  - `HasDispellableBuff()`: Check if an enemy carries a dispellable beneficial status (what a dispel can actually strip)
 - **Range and Distance:**
   - `WithinSpellRange(float/double range)`: Edge-to-edge distance check accounting for CombatReach (use for ALL range checks)
   - `EnemiesNearby(float distance)`: Get enemies within radius (uses cached Combat.Enemies)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,12 +202,16 @@ Understanding FFXIV-specific combat mechanics is essential for writing effective
 
 Magitek maintains **performance-critical cached collections** that are refreshed each frame. **Always use these instead of reimplementing**:
 
-### Combat.Enemies (`Utilities/Combat.cs`)
-- **`Combat.Enemies`**: Cached list of valid combat targets (refreshed each frame).
+### Combat.Enemies and Combat.Threats (`Utilities/Combat.cs`)
+- **`Combat.Enemies`**: Cached list of valid combat targets (refreshed each frame) — enemies our
+  damage can actually reach. Use it for anything that attacks.
   ```csharp
   var nearbyEnemies = Combat.Enemies.Count(x => x.WithinSpellRange(5));
   ```
-- **Never** query `GameObjectManager` directly for enemies; use `Combat.Enemies`.
+- **`Combat.Threats`**: Cached list of enemies engaged with us regardless of whether our damage can
+  reach them. Use it for defensive decisions — mitigation, interrupts, stuns, incoming-attack
+  checks — which must keep working against enemies we cannot hurt.
+- **Never** query `GameObjectManager` directly for enemies; use these collections.
 
 ### Combat Timers
 - **`Combat.CombatTime`**: Stopwatch tracking time in combat.

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -28,9 +28,11 @@ namespace Magitek.Extensions
                 return unit.Type != GameObjectType.Pc;
             }
 
-            // DamageableByMyMark keeps single-target damage off enemies we can't hurt under a mark-match
-            // mechanic (Meso Terminal Cell Block); it's a no-op whenever we carry no such mark.
-            return unit.CanAttack && unit.DamageableByMyMark();
+            // Rotations guard on this and then cast straight at CurrentTarget, so every immunity rule has
+            // to apply here, not just the mark one. NotInvulnerable() chains them all, so a boss immune to
+            // our damage type, dubbed against us, or unreachable without a buff stops the rotation instead
+            // of letting it pour damage into something it cannot hurt.
+            return unit.CanAttack && unit.NotInvulnerable();
         }
 
         public static bool BeingTargeted(this GameObject unit)

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -231,6 +231,15 @@ namespace Magitek.Extensions
                 : unitAsCharacter.CharacterAuras.Where(x => (x.TimespanLeft.TotalMilliseconds >= msLeft || x.TimespanLeft.TotalMilliseconds < 0)).Select(r => r.Id).ToList().Intersect(auras).Count() == auras.Count;
         }
 
+        // A live hostile unit, without asking whether our damage can reach it. Kept separate from
+        // ValidAttackUnit because the two answer different questions: this one is "does it threaten us",
+        // which is what fight logic needs — an enemy we are immune-locked out of damaging still casts, and
+        // its tank buster still lands on the party.
+        public static bool ValidThreatUnit(this GameObject unit)
+        {
+            return unit != null && unit.IsValid && unit.IsTargetable && unit.CanAttack && unit.CurrentHealth > 0;
+        }
+
         // A unit worth attacking is one we can actually hurt, so the immunity rules belong here rather than
         // being repeated by every caller. This is what closes the gap for paths that never reach
         // ThoroughCanAttack — most notably the Occult Crescent phantom-job actions, which run from
@@ -241,8 +250,7 @@ namespace Magitek.Extensions
         // and the target's (short) aura lists. Nothing here scans the object table.
         public static bool ValidAttackUnit(this GameObject unit)
         {
-            return unit != null && unit.IsValid && unit.IsTargetable && unit.CanAttack && unit.CurrentHealth > 0
-                   && unit.NotInvulnerable();
+            return unit.ValidThreatUnit() && unit.NotInvulnerable();
         }
 
 

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -269,10 +269,11 @@ namespace Magitek.Extensions
                 && unit.NotAnIgnoredMechanicAdd();
         }
 
-        // Adds that exist to be NOT attacked: hitting them is the mechanic failure. Same tiny
+        // Adds the routine should never spend actions on: the game NULLIFIES damage against them
+        // (combat logs: 153 player hits across multiple pulls, 151 dealt zero, no Page ever died),
+        // so attacking one is pure waste, and stray AoE splash onto them is harmless. Same tiny
         // zone-and-name table shape as RequiresAstralRealignment below, for the same per-pulse
-        // cost reason. Arbatel (the Forked Tower) spawns numbered Pages the routine must never
-        // attack — all four are ignored.
+        // cost reason. Arbatel (the Forked Tower) spawns numbered Pages; all four are ignored.
         private const ushort OccultCrescentNorthHornZoneId = 1346;
 
         private static readonly HashSet<string> ArbatelIgnoredPages = new HashSet<string>(StringComparer.Ordinal)

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -231,9 +231,18 @@ namespace Magitek.Extensions
                 : unitAsCharacter.CharacterAuras.Where(x => (x.TimespanLeft.TotalMilliseconds >= msLeft || x.TimespanLeft.TotalMilliseconds < 0)).Select(r => r.Id).ToList().Intersect(auras).Count() == auras.Count;
         }
 
+        // A unit worth attacking is one we can actually hurt, so the immunity rules belong here rather than
+        // being repeated by every caller. This is what closes the gap for paths that never reach
+        // ThoroughCanAttack — most notably the Occult Crescent phantom-job actions, which run from
+        // RotationManager before the job rotation's own check.
+        //
+        // Cheap enough to sit in this hot path: every predicate NotInvulnerable chains early-outs to true
+        // outside its own encounter — a zone-id compare, two aura lookups, and one pass each over our own
+        // and the target's (short) aura lists. Nothing here scans the object table.
         public static bool ValidAttackUnit(this GameObject unit)
         {
-            return unit != null && unit.IsValid && unit.IsTargetable && unit.CanAttack && unit.CurrentHealth > 0;
+            return unit != null && unit.IsValid && unit.IsTargetable && unit.CanAttack && unit.CurrentHealth > 0
+                   && unit.NotInvulnerable();
         }
 
 

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -336,7 +336,13 @@ namespace Magitek.Extensions
 
             var job = me.CurrentJob;
 
-            if (MagicDamageJobs.Contains(job) && unit.HasAnyAura(Auras.MagicImmunity))
+            // Blue Mage is the exception on both counts, which is why it cannot simply be moved between the
+            // two lists. It belongs in MagicDamageJobs so Ranged Resistance below does not filter it out —
+            // its ranged attacks are magical — but it is also the one job carrying genuinely physical
+            // attacks: Sharpened Knife is slashing and Triple Trident piercing, and both land through Magic
+            // Resistance. Blanket-blocking it would shut down the whole rotation over the spells it cannot
+            // use while discarding the ones it can.
+            if (MagicDamageJobs.Contains(job) && job != ClassJobType.BlueMage && unit.HasAnyAura(Auras.MagicImmunity))
                 return false;
 
             if (RangedPhysicalDps.Contains(job) && !MagicDamageJobs.Contains(job) && unit.HasAnyAura(Auras.RangedImmunity))

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -176,16 +176,18 @@ namespace Magitek.Extensions
 
         }
 
-        public static bool HasDispellableAura(this GameObject unit)
+        // Named for what it actually asks. A dispel strips BENEFICIAL statuses from an enemy, so a helper
+        // used to decide whether to dispel must ignore debuffs — otherwise a dispel action re-fires forever
+        // on an enemy that merely carries a dispellable debuff it can never remove, such as the Time Mage's
+        // own Slow / Occult Mage Masher. Calling that "HasDispellableAura" read as the opposite of what it
+        // did; healers' Esuna path is a separate concern and uses NeedsDispel/HasAnyDispellableAura.
+        public static bool HasDispellableBuff(this GameObject unit)
         {
             var unitAsCharacter = unit as Character;
 
             if (unitAsCharacter == null || !unitAsCharacter.IsValid)
                 return false;
 
-            // A dispel only removes BENEFICIAL statuses, so ignore debuffs. Otherwise a dispel action
-            // (e.g. Occult Dispel) re-fires forever on an enemy that merely carries a dispellable
-            // debuff it can never remove — such as the Time Mage's own Slow / Occult Mage Masher.
             return unitAsCharacter.CharacterAuras.Any(r => r.TimespanLeft.TotalMilliseconds >= 0 && r.IsDispellable && !r.IsDebuff);
         }
 

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -265,7 +265,32 @@ namespace Magitek.Extensions
                 && unit.DamageableByMyMark()
                 && unit.DamageableByMyDuelRole()
                 && unit.DamageableByMyDamageType()
-                && unit.DamageableGivenMyBuffs();
+                && unit.DamageableGivenMyBuffs()
+                && unit.NotAnIgnoredMechanicAdd();
+        }
+
+        // Adds that exist to be NOT attacked: hitting them is the mechanic failure. Same tiny
+        // zone-and-name table shape as RequiresAstralRealignment below, for the same per-pulse
+        // cost reason. Arbatel (the Forked Tower) spawns four numbered Pages and only the correct
+        // one may be attacked — Page 64 is deliberately absent from this list.
+        private const ushort OccultCrescentNorthHornZoneId = 1346;
+
+        private static readonly HashSet<string> ArbatelIgnoredPages = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Page 512",
+            "Page 16",
+            "Page 8",
+        };
+
+        public static bool NotAnIgnoredMechanicAdd(this GameObject unit)
+        {
+            if (unit == null)
+                return false;
+
+            if (WorldManager.ZoneId != OccultCrescentNorthHornZoneId)
+                return true; // cheap early-out: this only applies in one fight
+
+            return !ArbatelIgnoredPages.Contains(unit.EnglishName);
         }
 
         // Enemies that can only be damaged while we hold a particular buff, where the target itself carries

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -271,13 +271,14 @@ namespace Magitek.Extensions
 
         // Adds that exist to be NOT attacked: hitting them is the mechanic failure. Same tiny
         // zone-and-name table shape as RequiresAstralRealignment below, for the same per-pulse
-        // cost reason. Arbatel (the Forked Tower) spawns four numbered Pages and only the correct
-        // one may be attacked — Page 64 is deliberately absent from this list.
+        // cost reason. Arbatel (the Forked Tower) spawns numbered Pages the routine must never
+        // attack — all four are ignored.
         private const ushort OccultCrescentNorthHornZoneId = 1346;
 
         private static readonly HashSet<string> ArbatelIgnoredPages = new HashSet<string>(StringComparer.Ordinal)
         {
             "Page 512",
+            "Page 64",
             "Page 16",
             "Page 8",
         };

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -28,7 +28,9 @@ namespace Magitek.Extensions
                 return unit.Type != GameObjectType.Pc;
             }
 
-            return unit.CanAttack;
+            // DamageableByMyMark keeps single-target damage off enemies we can't hurt under a mark-match
+            // mechanic (Meso Terminal Cell Block); it's a no-op whenever we carry no such mark.
+            return unit.CanAttack && unit.DamageableByMyMark();
         }
 
         public static bool BeingTargeted(this GameObject unit)
@@ -179,7 +181,10 @@ namespace Magitek.Extensions
             if (unitAsCharacter == null || !unitAsCharacter.IsValid)
                 return false;
 
-            return unitAsCharacter.CharacterAuras.Any(r => r.TimespanLeft.TotalMilliseconds >= 0 && r.IsDispellable);
+            // A dispel only removes BENEFICIAL statuses, so ignore debuffs. Otherwise a dispel action
+            // (e.g. Occult Dispel) re-fires forever on an enemy that merely carries a dispellable
+            // debuff it can never remove — such as the Time Mage's own Slow / Occult Mage Masher.
+            return unitAsCharacter.CharacterAuras.Any(r => r.TimespanLeft.TotalMilliseconds >= 0 && r.IsDispellable && !r.IsDebuff);
         }
 
         public static bool HasAnyAura(this GameObject unit, List<uint> auras, bool isMyAura = false, int msLeft = 0)
@@ -229,9 +234,135 @@ namespace Magitek.Extensions
             return unit != null && unit.IsValid && unit.IsTargetable && unit.CanAttack && unit.CurrentHealth > 0;
         }
 
+
         public static bool NotInvulnerable(this GameObject unit)
         {
-            return unit != null && !unit.HasAnyAura(Auras.Invincibility);
+            return unit != null
+                && !unit.HasAnyAura(Auras.Invincibility)
+                && unit.DamageableByMyMark()
+                && unit.DamageableByMyDuelRole()
+                && unit.DamageableByMyDamageType()
+                && unit.DamageableGivenMyBuffs();
+        }
+
+        // Enemies that can only be damaged while we hold a particular buff, where the target itself carries
+        // no status to key off — so it has to be matched by zone and name instead.
+        //
+        // Deliberately a tiny static table rather than fight-logic catalogue data: NotInvulnerable() runs
+        // for every enemy on every pulse, and scanning the catalogue per call would be far too expensive.
+        // A zone-id compare costs essentially nothing everywhere else.
+        private const ushort LabyrinthOfTheAncientsZoneId = 174;
+
+        private static readonly HashSet<string> RequiresAstralRealignment = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Thanatos", // exact match keeps Eureka Orthos' "Orthos Thanatos" out of this
+        };
+
+        public static bool DamageableGivenMyBuffs(this GameObject unit)
+        {
+            if (unit == null)
+                return false;
+
+            if (WorldManager.ZoneId != LabyrinthOfTheAncientsZoneId)
+                return true; // cheap early-out: this only applies in one fight
+
+            var me = Core.Me;
+
+            if (me == null)
+                return true;
+
+            if (RequiresAstralRealignment.Contains(unit.EnglishName) && !me.HasAura(Auras.AstralRealignment))
+                return false;
+
+            return true;
+        }
+
+        // Jeuno's Ark Angels duel: a target dubbed a Villain nullifies damage from anyone not carrying the
+        // matching Hero status. This is the reverse of DamageableByMyMark — there our own mark selected the
+        // one enemy we could hit, here the enemy's own status decides whether we count. A target with no
+        // Villain status is damageable by anyone, so this stays inert outside that fight.
+        public static bool DamageableByMyDuelRole(this GameObject unit)
+        {
+            var target = unit as Character;
+
+            if (target == null)
+                return unit != null;
+
+            var me = Core.Me;
+
+            if (me == null)
+                return true;
+
+            uint requiredHeroAura = 0;
+
+            foreach (var aura in target.CharacterAuras)
+                if (Auras.DuelVillainRequiredHeroAura.TryGetValue(aura.Id, out requiredHeroAura))
+                    break;
+
+            if (requiredHeroAura == 0)
+                return true; // not duelling -> anyone can damage it (the common case)
+
+            return me.HasAura(requiredHeroAura);
+        }
+
+        // Damage-type immunity: the target is only invulnerable to *some* jobs, so this is answered from
+        // our own job rather than from the target alone. The Void Ark's Sawtooth and Irminsul each take one
+        // of these at random, which is why nothing here is keyed to an enemy name.
+        //
+        // Note the asymmetry: Magic Resistance blocks healers and casters, but Ranged Resistance blocks
+        // PHYSICAL ranged only — a caster's ranged attacks are magical and still land, so they must not be
+        // filtered out by it. Blue Mage appears in the physical-ranged list for role purposes but deals
+        // magic damage, so it is treated as a caster on both counts.
+        public static bool DamageableByMyDamageType(this GameObject unit)
+        {
+            if (unit == null)
+                return false;
+
+            var me = Core.Me;
+
+            if (me == null)
+                return true;
+
+            var job = me.CurrentJob;
+
+            if (MagicDamageJobs.Contains(job) && unit.HasAnyAura(Auras.MagicImmunity))
+                return false;
+
+            if (RangedPhysicalDps.Contains(job) && !MagicDamageJobs.Contains(job) && unit.HasAnyAura(Auras.RangedImmunity))
+                return false;
+
+            return true;
+        }
+
+        // The Meso Terminal Headsman pull tethers each player with a "Cell Block" mark; while marked, only
+        // the Headsman carrying the matching "Guard on Duty" letter takes that player's damage — every other
+        // target is immune ("Attacks against other targets are nullified"). Fast-outs to true whenever we
+        // carry no Cell Block mark (i.e. everywhere but that one mechanic), so the shared NotInvulnerable
+        // hot path stays a single cheap scan of our own aura list in the common case.
+        public static bool DamageableByMyMark(this GameObject unit)
+        {
+            if (unit == null)
+                return false;
+
+            var me = Core.Me;
+            if (me == null)
+                return true;
+
+            // If we carry a Cell Block mark, note the Guard on Duty status an enemy must have to be
+            // damageable by us. One pass over our own (small) aura list.
+            uint requiredEnemyAura = 0;
+            foreach (var aura in me.CharacterAuras)
+            {
+                if (Auras.MarkMatchDamageableEnemyAura.TryGetValue(aura.Id, out requiredEnemyAura))
+                    break;
+            }
+
+            // Not marked -> normal targeting (the overwhelmingly common case).
+            if (requiredEnemyAura == 0)
+                return true;
+
+            // Marked -> only the enemy with the matching Guard on Duty letter takes our damage.
+            return unit.HasAura(requiredEnemyAura);
         }
 
         public static IEnumerable<BattleCharacter> EnemiesNearby(this GameObject unit, float distance)
@@ -651,6 +782,24 @@ namespace Magitek.Extensions
             ClassJobType.Reaper,
             ClassJobType.Pictomancer,
             ClassJobType.Viper
+        };
+
+        // Jobs whose damage is magical — healers plus the casters. Used for damage-type immunity checks;
+        // Blue Mage is here (not with physical ranged) because its spells deal magic damage.
+        private static readonly List<ClassJobType> MagicDamageJobs = new List<ClassJobType>()
+        {
+            ClassJobType.Arcanist,
+            ClassJobType.Scholar,
+            ClassJobType.Conjurer,
+            ClassJobType.WhiteMage,
+            ClassJobType.Astrologian,
+            ClassJobType.Sage,
+            ClassJobType.Thaumaturge,
+            ClassJobType.BlackMage,
+            ClassJobType.Summoner,
+            ClassJobType.RedMage,
+            ClassJobType.Pictomancer,
+            ClassJobType.BlueMage,
         };
 
         private static readonly List<ClassJobType> RangedPhysicalDps = new List<ClassJobType>()

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -40,7 +40,9 @@ namespace Magitek.Extensions
             if (unit == null)
                 return false;
 
-            return Combat.Enemies.Any(x => x.TargetCharacter == unit);
+            // Combat.Threats, not Combat.Enemies: "is something attacking this unit" is a defensive
+            // question, and an enemy our damage cannot reach still hits the person it has targeted.
+            return Combat.Threats.Any(x => x.TargetCharacter == unit);
         }
 
         public static bool BeingTargetedBy(this GameObject unit, GameObject other)

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -764,7 +764,10 @@ namespace Magitek.Logic.Astrologian
                 return false;
 
             if (enemyCount > PartyManager.NumMembers)
-                if (Combat.Enemies.All(x => x.WithinSpellRange(Spells.Macrocosmos.Radius) && Group.CastableAlliesWithin20.Count() == PartyManager.NumMembers))
+                // Threats, not Enemies: "is every enemy close enough" is about what can hurt the party,
+                // and an enemy immune to OUR damage still hurts them; filtered-out enemies would also
+                // leave the list empty and the All() vacuously true.
+                if (Combat.Threats.All(x => x.WithinSpellRange(Spells.Macrocosmos.Radius) && Group.CastableAlliesWithin20.Count() == PartyManager.NumMembers))
                     return await Spells.Macrocosmos.HealAura(Core.Me, Auras.Macrocosmos);
 
             var isThereABoss = Combat.Enemies.Any(x => x.IsBoss());

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -219,7 +219,7 @@ namespace Magitek.Logic.Astrologian
             {
                 var celestialIntersectionTank = Group.CastableTanks.FirstOrDefault(r => !Utilities.Routines.Astrologian.DontCelestialIntersection.Contains(r.Name)
                 && r.CurrentHealthPercent <= AstrologianSettings.Instance.CelestialIntersectionHealthPercent
-                && Combat.Enemies.Any(x => x.TargetCharacter == r)
+                && Combat.Threats.Any(x => x.TargetCharacter == r)   // is anything hitting them, damageable or not
                 && !r.HasAura(Auras.CelestialIntersection)
                 && r.CheckTankImmunity() == TankImmunityCheck.HealThem);
 

--- a/Magitek/Logic/Dancer/Dances.cs
+++ b/Magitek/Logic/Dancer/Dances.cs
@@ -160,7 +160,12 @@ namespace Magitek.Logic.Dancer
                 switch (ActionResourceManager.Dancer.CurrentStep)
                 {
                     case ActionResourceManager.Dancer.DanceStep.Finish:
-                        if (DancerSettings.Instance.OnlyFinishStepInRange && Core.Me.CurrentTarget.Distance(Core.Me) > 15 + Core.Me.CurrentTarget.CombatReach)
+                        // No target counts as out of range rather than throwing: a dance outlives the enemy
+                        // that started it, and this runs ahead of the rotation's own target guard so the
+                        // steps are not lost to a fight-logic reaction.
+                        if (DancerSettings.Instance.OnlyFinishStepInRange
+                            && (Core.Me.CurrentTarget == null
+                                || Core.Me.CurrentTarget.Distance(Core.Me) > 15 + Core.Me.CurrentTarget.CombatReach))
                             return false;
 
                         if (Core.Me.HasAura(Auras.StandardStep))

--- a/Magitek/Logic/InterruptLogic.cs
+++ b/Magitek/Logic/InterruptLogic.cs
@@ -40,26 +40,30 @@ namespace Magitek.Logic
         {
             IEnumerable<BattleCharacter> castingEnemies;
 
+            // Combat.Threats, not Combat.Enemies: an interrupt stops a cast whether or not our damage
+            // can reach the caster, and Enemies drops anything we are immune-locked out of hurting —
+            // which would silently disable Interject, Head Graze, Leg Sweep and Flying Sardine against
+            // exactly the bosses whose mechanics we most need stopped.
             switch (strategy)
             {
                 case InterruptStrategy.Never:
                     castingEnemies = new List<BattleCharacter>();
                     break;
                 case InterruptStrategy.BossesOnly:
-                    castingEnemies = Combat.Enemies;
+                    castingEnemies = Combat.Threats;
                     castingEnemies = castingEnemies.Where(e => e.IsBoss());
                     break;
                 case InterruptStrategy.ExceptBoss:
-                    castingEnemies = Combat.Enemies;
+                    castingEnemies = Combat.Threats;
                     castingEnemies = castingEnemies.Where(r => r.InView() && r.IsCasting && !r.IsBoss())
                         .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
                     break;
                 case InterruptStrategy.CurrentTargetOnly:
-                    castingEnemies = Combat.Enemies;
+                    castingEnemies = Combat.Threats;
                     castingEnemies = castingEnemies.Where(e => e == Core.Me.CurrentTarget);
                     break;
                 case InterruptStrategy.AnyEnemy:
-                    castingEnemies = Combat.Enemies;
+                    castingEnemies = Combat.Threats;
                     castingEnemies = castingEnemies.Where(r => r.InView() && r.IsCasting)
                         .OrderBy(r => r.SpellCastInfo.RemainingCastTime);
                     break;

--- a/Magitek/Logic/Paladin/Defensive.cs
+++ b/Magitek/Logic/Paladin/Defensive.cs
@@ -72,7 +72,9 @@ namespace Magitek.Logic.Paladin
             if (!PaladinSettings.Instance.UseReprisal)
                 return false;
 
-            if (!UseDefensives() && Combat.Enemies.Count < 3)
+            // Threats, not Enemies: pull size is about how many enemies are hitting us, and an
+            // enemy our damage cannot reach still hurts.
+            if (!UseDefensives() && Combat.Threats.Count < 3)
                 return false;
 
             if (Core.Me.CurrentHealthPercent > PaladinSettings.Instance.ReprisalHealthPercent)

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -116,24 +116,31 @@ namespace Magitek.Logic.Roles
                 if (!spell.IsKnownAndReady())
                     return false;
 
-                if (Core.Me.CurrentTarget == null)
+                // Debuff the enemy we are REACTING to, not whatever we happen to be hitting — they are
+                // frequently different, and Feint or Addle landing on the wrong one does nothing about the
+                // mechanic. Reprisal is self-centred, so measuring range to the caster is right there too:
+                // if the caster is out of its radius, Reprisal genuinely cannot mitigate this cast.
+                // Falls back to the current target when nothing is mid-cast (lock-on reactions have no caster).
+                var debuffTarget = (GameObject)FightLogic.DetectedCaster() ?? Core.Me.CurrentTarget;
+
+                if (debuffTarget == null)
                     return false;
 
-                // For range-based debuffs (e.g., Reprisal), check if current target is within range
-                if (range > 0f && !Core.Me.CurrentTarget.WithinSpellRange(range))
+                // For range-based debuffs (e.g., Reprisal), check the caster is within range
+                if (range > 0f && !debuffTarget.WithinSpellRange(range))
                     return false;
 
                 // For target-based debuffs, check target aura
-                if (targetAuraCheck && Core.Me.CurrentTarget.HasAura(aura))
+                if (targetAuraCheck && debuffTarget.HasAura(aura))
                     return false;
 
                 if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs, BaseSettings.Instance.FightLogicResponseDelay))
                     return false;
 
                 if (BaseSettings.Instance.DebugFightLogic)
-                    Logger.WriteInfo($"[Debuff Response] Cast {spell.Name} on {Core.Me.CurrentTarget.Name}");
+                    Logger.WriteInfo($"[Debuff Response] Cast {spell.Name} on {debuffTarget.Name}");
 
-                return await FightLogic.DoAndBuffer(spell.Cast(Core.Me.CurrentTarget));
+                return await FightLogic.DoAndBuffer(spell.Cast(debuffTarget));
             }
 
             return false;

--- a/Magitek/Logic/Roles/Healer.cs
+++ b/Magitek/Logic/Roles/Healer.cs
@@ -122,7 +122,12 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoAction(limitBreak3Spell, Core.Me);
+                // Only clear the toggle when the action actually fired. DoAction can fail for passing
+                // reasons (animation lock from an oGCD the pulse before), and clearing on failure
+                // silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoAction(limitBreak3Spell, Core.Me))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -134,8 +139,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me))
-                    ActionManager.DoAction(limitBreak1Spell, Core.Me);
+                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me)
+                    && !ActionManager.DoAction(limitBreak1Spell, Core.Me))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Roles/MagicDps.cs
+++ b/Magitek/Logic/Roles/MagicDps.cs
@@ -36,6 +36,11 @@ namespace Magitek.Logic.Roles
             if (!BaseSettings.Instance.ForceLimitBreak)
                 return false;
 
+            // A DPS limit break resolves at the target, so there has to be one. Cheap here, and it lets the
+            // rotations run this above their attack guard without risking a null dereference.
+            if (Core.Me.CurrentTarget == null)
+                return false;
+
             //LB 3
             if (PartyManager.NumMembers == 8
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)

--- a/Magitek/Logic/Roles/MagicDps.cs
+++ b/Magitek/Logic/Roles/MagicDps.cs
@@ -36,8 +36,9 @@ namespace Magitek.Logic.Roles
             if (!BaseSettings.Instance.ForceLimitBreak)
                 return false;
 
-            // A DPS limit break resolves at the target, so there has to be one. Cheap here, and it lets the
-            // rotations run this above their attack guard without risking a null dereference.
+            // A DPS limit break resolves at the target, so there has to be one. The rotations call this
+            // below their attack guard — deliberately, so a forced damage LB is never poured into a
+            // target the routine cannot damage — but the check is cheap protection either way.
             if (Core.Me.CurrentTarget == null)
                 return false;
 
@@ -46,7 +47,12 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoActionLocation(limitBreak3Spell.Id, Core.Me.CurrentTarget.Location);
+                // Only clear the toggle when the action actually fired. DoAction can fail for passing
+                // reasons (animation lock from an oGCD the pulse before), and clearing on failure
+                // silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoActionLocation(limitBreak3Spell.Id, Core.Me.CurrentTarget.Location))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -58,8 +64,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoActionLocation(limitBreak2Spell.Id, Core.Me.CurrentTarget.Location))
-                    ActionManager.DoActionLocation(limitBreak1Spell.Id, Core.Me.CurrentTarget.Location); ;
+                if (!ActionManager.DoActionLocation(limitBreak2Spell.Id, Core.Me.CurrentTarget.Location)
+                    && !ActionManager.DoActionLocation(limitBreak1Spell.Id, Core.Me.CurrentTarget.Location))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -3209,7 +3209,9 @@ namespace Magitek.Logic.Roles
                 return false;
 
             var target = Core.Me.CurrentTarget;
-            if (target == null || !target.ValidAttackUnit())
+            // Threat check, not attack check: this casts on ourselves in answer to being hit, so an
+            // enemy immune to our damage must still count.
+            if (target == null || !target.ValidThreatUnit())
                 return false;
 
             // Check if target is targeting us
@@ -3499,7 +3501,9 @@ namespace Magitek.Logic.Roles
                 return false;
 
             var target = Core.Me.CurrentTarget;
-            if (target == null || !target.ValidAttackUnit())
+            // Threat check, not attack check: this casts on ourselves in answer to being hit, so an
+            // enemy immune to our damage must still count.
+            if (target == null || !target.ValidThreatUnit())
                 return false;
 
             // Always cast if target is targeting us (to build Finishing Fervor stacks)

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2158,7 +2158,7 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (!Core.Me.CurrentTarget.HasDispellableAura())
+            if (!Core.Me.CurrentTarget.HasDispellableBuff())
                 return false;
 
             // if (!Core.Me.CurrentTarget.HasAnyAura(OCAuras.DispellableAuras))

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2155,7 +2155,10 @@ namespace Magitek.Logic.Roles
             if (!OCSpells.OccultDispel.CanCast())
                 return false;
 
-            if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
+            // ValidThreatUnit, not ValidAttackUnit: a dispel deals no damage, so being immune to ours is no
+            // reason to withhold it — and stripping a buff off an enemy we cannot currently hurt is often
+            // exactly the point.
+            if (!Core.Me.CurrentTarget.ValidThreatUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
             if (!Core.Me.CurrentTarget.HasDispellableBuff())

--- a/Magitek/Logic/Roles/PhysicalDPS.cs
+++ b/Magitek/Logic/Roles/PhysicalDPS.cs
@@ -138,6 +138,11 @@ namespace Magitek.Logic.Roles
             if (!BaseSettings.Instance.ForceLimitBreak)
                 return false;
 
+            // A DPS limit break resolves at the target, so there has to be one. Cheap here, and it lets the
+            // rotations run this above their attack guard without risking a null dereference.
+            if (Core.Me.CurrentTarget == null)
+                return false;
+
             //LB 3
             if (PartyManager.NumMembers == 8
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)

--- a/Magitek/Logic/Roles/PhysicalDPS.cs
+++ b/Magitek/Logic/Roles/PhysicalDPS.cs
@@ -138,8 +138,9 @@ namespace Magitek.Logic.Roles
             if (!BaseSettings.Instance.ForceLimitBreak)
                 return false;
 
-            // A DPS limit break resolves at the target, so there has to be one. Cheap here, and it lets the
-            // rotations run this above their attack guard without risking a null dereference.
+            // A DPS limit break resolves at the target, so there has to be one. The rotations call this
+            // below their attack guard — deliberately, so a forced damage LB is never poured into a
+            // target the routine cannot damage — but the check is cheap protection either way.
             if (Core.Me.CurrentTarget == null)
                 return false;
 
@@ -148,7 +149,12 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoAction(limitBreak3Spell, Core.Me.CurrentTarget);
+                // Only clear the toggle when the action actually fired. DoAction can fail for passing
+                // reasons (animation lock from an oGCD the pulse before), and clearing on failure
+                // silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoAction(limitBreak3Spell, Core.Me.CurrentTarget))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -160,8 +166,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me.CurrentTarget))
-                    ActionManager.DoAction(limitBreak1Spell, Core.Me.CurrentTarget);
+                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me.CurrentTarget)
+                    && !ActionManager.DoAction(limitBreak1Spell, Core.Me.CurrentTarget))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -76,7 +76,9 @@ namespace Magitek.Logic.Roles
             if (Core.Me.CurrentHealthPercent > settings.ArmsLengthPercentage)
                 return false;
 
-            if (!(Combat.Enemies.Count(r => r.TargetGameObject == Core.Me) >= settings.ArmsLengthEnemies))
+            // Threats, not Enemies: this counts ATTACKERS, and an enemy our damage cannot reach
+            // still swings at us — same reasoning as BeingTargeted().
+            if (!(Combat.Threats.Count(r => r.TargetGameObject == Core.Me) >= settings.ArmsLengthEnemies))
                 return false;
 
             return await Spells.ArmsLength.Cast(Core.Me);

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -116,7 +116,12 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoAction(limitBreak3Spell, Core.Me);
+                // Only clear the toggle when the action actually fired. DoAction can fail for passing
+                // reasons (animation lock from an oGCD the pulse before), and clearing on failure
+                // silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoAction(limitBreak3Spell, Core.Me))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -128,8 +133,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me))
-                    ActionManager.DoAction(limitBreak1Spell, Core.Me);
+                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me)
+                    && !ActionManager.DoAction(limitBreak1Spell, Core.Me))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Summoner/Heal.cs
+++ b/Magitek/Logic/Summoner/Heal.cs
@@ -177,7 +177,10 @@ namespace Magitek.Logic.Summoner
             if (Core.Me.CurrentHealthPercent >= SummonerSettings.Instance.RadiantAegisHPThreshold)
                 return false;
 
-            if (!Combat.Enemies.All(x => x.TargetCharacter == Core.Me && x.IsCasting))
+            // Threats, not Enemies: this asks "is everything attacking me", and an enemy our damage
+            // cannot touch still attacks us. Enemies filters those out, which can leave it empty and
+            // make the All() vacuously true — spending the shield against nothing that qualifies.
+            if (!Combat.Threats.All(x => x.TargetCharacter == Core.Me && x.IsCasting))
                 return false;
 
             return await Spells.RadiantAegis.CastAura(Core.Me, Auras.RadiantAegis);

--- a/Magitek/Logic/Warrior/Defensive.cs
+++ b/Magitek/Logic/Warrior/Defensive.cs
@@ -50,7 +50,9 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UseReprisal)
                 return false;
 
-            if (!UseDefensives() && Combat.Enemies.Count < 3)
+            // Threats, not Enemies: pull size is about how many enemies are hitting us, and an
+            // enemy our damage cannot reach still hurts.
+            if (!UseDefensives() && Combat.Threats.Count < 3)
                 return false;
 
             if (Core.Me.CurrentHealthPercent > WarriorSettings.Instance.ReprisalHealthPercent)

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -47,7 +47,15 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_PartyShield(BardSettings.Instance.FightLogicNaturesMinne, Spells.NaturesMinne, true, aura: Auras.NaturesMinne)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(BardSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            if ((!canAttack || BardRoutine.GlobalCooldown.CanWeave()) && await PhysicalDps.Interrupt(BardSettings.Instance)) return true;
+
+            if (!canAttack)
                 return false;
 
             //LimitBreak
@@ -63,7 +71,6 @@ namespace Magitek.Rotations
                 if (await Utility.Troubadour()) return true;
                 if (await PhysicalDps.ArmsLength(BardSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(BardSettings.Instance)) return true;
-                if (await PhysicalDps.Interrupt(BardSettings.Instance)) return true;
                 if (await Cooldowns.UsePotion()) return true;
 
                 // Damage

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -56,7 +56,14 @@ namespace Magitek.Rotations
             if ((!canAttack || BardRoutine.GlobalCooldown.CanWeave()) && await PhysicalDps.Interrupt(BardSettings.Instance)) return true;
 
             if (!canAttack)
+            {
+                // Aimed at us, not the target: a forced Arm's Length and the Second Wind self-heal stay
+                // available while the enemy can't be damaged. Attack-mode priorities are unchanged —
+                // these still run from their usual weave slot below.
+                if (await PhysicalDps.ArmsLength(BardSettings.Instance)) return true;
+                if (await PhysicalDps.SecondWind(BardSettings.Instance)) return true;
                 return false;
+            }
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;

--- a/Magitek/Rotations/Bard.cs
+++ b/Magitek/Rotations/Bard.cs
@@ -43,15 +43,16 @@ namespace Magitek.Rotations
         {
             BardRoutine.RefreshVars();
 
+            if (await CommonFightLogic.FightLogic_PartyShield(BardSettings.Instance.FightLogicTroubadour, Spells.Troubadour, true, PhysicalDps.partyShieldAuras)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(BardSettings.Instance.FightLogicNaturesMinne, Spells.NaturesMinne, true, aura: Auras.NaturesMinne)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(BardSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_PartyShield(BardSettings.Instance.FightLogicTroubadour, Spells.Troubadour, true, PhysicalDps.partyShieldAuras)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(BardSettings.Instance.FightLogicNaturesMinne, Spells.NaturesMinne, true, aura: Auras.NaturesMinne)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(BardSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             if (BardRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -1,4 +1,4 @@
-using ff14bot;
+﻿using ff14bot;
 using Magitek.Extensions;
 using Magitek.Logic.BlackMage;
 using Magitek.Logic.Roles;
@@ -46,15 +46,16 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_SelfShield(BlackMageSettings.Instance.FightLogicManaward, Spells.Manaward, castTimeRemainingMs: 19000)) return true;
+            if (await MagicDps.FightLogic_Addle(BlackMageSettings.Instance)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(BlackMageSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(BlackMageSettings.Instance.FightLogicManaward, Spells.Manaward, castTimeRemainingMs: 19000)) return true;
-            if (await MagicDps.FightLogic_Addle(BlackMageSettings.Instance)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(BlackMageSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 
             if (await Aoe.FlareStar()) return true;
 

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -1,4 +1,4 @@
-﻿using ff14bot;
+using ff14bot;
 using Magitek.Extensions;
 using Magitek.Logic.BlackMage;
 using Magitek.Logic.Roles;

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -66,19 +66,23 @@ namespace Magitek.Rotations
             if (Core.Me.HasAura(Auras.WaningNocturne, true, 1000))
                 return false;
 
+            //Interrupt
+            if (await MagicDps.Interrupt(BlueMageSettings.Instance)) return true;
+
             // Magic Resistance nullifies almost everything Blue Mage has, but not all of it: Sharpened Knife
             // is slashing and Triple Trident piercing, and both still land. ThoroughCanAttack deliberately
             // lets Blue Mage through for that reason, so go straight to the two that work rather than
             // spending the window offering the target spells it ignores.
+            //
+            // Below the interrupt on purpose. Flying Sardine stops a cast whether or not our damage can
+            // reach the caster, and an immune target is exactly when we can least afford to let a mechanic
+            // through — the same reason the defensive reactions sit above the attack check.
             if (Core.Me.CurrentTarget.HasAnyAura(Auras.MagicImmunity))
             {
                 if (await SingleTarget.TripleTrident()) return true;
 
                 return await SingleTarget.SharpKnife();
             }
-
-            //Interrupt
-            if (await MagicDps.Interrupt(BlueMageSettings.Instance)) return true;
 
             //Manage PhantomFlury 
             ff14bot.Objects.Aura waxingNocturne = Core.Me.Auras.FirstOrDefault(x => x.Id == Auras.WaxingNocturne && x.CasterId == Core.Player.ObjectId);

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -66,6 +66,17 @@ namespace Magitek.Rotations
             if (Core.Me.HasAura(Auras.WaningNocturne, true, 1000))
                 return false;
 
+            // Magic Resistance nullifies almost everything Blue Mage has, but not all of it: Sharpened Knife
+            // is slashing and Triple Trident piercing, and both still land. ThoroughCanAttack deliberately
+            // lets Blue Mage through for that reason, so go straight to the two that work rather than
+            // spending the window offering the target spells it ignores.
+            if (Core.Me.CurrentTarget.HasAnyAura(Auras.MagicImmunity))
+            {
+                if (await SingleTarget.TripleTrident()) return true;
+
+                return await SingleTarget.SharpKnife();
+            }
+
             //Interrupt
             if (await MagicDps.Interrupt(BlueMageSettings.Instance)) return true;
 

--- a/Magitek/Rotations/BlueMage.cs
+++ b/Magitek/Rotations/BlueMage.cs
@@ -58,16 +58,17 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            // Can't attack, so just exit
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
-            // Can't attack, so just exit
+            // Waning Nocturne means we cannot act at all, so it stays ahead of everything.
             if (Core.Me.HasAura(Auras.WaningNocturne, true, 1000))
                 return false;
 
-            //Interrupt
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason.
             if (await MagicDps.Interrupt(BlueMageSettings.Instance)) return true;
+
+            // Can't attack, so just exit
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
             // Magic Resistance nullifies almost everything Blue Mage has, but not all of it: Sharpened Knife
             // is slashing and Triple Trident piercing, and both still land. ThoroughCanAttack deliberately

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -50,7 +50,15 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_PartyShield(DancerSettings.Instance.FightLogicShieldSamba, Spells.ShieldSamba, true, PhysicalDps.partyShieldAuras)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(DancerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            if ((!canAttack || DancerRoutine.GlobalCooldown.CanWeave()) && await PhysicalDps.Interrupt(DancerSettings.Instance)) return true;
+
+            if (!canAttack)
                 return false;
 
             //LimitBreak
@@ -71,7 +79,6 @@ namespace Magitek.Rotations
                 || (DancerRoutine.GlobalCooldown.CanWeave(1) && Casting.SpellCastHistory.Take(2).Any(s => s.Spell == Spells.Tillana || s.Spell == Spells.DoubleStandardFinish || s.Spell == Spells.QuadrupleTechnicalFinish)))
             {
                 //utility
-                if (await PhysicalDps.Interrupt(DancerSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(DancerSettings.Instance)) return true;
 
                 //Buff

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -59,7 +59,13 @@ namespace Magitek.Rotations
             if ((!canAttack || DancerRoutine.GlobalCooldown.CanWeave()) && await PhysicalDps.Interrupt(DancerSettings.Instance)) return true;
 
             if (!canAttack)
+            {
+                // Second Wind targets us, not the enemy — keep it available while the target can't be
+                // damaged. Never mid-dance: any action breaks the step sequence.
+                if (!Core.Me.HasAura(Auras.StandardStep) && !Core.Me.HasAura(Auras.TechnicalStep)
+                    && await PhysicalDps.SecondWind(DancerSettings.Instance)) return true;
                 return false;
+            }
 
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -42,6 +42,9 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_PartyShield(DancerSettings.Instance.FightLogicShieldSamba, Spells.ShieldSamba, true, PhysicalDps.partyShieldAuras)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(DancerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -59,8 +62,6 @@ namespace Magitek.Rotations
             if (Core.Me.HasAura(Auras.StandardStep) || Core.Me.HasAura(Auras.TechnicalStep))
                 return false;
 
-            if (await CommonFightLogic.FightLogic_PartyShield(DancerSettings.Instance.FightLogicShieldSamba, Spells.ShieldSamba, true, PhysicalDps.partyShieldAuras)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(DancerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             if ((DancerRoutine.GlobalCooldown.CanWeave() && !Casting.SpellCastHistory.Take(2).Any(s => s.Spell == Spells.Tillana || s.Spell == Spells.DoubleStandardFinish || s.Spell == Spells.QuadrupleTechnicalFinish))
                 || (DancerRoutine.GlobalCooldown.CanWeave(1) && Casting.SpellCastHistory.Take(2).Any(s => s.Spell == Spells.Tillana || s.Spell == Spells.DoubleStandardFinish || s.Spell == Spells.QuadrupleTechnicalFinish)))

--- a/Magitek/Rotations/Dancer.cs
+++ b/Magitek/Rotations/Dancer.cs
@@ -42,6 +42,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            // Ahead of the defensives, for the same reason Machinist keeps Flamethrower first: a dance is a
+            // sequence, and any other action spends the window without advancing it. Shield Samba or Arm's
+            // Length firing here would consume the animation lock and drop the steps.
+            if (await Dances.DanceStep()) return true;
+
             if (await CommonFightLogic.FightLogic_PartyShield(DancerSettings.Instance.FightLogicShieldSamba, Spells.ShieldSamba, true, PhysicalDps.partyShieldAuras)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(DancerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
@@ -55,7 +60,6 @@ namespace Magitek.Rotations
             if (await Buff.DancePartner()) return true;
 
             // Dance
-            if (await Dances.DanceStep()) return true;
             if (await Dances.StandardStep()) return true;
             if (await Dances.TechnicalStep()) return true;
 

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -28,11 +28,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (await CommonFightLogic.FightLogic_TankDefensive(DarkKnightSettings.Instance.FightLogicDefensives, DarkKnightRoutine.DefensiveSpells, DarkKnightRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(DarkKnightSettings.Instance.FightLogicPartyShield, Spells.DarkMissionary, true, aura: Auras.DarkMissionary)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(DarkKnightSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(DarkKnightSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
-
             // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
             // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
             // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
@@ -40,9 +35,13 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
+            if (await CommonFightLogic.FightLogic_TankDefensive(DarkKnightSettings.Instance.FightLogicDefensives, DarkKnightRoutine.DefensiveSpells, DarkKnightRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(DarkKnightSettings.Instance.FightLogicPartyShield, Spells.DarkMissionary, true, aura: Auras.DarkMissionary)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(DarkKnightSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(DarkKnightSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
 
 
             //Utility

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -33,11 +33,16 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(DarkKnightSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(DarkKnightSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
+            // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
+            // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
+            // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
+            // resolve at the target's location.
+            //LimitBreak
+            if (Defensive.ForceLimitBreak()) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            //LimitBreak
-            if (Defensive.ForceLimitBreak()) return true;
 
 
             //Utility

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -59,11 +59,12 @@ namespace Magitek.Rotations
                 if (await Tank.ArmsLength(DarkKnightSettings.Instance)) return true;
             }
 
+            // Stance first: an enemy immune to our damage still attacks and builds enmity pressure,
+            // so a missing tank stance must be restorable before the attack guard.
+            if (await Buff.Grit()) return true;
+
             if (!canAttack)
                 return false;
-
-            //Utility
-            if (await Buff.Grit()) return true;
 
             if (DarkKnightRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -40,24 +40,35 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(DarkKnightSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(DarkKnightSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
 
-
-            //Utility
-            if (await Buff.Grit()) return true;
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and still hurts the party — so interrupts and mitigation run before the
+            // guard. Weave discipline still applies while attacking; with no attackable target the GCD
+            // is idle, so the weave check alone would be false exactly when these are needed most.
+            // Internal order of the mitigation block is unchanged; it now simply precedes the Potion
+            // and damage oGCDs instead of sharing their weave block.
             if (await Tank.Interrupt(DarkKnightSettings.Instance)) return true;
 
-            if (DarkKnightRoutine.GlobalCooldown.CanWeave())
+            if (!canAttack || DarkKnightRoutine.GlobalCooldown.CanWeave())
             {
-                //Potion
-                if (await Buff.UsePotion()) return true;
-
                 //Defensive Buff
                 if (await Defensive.Execute()) return true;
                 if (await Defensive.Oblation(true)) return true;
                 if (await Defensive.Reprisal()) return true;
                 if (await Tank.ArmsLength(DarkKnightSettings.Instance)) return true;
+            }
+
+            if (!canAttack)
+                return false;
+
+            //Utility
+            if (await Buff.Grit()) return true;
+
+            if (DarkKnightRoutine.GlobalCooldown.CanWeave())
+            {
+                //Potion
+                if (await Buff.UsePotion()) return true;
 
                 if (await SingleTarget.CarveAndSpit()) return true;
                 if (await Aoe.SaltedEarth()) return true;

--- a/Magitek/Rotations/DarkKnight.cs
+++ b/Magitek/Rotations/DarkKnight.cs
@@ -28,16 +28,17 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_TankDefensive(DarkKnightSettings.Instance.FightLogicDefensives, DarkKnightRoutine.DefensiveSpells, DarkKnightRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(DarkKnightSettings.Instance.FightLogicPartyShield, Spells.DarkMissionary, true, aura: Auras.DarkMissionary)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(DarkKnightSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(DarkKnightSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_TankDefensive(DarkKnightSettings.Instance.FightLogicDefensives, DarkKnightRoutine.DefensiveSpells, DarkKnightRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(DarkKnightSettings.Instance.FightLogicPartyShield, Spells.DarkMissionary, true, aura: Auras.DarkMissionary)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(DarkKnightSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(DarkKnightSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             //Utility
             if (await Buff.Grit()) return true;

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -48,6 +48,9 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget && !Core.Me.InCombat)
                 return false;
 
+            if (await CommonFightLogic.FightLogic_Debuff(DragoonSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(DragoonSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -82,8 +85,6 @@ namespace Magitek.Rotations
             //LimitBreak
             if (SingleTarget.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_Debuff(DragoonSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(DragoonSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
             //Utility
             if (await PhysicalDps.Interrupt(DragoonSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(DragoonSettings.Instance)) return true;

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -56,7 +56,12 @@ namespace Magitek.Rotations
             if (await PhysicalDps.Interrupt(DragoonSettings.Instance)) return true;
 
             if (!Core.Me.CurrentTarget.ThoroughCanAttack())
+            {
+                // Self-heals target us, not the enemy — still available while it can't be damaged.
+                if (await PhysicalDps.SecondWind(DragoonSettings.Instance)) return true;
+                if (await PhysicalDps.Bloodbath(DragoonSettings.Instance)) return true;
                 return false;
+            }
 
             #region Off GCD debugging
             if (DragoonRoutine.JumpsList.Contains(Casting.LastSpell))

--- a/Magitek/Rotations/Dragoon.cs
+++ b/Magitek/Rotations/Dragoon.cs
@@ -51,6 +51,10 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(DragoonSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(DragoonSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason.
+            if (await PhysicalDps.Interrupt(DragoonSettings.Instance)) return true;
+
             if (!Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -86,7 +90,6 @@ namespace Magitek.Rotations
             if (SingleTarget.ForceLimitBreak()) return true;
 
             //Utility
-            if (await PhysicalDps.Interrupt(DragoonSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(DragoonSettings.Instance)) return true;
             if (await PhysicalDps.Bloodbath(DragoonSettings.Instance)) return true;
 

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -41,6 +41,11 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_TankDefensive(GunbreakerSettings.Instance.FightLogicDefensives, GunbreakerRoutine.DefensiveSpells, GunbreakerRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(GunbreakerSettings.Instance.FightLogicPartyShield, Spells.HeartofLight, true, aura: Auras.HeartofLight)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(GunbreakerSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(GunbreakerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -50,10 +55,6 @@ namespace Magitek.Rotations
             //Force Burst Strike
             if (await SingleTarget.ForceBurstStrike()) return true;
 
-            if (await CommonFightLogic.FightLogic_TankDefensive(GunbreakerSettings.Instance.FightLogicDefensives, GunbreakerRoutine.DefensiveSpells, GunbreakerRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(GunbreakerSettings.Instance.FightLogicPartyShield, Spells.HeartofLight, true, aura: Auras.HeartofLight)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(GunbreakerSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(GunbreakerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             //Utility
             if (await Buff.RoyalGuard()) return true;

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -46,11 +46,16 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(GunbreakerSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(GunbreakerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
+            // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
+            // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
+            // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
+            // resolve at the target's location.
+            //LimitBreak
+            if (Defensive.ForceLimitBreak()) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            //LimitBreak
-            if (Defensive.ForceLimitBreak()) return true;
 
             //Force Burst Strike
             if (await SingleTarget.ForceBurstStrike()) return true;

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -53,21 +53,18 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(GunbreakerSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(GunbreakerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
 
-            //Force Burst Strike
-            if (await SingleTarget.ForceBurstStrike()) return true;
-
-            //Utility
-            if (await Buff.RoyalGuard()) return true;
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and still hurts the party — so interrupts and mitigation run before the
+            // guard. Weave discipline still applies while attacking; with no attackable target the GCD
+            // is idle, so the weave check alone would be false exactly when these are needed most.
+            // Internal order of the mitigation block is unchanged; it now simply precedes the Potion
+            // and damage oGCDs instead of sharing their weave block.
             if (await Tank.Interrupt(GunbreakerSettings.Instance)) return true;
 
-            if (GunbreakerRoutine.GlobalCooldown.CanWeave())
+            if (!canAttack || GunbreakerRoutine.GlobalCooldown.CanWeave())
             {
-                //Potion
-                if (await Buff.UsePotion()) return true;
-
                 //Defensive Buff
                 if (await Defensive.Superbolide()) return true;
                 if (await Healing.Aurora()) return true;
@@ -78,6 +75,21 @@ namespace Magitek.Rotations
                 if (await Defensive.HeartofLight()) return true;
                 if (await Defensive.HeartofCorundum()) return true;
                 if (await Tank.ArmsLength(GunbreakerSettings.Instance)) return true;
+            }
+
+            if (!canAttack)
+                return false;
+
+            //Force Burst Strike
+            if (await SingleTarget.ForceBurstStrike()) return true;
+
+            //Utility
+            if (await Buff.RoyalGuard()) return true;
+
+            if (GunbreakerRoutine.GlobalCooldown.CanWeave())
+            {
+                //Potion
+                if (await Buff.UsePotion()) return true;
 
                 if (await SingleTarget.Trajectory()) return true;
             }

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -41,11 +41,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (await CommonFightLogic.FightLogic_TankDefensive(GunbreakerSettings.Instance.FightLogicDefensives, GunbreakerRoutine.DefensiveSpells, GunbreakerRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(GunbreakerSettings.Instance.FightLogicPartyShield, Spells.HeartofLight, true, aura: Auras.HeartofLight)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(GunbreakerSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(GunbreakerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
-
             // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
             // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
             // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
@@ -53,13 +48,16 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
+            if (await CommonFightLogic.FightLogic_TankDefensive(GunbreakerSettings.Instance.FightLogicDefensives, GunbreakerRoutine.DefensiveSpells, GunbreakerRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(GunbreakerSettings.Instance.FightLogicPartyShield, Spells.HeartofLight, true, aura: Auras.HeartofLight)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(GunbreakerSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(GunbreakerSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-
             //Force Burst Strike
             if (await SingleTarget.ForceBurstStrike()) return true;
-
 
             //Utility
             if (await Buff.RoyalGuard()) return true;

--- a/Magitek/Rotations/Gunbreaker.cs
+++ b/Magitek/Rotations/Gunbreaker.cs
@@ -77,14 +77,15 @@ namespace Magitek.Rotations
                 if (await Tank.ArmsLength(GunbreakerSettings.Instance)) return true;
             }
 
+            // Stance first: an enemy immune to our damage still attacks and builds enmity pressure,
+            // so a missing tank stance must be restorable before the attack guard.
+            if (await Buff.RoyalGuard()) return true;
+
             if (!canAttack)
                 return false;
 
             //Force Burst Strike
             if (await SingleTarget.ForceBurstStrike()) return true;
-
-            //Utility
-            if (await Buff.RoyalGuard()) return true;
 
             if (GunbreakerRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -69,7 +69,16 @@ namespace Magitek.Rotations
             if ((!canAttack || MachinistRoutine.GlobalCooldown.CanWeave(1)) && await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
 
             if (!canAttack)
+            {
+                // Aimed at us, not the target — still available while the enemy can't be damaged.
+                // Never during Flamethrower: any action ends the channel.
+                if (!Core.Me.HasAura(Auras.Flamethrower))
+                {
+                    if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
+                    if (await PhysicalDps.SecondWind(MachinistSettings.Instance)) return true;
+                }
                 return false;
+            }
 
             //LimitBreak
             if (MultiTarget.ForceLimitBreak()) return true;

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -60,7 +60,15 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_PartyShield(MachinistSettings.Instance.FightLogicTactician, Spells.Tactician, true, PhysicalDps.partyShieldAuras)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(MachinistSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            if ((!canAttack || MachinistRoutine.GlobalCooldown.CanWeave(1)) && await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
+
+            if (!canAttack)
                 return false;
 
             //LimitBreak
@@ -79,7 +87,6 @@ namespace Magitek.Rotations
                 {
                     //Utility
                     if (await PhysicalDps.ArmsLength(MachinistSettings.Instance)) return true;
-                    if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
 
                     //Pets
                     if (await Pet.RookQueen()) return true;
@@ -101,7 +108,6 @@ namespace Magitek.Rotations
                     if (await Utility.Tactician()) return true;
                     if (await Utility.Dismantle()) return true;
                     if (await PhysicalDps.SecondWind(MachinistSettings.Instance)) return true;
-                    if (await PhysicalDps.Interrupt(MachinistSettings.Instance)) return true;
                     if (await Cooldowns.UsePotion()) return true;
 
                     //Pets

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -40,13 +40,9 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (await CommonFightLogic.FightLogic_Debuff(MachinistSettings.Instance.FightLogicDismantle, Spells.Dismantle, true, Auras.Dismantled)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(MachinistSettings.Instance.FightLogicTactician, Spells.Tactician, true, PhysicalDps.partyShieldAuras)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(MachinistSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
-
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
-
+            // Ahead of everything, defensives included: Flamethrower is a channel and ANY other action ends
+            // it, so a reaction firing here throws the channel away. It reads only Core.Me, so it is safe
+            // above the target guard. This is the order the rotation had before the defensives were hoisted.
             if (MachinistSettings.Instance.UseFlamethrower && Core.Me.HasAura(Auras.Flamethrower))
             {
                 // First check movement otherwise Flamethrower can be executed whereas you are moving
@@ -59,6 +55,13 @@ namespace Magitek.Rotations
                 if (Core.Me.EnemiesInCone(8) >= MachinistSettings.Instance.FlamethrowerEnemyCount)
                     return true;
             }
+
+            if (await CommonFightLogic.FightLogic_Debuff(MachinistSettings.Instance.FightLogicDismantle, Spells.Dismantle, true, Auras.Dismantled)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(MachinistSettings.Instance.FightLogicTactician, Spells.Tactician, true, PhysicalDps.partyShieldAuras)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(MachinistSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+                return false;
 
             //LimitBreak
             if (MultiTarget.ForceLimitBreak()) return true;

--- a/Magitek/Rotations/Machinist.cs
+++ b/Magitek/Rotations/Machinist.cs
@@ -40,6 +40,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_Debuff(MachinistSettings.Instance.FightLogicDismantle, Spells.Dismantle, true, Auras.Dismantled)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(MachinistSettings.Instance.FightLogicTactician, Spells.Tactician, true, PhysicalDps.partyShieldAuras)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(MachinistSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -59,9 +63,6 @@ namespace Magitek.Rotations
             //LimitBreak
             if (MultiTarget.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_Debuff(MachinistSettings.Instance.FightLogicDismantle, Spells.Dismantle, true, Auras.Dismantled)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(MachinistSettings.Instance.FightLogicTactician, Spells.Tactician, true, PhysicalDps.partyShieldAuras)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(MachinistSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             if (ActionResourceManager.Machinist.OverheatRemaining != TimeSpan.Zero)
             {

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -52,7 +52,15 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(MonkSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(MonkSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            if ((!canAttack || MonkRoutine.GlobalCooldown.CanWeave()) && await PhysicalDps.Interrupt(MonkSettings.Instance)) return true;
+
+            if (!canAttack)
             {
                 if (await Buff.Meditate())
                     return true;
@@ -71,7 +79,6 @@ namespace Magitek.Rotations
             //if (MonkRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.Bootshine.Cooldown.TotalMilliseconds > 750 + BaseSettings.Instance.UserLatencyOffset)
             if (MonkRoutine.GlobalCooldown.CanWeave())
             {
-                if (await PhysicalDps.Interrupt(MonkSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(MonkSettings.Instance)) return true;
                 if (await PhysicalDps.Bloodbath(MonkSettings.Instance)) return true;
                 if (await PhysicalDps.Feint(MonkSettings.Instance)) return true;

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -48,6 +48,10 @@ namespace Magitek.Rotations
         {
             MonkRoutine.RefreshVars();
 
+            if (await CommonFightLogic.FightLogic_PartyShield(MonkSettings.Instance.FightLogicMantra, Spells.Mantra, true, aura: Auras.Mantra)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(MonkSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(MonkSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
             {
                 if (await Buff.Meditate())
@@ -59,9 +63,6 @@ namespace Magitek.Rotations
             if (SingleTarget.ForceLimitBreak())
                 return true;
 
-            if (await CommonFightLogic.FightLogic_PartyShield(MonkSettings.Instance.FightLogicMantra, Spells.Mantra, true, aura: Auras.Mantra)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(MonkSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(MonkSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, Auras.ArmsLength)) return true;
 
             //Buff
             if (await Buff.Meditate())

--- a/Magitek/Rotations/Monk.cs
+++ b/Magitek/Rotations/Monk.cs
@@ -62,6 +62,9 @@ namespace Magitek.Rotations
 
             if (!canAttack)
             {
+                // Self-heals target us, not the enemy — still available while it can't be damaged.
+                if (await PhysicalDps.SecondWind(MonkSettings.Instance)) return true;
+                if (await PhysicalDps.Bloodbath(MonkSettings.Instance)) return true;
                 if (await Buff.Meditate())
                     return true;
                 return false;

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -60,7 +60,19 @@ namespace Magitek.Rotations
                 if (await CommonFightLogic.FightLogic_Knockback(NinjaSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
             }
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            // Gated on Mudra/Ten Chi Jin like the fight-logic block above: ANY action mid-chain
+            // destroys it. The attack-mode gate is Ninja's own oGCD window, kept verbatim.
+            if (!Core.Me.HasAura(Auras.Mudra) && !Core.Me.HasAura(Auras.TenChiJin)
+                && (!canAttack || (NinjaRoutine.GlobalCooldown.CountOGCDs() < 2 && Spells.SpinningEdge.Cooldown.TotalMilliseconds >= 770 && DateTime.Now >= NinjaRoutine.oGCD))
+                && await PhysicalDps.Interrupt(NinjaSettings.Instance)) return true;
+
+            if (!canAttack)
                 return false;
 
             Utilities.Routines.Ninja.RefreshVars();
@@ -76,7 +88,6 @@ namespace Magitek.Rotations
                 && DateTime.Now >= NinjaRoutine.oGCD)
             {
 
-                if (await PhysicalDps.Interrupt(NinjaSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(NinjaSettings.Instance)) return true;
                 if (await PhysicalDps.Bloodbath(NinjaSettings.Instance)) return true;
                 if (await PhysicalDps.Feint(NinjaSettings.Instance)) return true;

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -1,4 +1,4 @@
-using ff14bot;
+﻿using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.Ninja;
@@ -47,6 +47,10 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift, castTimeRemainingMs: 19000)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(NinjaSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(NinjaSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -56,9 +60,6 @@ namespace Magitek.Rotations
             if (SingleTarget.ForceLimitBreak())
                 return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift, castTimeRemainingMs: 19000)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(NinjaSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(NinjaSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             if (await Ninjutsu.PrePullSuitonUseCheck()) return true;
 

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -47,9 +47,18 @@ namespace Magitek.Rotations
         }
         public static async Task<bool> Combat()
         {
-            if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift, castTimeRemainingMs: 19000)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(NinjaSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(NinjaSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+            // A mudra chain and Ten Chi Jin are both destroyed by ANY non-mudra action, and the chain is
+            // built one mudra per pulse — so a Shade Shift, Feint or Arm's Length landing between mudras
+            // throws away the charges already spent, and one landing inside Ten Chi Jin discards the rest of
+            // a two-minute cooldown. Unlike Machinist and Paladin the answer is not to bail out — the
+            // ninjutsu below still wants to finish — so hold just the reactions until the window closes.
+            // It lasts a couple of GCDs at most.
+            if (!Core.Me.HasAura(Auras.Mudra) && !Core.Me.HasAura(Auras.TenChiJin))
+            {
+                if (await CommonFightLogic.FightLogic_SelfShield(NinjaSettings.Instance.FightLogicShadeShift, Spells.ShadeShift, castTimeRemainingMs: 19000)) return true;
+                if (await CommonFightLogic.FightLogic_Debuff(NinjaSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+                if (await CommonFightLogic.FightLogic_Knockback(NinjaSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+            }
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -1,4 +1,4 @@
-﻿using ff14bot;
+using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.Ninja;

--- a/Magitek/Rotations/Ninja.cs
+++ b/Magitek/Rotations/Ninja.cs
@@ -73,7 +73,16 @@ namespace Magitek.Rotations
                 && await PhysicalDps.Interrupt(NinjaSettings.Instance)) return true;
 
             if (!canAttack)
+            {
+                // Self-heals target us, not the enemy — still available while it can't be damaged.
+                // Same Mudra/Ten Chi Jin gate as above: ANY action mid-chain destroys the chain.
+                if (!Core.Me.HasAura(Auras.Mudra) && !Core.Me.HasAura(Auras.TenChiJin))
+                {
+                    if (await PhysicalDps.SecondWind(NinjaSettings.Instance)) return true;
+                    if (await PhysicalDps.Bloodbath(NinjaSettings.Instance)) return true;
+                }
                 return false;
+            }
 
             Utilities.Routines.Ninja.RefreshVars();
 

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -47,11 +47,16 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(PaladinSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
+            // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
+            // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
+            // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
+            // resolve at the target's location.
+            //LimitBreak
+            if (Defensive.ForceLimitBreak()) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            //LimitBreak
-            if (Defensive.ForceLimitBreak()) return true;
 
 
             if (!Core.Me.HasAura(Auras.PassageOfArms))

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -88,13 +88,16 @@ namespace Magitek.Rotations
                 if (await Defensive.Cover()) return true;
             }
 
+            // Stance first: an enemy immune to our damage still attacks and builds enmity pressure,
+            // so a missing tank stance must be restorable before the attack guard.
+            if (!Core.Me.HasAura(Auras.PassageOfArms) && await Buff.IronWill()) return true;
+
             if (!canAttack)
                 return false;
 
             if (!Core.Me.HasAura(Auras.PassageOfArms))
             {
                 //Utility
-                if (await Buff.IronWill()) return true;
 
                 if (PaladinRoutine.GlobalCooldown.CanWeave())
                 {

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -48,12 +48,6 @@ namespace Magitek.Rotations
             if (Core.Me.HasAura(Auras.PassageOfArms))
                 return false;
 
-            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveFastSpells, PaladinRoutine.Defensives, castTimeRemainingMs: 3000)) return true;
-            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveSpells, PaladinRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(PaladinSettings.Instance.FightLogicPartyShield, Spells.DivineVeil, true, aura: Auras.DivineVeil)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(PaladinSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
-
             // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
             // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
             // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
@@ -61,9 +55,14 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
+            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveFastSpells, PaladinRoutine.Defensives, castTimeRemainingMs: 3000)) return true;
+            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveSpells, PaladinRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(PaladinSettings.Instance.FightLogicPartyShield, Spells.DivineVeil, true, aura: Auras.DivineVeil)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(PaladinSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
 
 
             if (!Core.Me.HasAura(Auras.PassageOfArms))

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -41,6 +41,13 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            // Ahead of everything, defensives included: Passage of Arms is a held channel that ANY other
+            // action ends, which is what the check further down guards against. The routine never casts it —
+            // the player does — so this is purely "stay out of the way". It reads only Core.Me, so it is
+            // safe above the target guard. Same reasoning as Machinist's Flamethrower.
+            if (Core.Me.HasAura(Auras.PassageOfArms))
+                return false;
+
             if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveFastSpells, PaladinRoutine.Defensives, castTimeRemainingMs: 3000)) return true;
             if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveSpells, PaladinRoutine.Defensives)) return true;
             if (await CommonFightLogic.FightLogic_PartyShield(PaladinSettings.Instance.FightLogicPartyShield, Spells.DivineVeil, true, aura: Auras.DivineVeil)) return true;

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -61,33 +61,45 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(PaladinSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
 
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and still hurts the party — so interrupts and mitigation run before the
+            // guard. Weave discipline still applies while attacking; with no attackable target the GCD
+            // is idle, so the weave check alone would be false exactly when these are needed most.
+            // Internal order of the mitigation block is unchanged; it now simply precedes the Potion
+            // and damage oGCDs instead of sharing their weave block. (The top-level Passage of Arms
+            // bail already protects everything here.)
+            if (await SingleTarget.Interrupt()) return true;
+
+            if (!canAttack || PaladinRoutine.GlobalCooldown.CanWeave())
+            {
+                //Defensive Buff
+                if (await Defensive.HallowedGround()) return true;
+                if (await Defensive.Sentinel()) return true;
+                if (await Defensive.Rampart()) return true;
+                if (await Defensive.Reprisal()) return true;
+                if (await Defensive.Sheltron()) return true;
+                if (await Defensive.DivineVeil()) return true;
+                if (await Tank.ArmsLength(PaladinSettings.Instance)) return true;
+
+                //Cover
+                if (await Defensive.Intervention()) return true;
+                if (await Defensive.Cover()) return true;
+            }
+
+            if (!canAttack)
+                return false;
 
             if (!Core.Me.HasAura(Auras.PassageOfArms))
             {
                 //Utility
-                if (await SingleTarget.Interrupt()) return true;
                 if (await Buff.IronWill()) return true;
 
                 if (PaladinRoutine.GlobalCooldown.CanWeave())
                 {
                     //Potion
                     if (await Buff.UsePotion()) return true;
-
-                    //Defensive Buff
-                    if (await Defensive.HallowedGround()) return true;
-                    if (await Defensive.Sentinel()) return true;
-                    if (await Defensive.Rampart()) return true;
-                    if (await Defensive.Reprisal()) return true;
-                    if (await Defensive.Sheltron()) return true;
-                    if (await Defensive.DivineVeil()) return true;
-                    if (await Tank.ArmsLength(PaladinSettings.Instance)) return true;
-
-                    //Cover
-                    if (await Defensive.Intervention()) return true;
-                    if (await Defensive.Cover()) return true;
 
                     //Damage Buff
                     if (await Buff.FightOrFlight()) return true;

--- a/Magitek/Rotations/Paladin.cs
+++ b/Magitek/Rotations/Paladin.cs
@@ -41,17 +41,18 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveFastSpells, PaladinRoutine.Defensives, castTimeRemainingMs: 3000)) return true;
+            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveSpells, PaladinRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(PaladinSettings.Instance.FightLogicPartyShield, Spells.DivineVeil, true, aura: Auras.DivineVeil)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(PaladinSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveFastSpells, PaladinRoutine.Defensives, castTimeRemainingMs: 3000)) return true;
-            if (await CommonFightLogic.FightLogic_TankDefensive(PaladinSettings.Instance.FightLogicDefensives, PaladinRoutine.DefensiveSpells, PaladinRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(PaladinSettings.Instance.FightLogicPartyShield, Spells.DivineVeil, true, aura: Auras.DivineVeil)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(PaladinSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(PaladinSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             if (!Core.Me.HasAura(Auras.PassageOfArms))
             {

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -47,6 +47,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            // Ahead of the attack check: an enemy we cannot damage still hits the party, so mitigation must
+            // not depend on being able to hurt it. The Starry Muse condition is carried up unchanged, so
+            // burst behaviour is exactly as before — only the damage-immunity gating is removed.
+            if (!Core.Me.HasAura(Auras.StarryMuse, true))
+            {
+                if (await Buff.FightLogic_TemperaGrassa()) return true;
+                if (await Buff.FightLogic_TemperaCoat()) return true;
+                if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
+            }
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
             {
                 // Paint up the palettes during "downtime".
@@ -61,12 +71,6 @@ namespace Magitek.Rotations
 
             PictomancerRoutine.DetectSmudge();
 
-            if (!Core.Me.HasAura(Auras.StarryMuse, true))
-            {
-                if (await Buff.FightLogic_TemperaGrassa()) return true;
-                if (await Buff.FightLogic_TemperaCoat()) return true;
-                if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
-            }
 
             if (await CommonFightLogic.FightLogic_Knockback(PictomancerSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 

--- a/Magitek/Rotations/Pictomancer.cs
+++ b/Magitek/Rotations/Pictomancer.cs
@@ -57,6 +57,11 @@ namespace Magitek.Rotations
                 if (await MagicDps.FightLogic_Addle(PictomancerSettings.Instance)) return true;
             }
 
+            // Anti-knockback belongs with the other defensives, not below the attack check — a knockback
+            // from an enemy we cannot damage still moves us. Outside the Starry Muse block because, unlike
+            // Tempera, Surecast costs nothing worth protecting during burst.
+            if (await CommonFightLogic.FightLogic_Knockback(PictomancerSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
             {
                 // Paint up the palettes during "downtime".
@@ -71,8 +76,6 @@ namespace Magitek.Rotations
 
             PictomancerRoutine.DetectSmudge();
 
-
-            if (await CommonFightLogic.FightLogic_Knockback(PictomancerSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 
             if (PictomancerRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -51,7 +51,15 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(ReaperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(ReaperSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            if ((!canAttack || ReaperRoutine.GlobalCooldown.CanWeave()) && await PhysicalDps.Interrupt(ReaperSettings.Instance)) return true;
+
+            if (!canAttack)
             {
                 if (await Utility.Soulsow()) return true;
                 return false;
@@ -80,7 +88,6 @@ namespace Magitek.Rotations
                 if (ReaperRoutine.GlobalCooldown.CanWeave())
                 {
                     if (await Utility.UsePotion()) return true;
-                    if (await PhysicalDps.Interrupt(ReaperSettings.Instance)) return true;
                     if (await PhysicalDps.SecondWind(ReaperSettings.Instance)) return true;
                     if (await PhysicalDps.Bloodbath(ReaperSettings.Instance)) return true;
 

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -61,6 +61,10 @@ namespace Magitek.Rotations
 
             if (!canAttack)
             {
+                // Self-heals target us, not the enemy — still available while it can't be damaged.
+                // No Enshroud gate: unlike a mudra chain, Enshroud is not broken by other actions.
+                if (await PhysicalDps.SecondWind(ReaperSettings.Instance)) return true;
+                if (await PhysicalDps.Bloodbath(ReaperSettings.Instance)) return true;
                 if (await Utility.Soulsow()) return true;
                 return false;
             }

--- a/Magitek/Rotations/Reaper.cs
+++ b/Magitek/Rotations/Reaper.cs
@@ -47,15 +47,15 @@ namespace Magitek.Rotations
         {
             ReaperRoutine.RefreshVars();
 
+            if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false, castTimeRemainingMs: 3000)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(ReaperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(ReaperSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
             {
                 if (await Utility.Soulsow()) return true;
                 return false;
             }
-
-            if (await CommonFightLogic.FightLogic_SelfShield(ReaperSettings.Instance.FightLogicArcaneCrest, Spells.ArcaneCrest, false, castTimeRemainingMs: 3000)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(ReaperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(ReaperSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             if (SingleTarget.ForceLimitBreak()) return true;
 

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -1,4 +1,4 @@
-using ff14bot;
+﻿using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.RedMage;
@@ -59,6 +59,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_PartyShield(RedMageSettings.Instance.FightLogicMagickBarrier, Spells.MagickBarrier, castTimeRemainingMs: 4500)) return true;
+            if (await MagicDps.FightLogic_Addle(RedMageSettings.Instance)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(RedMageSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -80,9 +84,6 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_PartyShield(RedMageSettings.Instance.FightLogicMagickBarrier, Spells.MagickBarrier, castTimeRemainingMs: 4500)) return true;
-            if (await MagicDps.FightLogic_Addle(RedMageSettings.Instance)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(RedMageSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 
             if (RedMageRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/RedMage.cs
+++ b/Magitek/Rotations/RedMage.cs
@@ -1,4 +1,4 @@
-﻿using ff14bot;
+using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.RedMage;

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -45,6 +45,10 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(SamuraiSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(SamuraiSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason.
+            if (await PhysicalDps.Interrupt(SamuraiSettings.Instance)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -54,7 +58,6 @@ namespace Magitek.Rotations
             if (SingleTarget.ForceLimitBreak()) return true;
 
             //Utility
-            if (await PhysicalDps.Interrupt(SamuraiSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(SamuraiSettings.Instance)) return true;
             if (await PhysicalDps.Bloodbath(SamuraiSettings.Instance)) return true;
 

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -50,7 +50,12 @@ namespace Magitek.Rotations
             if (await PhysicalDps.Interrupt(SamuraiSettings.Instance)) return true;
 
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            {
+                // Self-heals target us, not the enemy — still available while it can't be damaged.
+                if (await PhysicalDps.SecondWind(SamuraiSettings.Instance)) return true;
+                if (await PhysicalDps.Bloodbath(SamuraiSettings.Instance)) return true;
                 return false;
+            }
 
             SamuraiRoutine.RefreshVars();
 

--- a/Magitek/Rotations/Samurai.cs
+++ b/Magitek/Rotations/Samurai.cs
@@ -41,6 +41,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_SelfShield(SamuraiSettings.Instance.FightLogicTengentsu, Spells.Tengentsu.IsKnown() ? Spells.Tengentsu : Spells.ThirdEye, castTimeRemainingMs: 2000)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(SamuraiSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(SamuraiSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -49,9 +53,6 @@ namespace Magitek.Rotations
             //LimitBreak
             if (SingleTarget.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_SelfShield(SamuraiSettings.Instance.FightLogicTengentsu, Spells.Tengentsu.IsKnown() ? Spells.Tengentsu : Spells.ThirdEye, castTimeRemainingMs: 2000)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(SamuraiSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(SamuraiSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
             //Utility
             if (await PhysicalDps.Interrupt(SamuraiSettings.Instance)) return true;
             if (await PhysicalDps.SecondWind(SamuraiSettings.Instance)) return true;

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -51,6 +51,10 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await MagicDps.FightLogic_Addle(SummonerSettings.Instance)) return true;
+            if (await CommonFightLogic.FightLogic_SelfShield(SummonerSettings.Instance.FightLogicRadiantAegis, Spells.RadiantAegis, true, Auras.RadiantAegis)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(SummonerSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
+
             // Every other job opens Combat() with this; Summoner instead hand-checked Magic Resistance alone,
             // which is only one of the ways a target can be immune to us. ThoroughCanAttack covers that same
             // status (942 is in Auras.MagicImmunity) plus the mark, duel and damage-type rules, so this is
@@ -68,9 +72,6 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Aoe.ForceLimitBreak()) return true;
 
-            if (await MagicDps.FightLogic_Addle(SummonerSettings.Instance)) return true;
-            if (await CommonFightLogic.FightLogic_SelfShield(SummonerSettings.Instance.FightLogicRadiantAegis, Spells.RadiantAegis, true, Auras.RadiantAegis)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(SummonerSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 
             if (await Aoe.CrimsonStrike()) return true;
             if (await Buff.LucidDreaming()) return true;

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -51,7 +51,12 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (Core.Me.CurrentTarget.HasAura(Auras.MagicResistance))
+            // Every other job opens Combat() with this; Summoner instead hand-checked Magic Resistance alone,
+            // which is only one of the ways a target can be immune to us. ThoroughCanAttack covers that same
+            // status (942 is in Auras.MagicImmunity) plus the mark, duel and damage-type rules, so this is
+            // strictly wider than what it replaces — and without it Summoner keeps casting into, say, an
+            // Occult Villain it cannot damage.
+            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             //Fix issue with level 1 SMN and/or PotD

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -59,7 +59,12 @@ namespace Magitek.Rotations
             if ((!canAttack || ViperRoutine.GlobalCooldown.CanWeave(1)) && await PhysicalDps.Interrupt(ViperSettings.Instance)) return true;
 
             if (!canAttack)
+            {
+                // Self-heals target us, not the enemy — still available while it can't be damaged.
+                if (await PhysicalDps.SecondWind(ViperSettings.Instance)) return true;
+                if (await PhysicalDps.Bloodbath(ViperSettings.Instance)) return true;
                 return false;
+            }
 
             ViperRoutine.RefreshVars();
 

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -40,6 +40,16 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            // Ahead of the attack check: an enemy we cannot damage still hits the party, so mitigation must
+            // not depend on being able to hurt it. Still weave-gated, so the GCD is no more at risk than
+            // before — these two simply moved out from under the damage-immunity check, leaving the rest of
+            // the weave window (Interrupt, Second Wind, Bloodbath) where it was.
+            if (ViperRoutine.GlobalCooldown.CanWeave(1))
+            {
+                if (await CommonFightLogic.FightLogic_Debuff(ViperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
+                if (await CommonFightLogic.FightLogic_Knockback(ViperSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+            }
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
@@ -49,8 +59,6 @@ namespace Magitek.Rotations
 
             if (ViperRoutine.GlobalCooldown.CanWeave(1))
             {
-                if (await CommonFightLogic.FightLogic_Debuff(ViperSettings.Instance.FightLogicFeint, Spells.Feint, true, Auras.Feint)) return true;
-                if (await CommonFightLogic.FightLogic_Knockback(ViperSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
                 if (await PhysicalDps.Interrupt(ViperSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(ViperSettings.Instance)) return true;
                 if (await PhysicalDps.Bloodbath(ViperSettings.Instance)) return true;

--- a/Magitek/Rotations/Viper.cs
+++ b/Magitek/Rotations/Viper.cs
@@ -50,7 +50,15 @@ namespace Magitek.Rotations
                 if (await CommonFightLogic.FightLogic_Knockback(ViperSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
             }
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
+
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and the interrupt scan reads Combat.Threats for exactly that reason. Weave
+            // discipline still applies while attacking; with no attackable target the GCD is idle, so
+            // the weave check alone would be false exactly when the interrupt is needed most.
+            if ((!canAttack || ViperRoutine.GlobalCooldown.CanWeave(1)) && await PhysicalDps.Interrupt(ViperSettings.Instance)) return true;
+
+            if (!canAttack)
                 return false;
 
             ViperRoutine.RefreshVars();
@@ -59,7 +67,6 @@ namespace Magitek.Rotations
 
             if (ViperRoutine.GlobalCooldown.CanWeave(1))
             {
-                if (await PhysicalDps.Interrupt(ViperSettings.Instance)) return true;
                 if (await PhysicalDps.SecondWind(ViperSettings.Instance)) return true;
                 if (await PhysicalDps.Bloodbath(ViperSettings.Instance)) return true;
 

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -45,11 +45,16 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(WarriorSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(WarriorSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
+            // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
+            // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
+            // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
+            // resolve at the target's location.
+            //LimitBreak
+            if (Defensive.ForceLimitBreak()) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            //LimitBreak
-            if (Defensive.ForceLimitBreak()) return true;
 
 
             //Utility

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -40,11 +40,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
-            if (await CommonFightLogic.FightLogic_TankDefensive(WarriorSettings.Instance.FightLogicDefensives, WarriorRoutine.DefensiveSpells, WarriorRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(WarriorSettings.Instance.FightLogicPartyShield, Spells.ShakeItOff, true, aura: Auras.ShakeItOff)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(WarriorSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(WarriorSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
-
             // Above the attack check: a tank limit break is party mitigation, aimed at Core.Me rather
             // than the target (Tank.ForceLimitBreak), so an enemy we cannot damage is no reason to
             // withhold it. The DPS limit breaks stay below the guard — those are damage, and they
@@ -52,9 +47,13 @@ namespace Magitek.Rotations
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
+            if (await CommonFightLogic.FightLogic_TankDefensive(WarriorSettings.Instance.FightLogicDefensives, WarriorRoutine.DefensiveSpells, WarriorRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(WarriorSettings.Instance.FightLogicPartyShield, Spells.ShakeItOff, true, aura: Auras.ShakeItOff)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(WarriorSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(WarriorSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
-
 
 
             //Utility

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -77,11 +77,12 @@ namespace Magitek.Rotations
                 if (await Tank.ArmsLength(WarriorSettings.Instance)) return true;
             }
 
+            // Stance first: an enemy immune to our damage still attacks and builds enmity pressure,
+            // so a missing tank stance must be restorable before the attack guard.
+            if (await Buff.Defiance()) return true;
+
             if (!canAttack)
                 return false;
-
-            //Utility
-            if (await Buff.Defiance()) return true;
 
             if (WarriorRoutine.GlobalCooldown.CanWeave())
             {

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -52,19 +52,18 @@ namespace Magitek.Rotations
             if (await CommonFightLogic.FightLogic_Debuff(WarriorSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(WarriorSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
-            if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
-                return false;
+            var canAttack = Core.Me.HasTarget && Core.Me.CurrentTarget.ThoroughCanAttack();
 
-
-            //Utility
-            if (await Buff.Defiance()) return true;
+            // Above the attack guard: an enemy our damage cannot reach can still be casting something
+            // interruptible, and still hurts the party — so interrupts and mitigation run before the
+            // guard. Weave discipline still applies while attacking; with no attackable target the GCD
+            // is idle, so the weave check alone would be false exactly when these are needed most.
+            // Internal order of the mitigation block is unchanged; it now simply precedes the Potion
+            // and damage oGCDs instead of sharing their weave block.
             if (await Tank.Interrupt(WarriorSettings.Instance)) return true;
 
-            if (WarriorRoutine.GlobalCooldown.CanWeave())
+            if (!canAttack || WarriorRoutine.GlobalCooldown.CanWeave())
             {
-                //Potion
-                if (await Buff.UsePotion()) return true;
-
                 //Defensive Buff
                 if (await Defensive.Holmgang()) return true;
                 if (await Healing.Equilibrium()) return true;
@@ -76,6 +75,18 @@ namespace Magitek.Rotations
                 if (await Defensive.ShakeItOff()) return true;
                 if (await Buff.NascentFlash()) return true;
                 if (await Tank.ArmsLength(WarriorSettings.Instance)) return true;
+            }
+
+            if (!canAttack)
+                return false;
+
+            //Utility
+            if (await Buff.Defiance()) return true;
+
+            if (WarriorRoutine.GlobalCooldown.CanWeave())
+            {
+                //Potion
+                if (await Buff.UsePotion()) return true;
 
                 //Cooldowns
                 if (await Buff.InnerRelease()) return true;

--- a/Magitek/Rotations/Warrior.cs
+++ b/Magitek/Rotations/Warrior.cs
@@ -40,16 +40,17 @@ namespace Magitek.Rotations
 
         public static async Task<bool> Combat()
         {
+            if (await CommonFightLogic.FightLogic_TankDefensive(WarriorSettings.Instance.FightLogicDefensives, WarriorRoutine.DefensiveSpells, WarriorRoutine.Defensives)) return true;
+            if (await CommonFightLogic.FightLogic_PartyShield(WarriorSettings.Instance.FightLogicPartyShield, Spells.ShakeItOff, true, aura: Auras.ShakeItOff)) return true;
+            if (await CommonFightLogic.FightLogic_Debuff(WarriorSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
+            if (await CommonFightLogic.FightLogic_Knockback(WarriorSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
+
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
             //LimitBreak
             if (Defensive.ForceLimitBreak()) return true;
 
-            if (await CommonFightLogic.FightLogic_TankDefensive(WarriorSettings.Instance.FightLogicDefensives, WarriorRoutine.DefensiveSpells, WarriorRoutine.Defensives)) return true;
-            if (await CommonFightLogic.FightLogic_PartyShield(WarriorSettings.Instance.FightLogicPartyShield, Spells.ShakeItOff, true, aura: Auras.ShakeItOff)) return true;
-            if (await CommonFightLogic.FightLogic_Debuff(WarriorSettings.Instance.FightLogicReprisal, Spells.Reprisal, true, aura: Auras.Reprisal, range: Spells.Reprisal.Radius)) return true;
-            if (await CommonFightLogic.FightLogic_Knockback(WarriorSettings.Instance.FightLogicKnockback, Spells.ArmsLength, true, aura: Auras.ArmsLength)) return true;
 
             //Utility
             if (await Buff.Defiance()) return true;

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -707,7 +707,7 @@ namespace Magitek.Utilities
         public const int AstralRealignment = 398;
         #endregion
 
-        #region Jeuno: The First Walk — Ark Angels "Hero" / "Villain" duel
+        #region "Hero" / "Villain" duels — Jeuno's Ark Angels and the Occult Crescent
         // Each Ark Angel can be dubbed a Villain, whose tooltip reads "Damage from those who have not been
         // dubbed <X> Hero is nullified". This is the mirror of the Meso Terminal mark: there OUR mark chose
         // which enemy we could hit, here the ENEMY's status dictates which players may hit it. Maps the
@@ -723,11 +723,20 @@ namespace Magitek.Utilities
             VauntedHero = 4196,
             VauntedVillain = 4197;
 
+        // The Occult Crescent's Blue Head and Green Head run the same duel, but the game gives that
+        // encounter its own copies of the Villain statuses while reusing the very same Hero statuses above.
+        // Only two exist because there are only two heads — there is no second Vaunted Villain.
+        public const int
+            EpicVillainOccult = 5400,
+            FatedVillainOccult = 5401;
+
         public static readonly Dictionary<uint, uint> DuelVillainRequiredHeroAura = new Dictionary<uint, uint>
         {
             { EpicVillain, EpicHero },
             { FatedVillain, FatedHero },
             { VauntedVillain, VauntedHero },
+            { EpicVillainOccult, EpicHero },
+            { FatedVillainOccult, FatedHero },
         };
         #endregion
 

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -476,7 +476,8 @@ namespace Magitek.Utilities
             Invincibility6 = 656,
             Invincibility7 = 529,
             Invincibility8 = 325,
-            Invincibility9 = 394;
+            Invincibility9 = 394,
+            Invincibility10 = 4410;
 
         public const int
 
@@ -668,7 +669,87 @@ namespace Magitek.Utilities
             Invincibility6,
             Invincibility7,
             Invincibility8,
-            Invincibility9
+            Invincibility9,
+            Invincibility10
         };
+
+        #region The Meso Terminal — Headsman "Cell Block" / "Guard on Duty" match mechanic
+        // Each of the four Headsmen carries a Guard on Duty α/β/γ/δ status and tethers one player,
+        // marking them with the matching Cell Block letter. While marked, that player can ONLY damage
+        // the Headsman whose Guard on Duty letter matches their Cell Block — "Attacks against other
+        // targets are nullified." MarkMatchDamageableEnemyAura maps the player's Cell Block mark to the
+        // Guard on Duty status an enemy must carry to be damageable by that player. Same-letter pairing;
+        // XIVAPI-confirmed status ids. Consumed by GameObjectExtensions.DamageableByMyMark().
+        public const int
+            CellBlockAlpha = 4542,
+            CellBlockBeta = 4543,
+            CellBlockGamma = 4544,
+            CellBlockDelta = 4545,
+            GuardOnDutyAlpha = 4546,
+            GuardOnDutyBeta = 4547,
+            GuardOnDutyGamma = 4548,
+            GuardOnDutyDelta = 4549;
+
+        public static readonly Dictionary<uint, uint> MarkMatchDamageableEnemyAura = new Dictionary<uint, uint>
+        {
+            { CellBlockAlpha, GuardOnDutyAlpha },
+            { CellBlockBeta, GuardOnDutyBeta },
+            { CellBlockGamma, GuardOnDutyGamma },
+            { CellBlockDelta, GuardOnDutyDelta },
+        };
+        #endregion
+
+        #region The Labyrinth of the Ancients — Astral Realignment gate
+        // Player buff whose tooltip reads "Existentially aligned to the astral realm. Damage dealt is
+        // reduced, but can attack ghostly beings." Without it, damage against Thanatos does nothing.
+        // Unlike the Ark Angels duel there is NO status on the target to key off, so the rule that
+        // consumes this (GameObjectExtensions.DamageableGivenMyBuffs) matches on zone + enemy name.
+        public const int AstralRealignment = 398;
+        #endregion
+
+        #region Jeuno: The First Walk — Ark Angels "Hero" / "Villain" duel
+        // Each Ark Angel can be dubbed a Villain, whose tooltip reads "Damage from those who have not been
+        // dubbed <X> Hero is nullified". This is the mirror of the Meso Terminal mark: there OUR mark chose
+        // which enemy we could hit, here the ENEMY's status dictates which players may hit it. Maps the
+        // Villain status an enemy carries to the Hero status a player needs to damage it.
+        //
+        // Note 4198 (Mighty Strikes) sits in the middle of this id range but is unrelated — it is an Ark
+        // Angel self-buff that crits its melee attacks, and must NOT be treated as a duel status.
+        public const int
+            EpicHero = 4192,
+            EpicVillain = 4193,
+            FatedHero = 4194,
+            FatedVillain = 4195,
+            VauntedHero = 4196,
+            VauntedVillain = 4197;
+
+        public static readonly Dictionary<uint, uint> DuelVillainRequiredHeroAura = new Dictionary<uint, uint>
+        {
+            { EpicVillain, EpicHero },
+            { FatedVillain, FatedHero },
+            { VauntedVillain, VauntedHero },
+        };
+        #endregion
+
+        #region Damage-type immunity (e.g. The Void Ark — Sawtooth / Irminsul)
+        // Some encounters hand a boss immunity to one damage type instead of full invulnerability, so
+        // whether we can hurt it depends on our job. In The Void Ark the pair take one each at random,
+        // which is why this keys off the status rather than the enemy.
+        //
+        // "Magic Resistance" — invulnerable to magic attacks: blocks healers and casters.
+        // "Ranged Resistance" — invulnerable to ranged attacks: blocks PHYSICAL ranged only. Magical
+        // ranged still lands, so casters must NOT be excluded by it.
+        // Consumed by GameObjectExtensions.DamageableByMyDamageType().
+        public static readonly uint[] MagicImmunity =
+        {
+            942,  // Magic Resistance
+            3621, // Magic Resistance (same status, reused by later content)
+        };
+
+        public static readonly uint[] RangedImmunity =
+        {
+            941, // Ranged Resistance
+        };
+        #endregion
     }
 }

--- a/Magitek/Utilities/Combat.cs
+++ b/Magitek/Utilities/Combat.cs
@@ -11,6 +11,12 @@ namespace Magitek.Utilities
     internal static class Combat
     {
         public static readonly List<BattleCharacter> Enemies = new List<BattleCharacter>();
+
+        // Everything hostile and alive nearby, including what we cannot currently damage — a Villain we lack
+        // the matching Hero buff for, a boss immune to our damage type. Enemies is the list to attack;
+        // this is the list to defend against, and fight logic reads it so a mechanic still gets answered
+        // when the caster happens to be one we are locked out of hurting.
+        public static readonly List<BattleCharacter> Threats = new List<BattleCharacter>();
         public static readonly Stopwatch CombatTime = new Stopwatch();
         public static readonly Stopwatch OutOfCombatTime = new Stopwatch();
         public static readonly Stopwatch MovingInCombatTime = new Stopwatch();

--- a/Magitek/Utilities/Combat.cs
+++ b/Magitek/Utilities/Combat.cs
@@ -27,7 +27,10 @@ namespace Magitek.Utilities
 
         public static bool IsBoss()
         {
-            return Core.Me.CurrentTarget.IsBoss() || (Globals.InActiveDuty && Enemies.Count == 1);
+            // Threats, not Enemies, for the single-enemy fallback: "alone with one enemy in a duty"
+            // is about what is ALIVE, not what we can currently damage. Counting the damageable
+            // subset made the one matching Headsman in a Cell Block pull read as a boss.
+            return Core.Me.CurrentTarget.IsBoss() || (Globals.InActiveDuty && Threats.Count == 1);
         }
 
         public static bool IsMoving(GameObject target)

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -306,6 +306,21 @@ namespace Magitek.Utilities
             return false;
         }
 
+        /// <summary>
+        /// The catalogued enemy whose cast the detectors matched, while it is still casting — or null.
+        /// <para>
+        /// Reactions that debuff the CASTER (Feint, Addle, Dismantle, Reprisal) need this rather than
+        /// Core.Me.CurrentTarget: the two are frequently different enemies, and a mitigation debuff applied
+        /// to whatever we happen to be hitting does nothing about the mechanic we are reacting to.
+        /// </para>
+        /// </summary>
+        public static BattleCharacter DetectedCaster()
+        {
+            var (_, _, enemy) = GetEnemyLogicAndEnemy();
+
+            return enemy != null && enemy.IsValid && enemy.IsCasting ? enemy : null;
+        }
+
         public static bool EnemyHasAnyKnockbackLogic()
         {
             if (ZoneHasFightLogic())

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -375,9 +375,11 @@ namespace Magitek.Utilities
             if (encounter == null)
                 return SetAndReturn();
 
-            enemyLogic = encounter.Enemies.FirstOrDefault(x => Combat.Enemies.Any(y => x.Id == y.NpcId || x.Name == y.EnglishName), encounter.Enemies.FirstOrDefault());
+            // Combat.Threats, not Combat.Enemies: the latter drops anything our damage cannot reach, and a
+            // boss we are immune-locked out of hurting still casts tank busters and raidwides at us.
+            enemyLogic = encounter.Enemies.FirstOrDefault(x => Combat.Threats.Any(y => x.Id == y.NpcId || x.Name == y.EnglishName), encounter.Enemies.FirstOrDefault());
 
-            enemy = Combat.Enemies.FirstOrDefault(y => enemyLogic.Id == y.NpcId || enemyLogic.Name == y.EnglishName, Combat.Enemies.FirstOrDefault());
+            enemy = Combat.Threats.FirstOrDefault(y => enemyLogic.Id == y.NpcId || enemyLogic.Name == y.EnglishName, Combat.Threats.FirstOrDefault());
 
             if (enemy != null && enemy.IsCasting && !FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
                 FlHandledCastingSpellId.Clear();

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -392,9 +392,44 @@ namespace Magitek.Utilities
 
             // Combat.Threats, not Combat.Enemies: the latter drops anything our damage cannot reach, and a
             // boss we are immune-locked out of hurting still casts tank busters and raidwides at us.
-            enemyLogic = encounter.Enemies.FirstOrDefault(x => Combat.Threats.Any(y => x.Id == y.NpcId || x.Name == y.EnglishName), encounter.Enemies.FirstOrDefault());
+            //
+            // Prefer a catalogued enemy that is CASTING one of its own catalogued mechanics right now.
+            // With several catalogued enemies alive at once (Jeuno's Ark Angel phase), binding the first
+            // list entry made every other boss's mechanics invisible for the whole fight.
+            foreach (var candidateLogic in encounter.Enemies)
+            {
+                foreach (var threat in Combat.Threats)
+                {
+                    if (candidateLogic.Id != threat.NpcId && candidateLogic.Name != threat.EnglishName)
+                        continue;
 
-            enemy = Combat.Threats.FirstOrDefault(y => enemyLogic.Id == y.NpcId || enemyLogic.Name == y.EnglishName, Combat.Threats.FirstOrDefault());
+                    if (!threat.IsCasting || FlHandledCastingSpellId.Contains(threat.CastingSpellId))
+                        continue;
+
+                    var castId = threat.CastingSpellId;
+                    if ((candidateLogic.TankBusters != null && candidateLogic.TankBusters.Contains(castId))
+                        || (candidateLogic.SharedTankBusters != null && candidateLogic.SharedTankBusters.Contains(castId))
+                        || (candidateLogic.Aoes != null && candidateLogic.Aoes.Contains(castId))
+                        || (candidateLogic.BigAoes != null && candidateLogic.BigAoes.Contains(castId))
+                        || (candidateLogic.Knockbacks != null && candidateLogic.Knockbacks.Contains(castId)))
+                    {
+                        enemyLogic = candidateLogic;
+                        enemy = threat;
+                        break;
+                    }
+                }
+
+                if (enemy != null)
+                    break;
+            }
+
+            // Nothing catalogued is being cast right now: fall back to the original selection.
+            if (enemy == null)
+            {
+                enemyLogic = encounter.Enemies.FirstOrDefault(x => Combat.Threats.Any(y => x.Id == y.NpcId || x.Name == y.EnglishName), encounter.Enemies.FirstOrDefault());
+
+                enemy = Combat.Threats.FirstOrDefault(y => enemyLogic.Id == y.NpcId || enemyLogic.Name == y.EnglishName, Combat.Threats.FirstOrDefault());
+            }
 
             if (enemy != null && enemy.IsCasting && !FlHandledCastingSpellId.Contains(enemy.CastingSpellId))
                 FlHandledCastingSpellId.Clear();

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -133,11 +133,17 @@ namespace Magitek.Utilities
             }
 
             Combat.Enemies.Clear();
+            Combat.Threats.Clear();
 
             foreach (var unit in _enemyCache)
             {
-                if (!unit.ValidAttackUnit())
+                if (!unit.ValidThreatUnit())
                     continue;
+
+                // Recorded before the immunity filter below. Fight logic reacts to what an enemy CASTS, so it
+                // has to keep seeing a boss we cannot damage — otherwise the one mechanic we most need to
+                // mitigate becomes invisible precisely because we are locked out of hurting its caster.
+                Combat.Threats.Add(unit);
 
                 if (!unit.NotInvulnerable())
                     continue;

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -252,7 +252,7 @@ namespace Magitek.Utilities
 
             Debug.Instance.Enemies = new ObservableCollection<EnemyInfo>(EnemyInfos);
 
-            StunTracker.Update(Combat.Enemies);
+            StunTracker.Update(Combat.Threats);
 
             if (Core.Me.InCombat) mWasInCombat = true;
             if (!Core.Me.InCombat && mWasInCombat)

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -145,12 +145,9 @@ namespace Magitek.Utilities
                 // mitigate becomes invisible precisely because we are locked out of hurting its caster.
                 Combat.Threats.Add(unit);
 
-                if (!unit.NotInvulnerable())
-                    continue;
-
-                if (!unit.IsTargetable)
-                    continue;
-
+                // Recorded for every live threat, before the filters below. These are diagnostic
+                // histories, not targeting: an enemy we cannot damage is exactly the one a user
+                // debugging a fight wants a cast and aura trail for.
                 if (BaseSettings.Instance.EnemySpellCastHistory)
                 {
                     UpdateEnemyCastedSpells(unit);
@@ -165,6 +162,12 @@ namespace Magitek.Utilities
                 {
                     UpdateEnemyTargetHistory(unit);
                 }
+
+                if (!unit.NotInvulnerable())
+                    continue;
+
+                if (!unit.IsTargetable)
+                    continue;
 
                 Combat.Enemies.Add(unit);
 


### PR DESCRIPTION
Rotations check attack validity before casting straight at the current target, so every immunity rule needs to apply there rather than only the mark-matching one. That split — enemies we can hurt versus enemies that merely threaten us — runs through the whole set.

- Attack validity now chains the full invulnerability check: a boss immune to our damage type, dubbed against us, or unreachable without a buff stops the rotation instead of soaking wasted damage — for every role, not just the main attack path
- Defensive play no longer switches off against those same enemies: mitigation, tank buster responses, interrupts, stuns, self-heals and shield support keep working against enemies that threaten us even when our damage cannot reach them
- Fight logic reacts to whichever enemy is casting a catalogued mechanic rather than only the current target, and aims Feint, Addle and Reprisal at that caster
- Forced limit breaks fire first, are never consumed by a failed attempt, and are refused with nothing targeted — for every role
- Job protections: Dancer finishes the dance before answering a mechanic, Paladin's Passage of Arms and Ninja's mudra chains are no longer broken by reactions, and Blue Mage goes straight to physical attacks against magic-immune enemies
- Occult Crescent: Arbatel's forbidden Pages are never attacked, Occult Dispel still works against enemies our damage cannot reach, and Hero engagement targeting no longer swaps to the wrong enemy

Tested in game across Occult Crescent field content and Forked Tower sessions — the Threats-versus-Enemies split has been running live through multiple critical engagements.