### PR TITLE
FightLogic - Turn away from gaze attacks and stop acting when a mechanic punishes it

### DIFF
--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -35,7 +35,10 @@ namespace Magitek.Extensions
             if (!GameSettingsManager.FaceTargetOnAction && BaseSettings.Instance.AssumeFaceTargetOnAction)
                 GameSettingsManager.FaceTargetOnAction = true;
 
-            if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving)
+            // FightLogic.GazeHoldActive: a gaze reaction is steering our facing, so don't snap back to the
+            // target. Note this auto-face only runs while stationary, which is why a gaze turn used to
+            // survive on the move and get undone standing still.
+            if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving && !FightLogic.GazeHoldActive)
                 Core.Me.Face(target);
 
             return await DoPvPCombo(spell, spellPvpCombo, target);
@@ -101,7 +104,10 @@ namespace Magitek.Extensions
             if (!GameSettingsManager.FaceTargetOnAction && BaseSettings.Instance.AssumeFaceTargetOnAction)
                 GameSettingsManager.FaceTargetOnAction = true;
 
-            if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving)
+            // FightLogic.GazeHoldActive: a gaze reaction is steering our facing, so don't snap back to the
+            // target. Note this auto-face only runs while stationary, which is why a gaze turn used to
+            // survive on the move and get undone standing still.
+            if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving && !FightLogic.GazeHoldActive)
                 Core.Me.Face(target);
 
             return await DoAction(spell, target, callback: callback);
@@ -125,7 +131,10 @@ namespace Magitek.Extensions
             if (!GameSettingsManager.FaceTargetOnAction && BaseSettings.Instance.AssumeFaceTargetOnAction)
                 GameSettingsManager.FaceTargetOnAction = true;
 
-            if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving)
+            // FightLogic.GazeHoldActive: a gaze reaction is steering our facing, so don't snap back to the
+            // target. Note this auto-face only runs while stationary, which is why a gaze turn used to
+            // survive on the move and get undone standing still.
+            if (BotManager.Current.IsAutonomous && !GameSettingsManager.FaceTargetOnAction && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing) && !MovementManager.IsMoving && !FightLogic.GazeHoldActive)
                 Core.Me.Face(target);
 
             return await DoAction(spell, target, aura, needAura, useRefreshTime, refreshTime, auraTarget: auraTarget, callback: callback);
@@ -237,7 +246,10 @@ namespace Magitek.Extensions
                 // https://github.com/Exmortem/MagitekRoutine/pull/396
             }
 
-            return Core.Me.HasAura(Auras.Swiftcast) || !MovementManager.IsMoving || spell.AdjustedCastTime <= TimeSpan.Zero;
+            // Dualcast (RDM) makes the next cast instant just like Swiftcast, so it's castable while
+            // moving. The gate historically only whitelisted Swiftcast, which silently blocked
+            // Dualcast-primed casts on the move (e.g. Heal.Vercure's own Dualcast-while-moving path).
+            return Core.Me.HasAura(Auras.Swiftcast) || Core.Me.HasAura(Auras.Dualcast) || !MovementManager.IsMoving || spell.AdjustedCastTime <= TimeSpan.Zero;
         }
 
         public static bool CanCast(this SpellData spell, GameObject target)

--- a/Magitek/Logic/BlueMage/Aoe.cs
+++ b/Magitek/Logic/BlueMage/Aoe.cs
@@ -40,6 +40,11 @@ namespace Magitek.Logic.BlueMage
             if (!BlueMageSettings.Instance.UseJKick)
                 return false;
 
+            // J Kick leaps to the target — Quasar, which shares its recast, does not. Gate the one that
+            // actually moves us.
+            if (!Movement.CanUseGapCloser())
+                return false;
+
             if (Utilities.Routines.BlueMage.IsSurpanakhaInProgress)
                 return false;
 

--- a/Magitek/Logic/Ninja/SingleTarget.cs
+++ b/Magitek/Logic/Ninja/SingleTarget.cs
@@ -129,6 +129,11 @@ namespace Magitek.Logic.Ninja
             if (!NinjaSettings.Instance.UseForkedRaiju)
                 return false;
 
+            // Forked Raiju rushes the target from up to 20y; Fleeting Raiju is the stationary half of the
+            // pair. Only this one needs the movement gate.
+            if (!Movement.CanUseGapCloser())
+                return false;
+
             if (!Spells.ForkedRaiju.IsKnown())
                 return false;
 

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -211,6 +211,14 @@ namespace Magitek.Logic.Roles
 
             StopInFlightCast();
 
+            // Consuming the pulse stops the routine ISSUING actions, but auto-attacks keep swinging on their
+            // own — and Pyretic is "damage is taken with every action", weapon swings included. RebornBuddy
+            // exposes no way to stop auto-attack directly, so turn away instead: the game only swings at what
+            // we are facing. Preferred over dropping the target, which would leave the rotation with nothing
+            // to resume on. Re-asserted every pulse the debuff is up, and normal combat re-faces once it ends.
+            if (Core.Me.HasTarget && Core.Me.CurrentTarget.CanAttack)
+                FightLogic.FaceForGaze(FightLogic.GazeDirection.Away, Core.Me.CurrentTarget);
+
             if (BaseSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo($"[ActionAware] Holding — {mechanic.Name} is up; not casting until it expires.");
 

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -194,7 +194,7 @@ namespace Magitek.Logic.Roles
             // Acceleration Bomb. Best-effort: a botbase actively pathing may re-issue movement next tick.
             if (mechanic.PunishesMovement)
             {
-                if (MovementManager.IsMoving)
+                if (MovementManager.IsMoving && Navigator.PlayerMover != null)
                     Navigator.PlayerMover.MoveStop();
 
                 // Stopping alone is not enough: the rest of the pulse would navigate straight back out
@@ -315,9 +315,15 @@ namespace Magitek.Logic.Roles
 
         private static Task<bool> Hold(FightLogic.GazeDirection direction, GameObject source, string via, int graceMs)
         {
+            if (source == null || !source.IsValid || Core.Me == null)
+                return Task.FromResult(false);
+
             // Movement beats SetFacing, so a navigator still driving us towards something would undo the
             // turn every frame and leave us looking the wrong way for the whole gaze. Stop it first.
-            if (MovementManager.IsMoving)
+            //
+            // PlayerMover is null whenever RebornBuddy has no navigation provider loaded — which happens in
+            // the Occult Crescent, and threw a NullReferenceException on every single gaze there.
+            if (MovementManager.IsMoving && Navigator.PlayerMover != null)
                 Navigator.PlayerMover.MoveStop();
 
             StopInFlightCast();

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -1,4 +1,6 @@
 ﻿using ff14bot;
+using ff14bot.Managers;
+using ff14bot.Navigation;
 using ff14bot.Objects;
 using Magitek.Extensions;
 using Magitek.Models.Account;
@@ -164,6 +166,126 @@ namespace Magitek.Logic.Roles
                 return await FightLogic.DoAndBuffer(spell.Cast(Core.Me));
             }
             return false;
+        }
+
+        // Action-aware mechanics (Pyretic, Acceleration Bomb): a debuff on the player that detonates if we
+        // act or move while it's up. Unlike the other reactions this is player-status driven and NOT zone-
+        // gated, and instead of casting something it PAUSES the routine — returning true consumes the pulse
+        // so no GCD/oGCD fires until the debuff falls off. That's the "stop casting with the aura up" fix.
+        public static Task<bool> FightLogic_ActionState(int expiryLeadMs = 2000)
+        {
+            // This one is not zone-gated, so unlike every other reaction it never passed through
+            // ZoneHasFightLogic() and so ignored the master switch. Turning fight logic off has to turn
+            // this off too, or "Enable Fight Logic" does not mean what it says.
+            if (!BaseSettings.Instance.UseFightLogic || !BaseSettings.Instance.FightLogicActionAwareness)
+                return Task.FromResult(false);
+
+            var mechanic = FightLogic.PlayerActionPunishAura(out var msRemaining);
+            if (mechanic == null)
+                return Task.FromResult(false);
+
+            // Snapshot mechanics only care what we're doing at the moment they fall off, so keep playing
+            // until the window closes instead of surrendering the debuff's whole duration — Buyer's Remorse
+            // sits for 8s, and freezing for all of it would cost far more than the mechanic does.
+            if (mechanic.ChecksOnExpiry && msRemaining > expiryLeadMs)
+                return Task.FromResult(false);
+
+            // Halt routine-driven movement — the usual killer for movement-punish mechanics like
+            // Acceleration Bomb. Best-effort: a botbase actively pathing may re-issue movement next tick.
+            if (mechanic.PunishesMovement && MovementManager.IsMoving)
+                Navigator.PlayerMover.MoveStop();
+
+            // A mechanic that only objects to movement has no quarrel with casting, so there is nothing
+            // to gain by going quiet for it. Acceleration Bomb is the common case: stop moving, then let
+            // the rotation carry on rather than surrendering every action in the window for nothing.
+            if (!mechanic.PunishesActions)
+                return Task.FromResult(false);
+
+            StopInFlightCast();
+
+            if (BaseSettings.Instance.DebugFightLogic)
+                Logger.WriteInfo($"[ActionAware] Holding — {mechanic.Name} is up; not casting until it expires.");
+
+            return Task.FromResult(true); // consume the pulse: cast nothing
+        }
+
+        // Gaze mechanics (look away / look toward): turn away from — or toward — the caster and hold.
+        // Returning true consumes the pulse so the routine doesn't fire an action and snap us back to
+        // face the boss. Catalogued per encounter and NOT throttled, so facing is re-asserted the whole
+        // cast; once the cast ends detection returns None and normal combat re-faces the boss ("look back").
+        public static Task<bool> FightLogic_Gaze(bool useGaze, int castTimeRemainingMs = 3000, int graceMs = 800, int markerTurnDelayMs = 2500)
+        {
+            if (!useGaze)
+                return Task.FromResult(false);
+
+            if (!FightLogic.ZoneHasFightLogic() || !FightLogic.EnemyHasAnyGazeLogic())
+                return Task.FromResult(false);
+
+            var direction = FightLogic.EnemyIsCastingGaze(out var caster);
+
+            if (direction != FightLogic.GazeDirection.None && caster != null)
+            {
+                var remaining = caster.SpellCastInfo.RemainingCastTime.TotalMilliseconds;
+
+                if (BaseSettings.Instance.DebugFightLogic)
+                    Logger.WriteInfo($"[Gaze Detected] {caster.Name} casting {caster.CastingSpellId} — {direction}, {remaining:F0}ms left.");
+
+                // Turn late. Holding through an entire gaze cast would bleed a lot of uptime (the long
+                // variants run ~8s, and they arrive in waves), and SetFacing is instant so there's no reason
+                // to commit early. Take over only for the last few seconds — wide enough to span a GCD, so a
+                // weaponskill can't fire mid-hold and auto-face us back into the gaze.
+                if (remaining > castTimeRemainingMs)
+                    return Task.FromResult(false);
+
+                return Hold(direction, caster, "cast", graceMs);
+            }
+
+            // Head-marker gazes carry no cast bar, so there is no countdown to turn late against. Turning
+            // the moment the marker lands would surrender its entire lifetime, and we cannot attack a boss
+            // we are facing away from, so that is dead time. Measure the marker's age instead and stay on
+            // target until it has been up a while — the turn itself is instant, so a late one still lands.
+            var markerDirection = FightLogic.GazeLockOnActive(out var markerSource, out var markerId);
+
+            if (markerDirection != FightLogic.GazeDirection.None && markerSource != null)
+            {
+                if (FightLogic.GazeMarkerAgeMs(markerId) < markerTurnDelayMs)
+                    return Task.FromResult(false); // keep attacking; turn shortly
+
+                return Hold(markerDirection, markerSource, "marker", graceMs);
+            }
+
+            // The gaze is no longer detectable but its snapshot may not have landed yet — keep the facing
+            // (and the auto-face suppression) alive through the grace window rather than releasing on the
+            // exact frame the cast ends.
+            return Task.FromResult(FightLogic.ReassertGazeHold());
+        }
+
+        /// <summary>
+        /// Consuming the pulse stops the NEXT action, but a cast already under way still completes — and
+        /// completing it is precisely what these mechanics punish, whether by counting as an action or by
+        /// spinning us back to face the boss. Cancel it rather than watch it land.
+        /// </summary>
+        private static void StopInFlightCast()
+        {
+            if (Core.Me.IsCasting)
+                ActionManager.StopCasting();
+        }
+
+        private static Task<bool> Hold(FightLogic.GazeDirection direction, GameObject source, string via, int graceMs)
+        {
+            // Movement beats SetFacing, so a navigator still driving us towards something would undo the
+            // turn every frame and leave us looking the wrong way for the whole gaze. Stop it first.
+            if (MovementManager.IsMoving)
+                Navigator.PlayerMover.MoveStop();
+
+            StopInFlightCast();
+            FightLogic.FaceForGaze(direction, source);
+            FightLogic.LatchGazeHold(direction, source, graceMs);
+
+            if (BaseSettings.Instance.DebugFightLogic)
+                Logger.WriteInfo($"[Gaze Response] Facing {(direction == FightLogic.GazeDirection.Away ? "away from" : "toward")} {source.Name} ({via}).");
+
+            return Task.FromResult(true); // hold: cast nothing so we stay oriented
         }
     }
 }

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -253,6 +253,24 @@ namespace Magitek.Logic.Roles
                 if (remaining > castTimeRemainingMs)
                     return Task.FromResult(false);
 
+                // A gaze's snapshot lands a moment AFTER its cast bar ends — that gap is what the grace
+                // window exists to cover. Kefka's statues alternate their demand and their casts overlap, so
+                // the instant the first one ends the second is already detected, wanting the opposite
+                // heading. Obeying it straight away turns us into the first gaze's snapshot and eats it.
+                // Sit out the remainder of the latch instead; the new gaze still has its own cast left to
+                // run and SetFacing is instant, so the later turn lands just as well.
+                if (FightLogic.GazeHoldDirection != FightLogic.GazeDirection.None
+                    && FightLogic.GazeHoldDirection != direction)
+                {
+                    if (FightLogic.ReassertGazeHold())
+                    {
+                        if (BaseSettings.Instance.DebugFightLogic)
+                            Logger.WriteInfo($"[Gaze Hold] Keeping {FightLogic.GazeHoldDirection} through its grace window; {caster.Name} wants {direction}.");
+
+                        return Task.FromResult(true);
+                    }
+                }
+
                 return Hold(direction, caster, "cast", graceMs);
             }
 

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -182,7 +182,12 @@ namespace Magitek.Logic.Roles
 
             var mechanic = FightLogic.PlayerActionPunishAura(out var msRemaining);
             if (mechanic == null)
+            {
+                // Nothing punishing us any more — drop the hold rather than letting the last pulse's
+                // one-second re-arm keep navigation and gap closers parked after the fact.
+                FightLogic.ReleaseMovementHold();
                 return Task.FromResult(false);
+            }
 
             // Snapshot mechanics only care what we're doing at the moment they fall off, so keep playing
             // until the window closes instead of surrendering the debuff's whole duration — Buyer's Remorse

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -275,8 +275,16 @@ namespace Magitek.Logic.Roles
         /// </summary>
         private static void StopInFlightCast()
         {
-            if (Core.Me.IsCasting)
-                ActionManager.StopCasting();
+            if (!Core.Me.IsCasting)
+                return;
+
+            ActionManager.StopCasting();
+
+            // Casting.CancelCast stops the stopwatch alongside StopCasting, and for good reason:
+            // CheckForSuccessfulCast branches on CastingTime.IsRunning. Leaving it running means the cast we
+            // just cancelled is later measured as though it had completed, and its elapsed time compared
+            // against the expected duration of a cast that never landed.
+            Casting.CastingTime.Stop();
         }
 
         private static Task<bool> Hold(FightLogic.GazeDirection direction, GameObject source, string via, int graceMs)

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -192,8 +192,16 @@ namespace Magitek.Logic.Roles
 
             // Halt routine-driven movement — the usual killer for movement-punish mechanics like
             // Acceleration Bomb. Best-effort: a botbase actively pathing may re-issue movement next tick.
-            if (mechanic.PunishesMovement && MovementManager.IsMoving)
-                Navigator.PlayerMover.MoveStop();
+            if (mechanic.PunishesMovement)
+            {
+                if (MovementManager.IsMoving)
+                    Navigator.PlayerMover.MoveStop();
+
+                // Stopping alone is not enough: the rest of the pulse would navigate straight back out
+                // again. Park navigation for a moment so standing still actually sticks. Refreshed every
+                // pulse the mechanic is up, so it lapses on its own the instant it is not.
+                FightLogic.HoldMovement(1000);
+            }
 
             // A mechanic that only objects to movement has no quarrel with casting, so there is nothing
             // to gain by going quiet for it. Acceleration Bomb is the common case: stop moving, then let

--- a/Magitek/Logic/Warrior/Aoe.cs
+++ b/Magitek/Logic/Warrior/Aoe.cs
@@ -121,6 +121,13 @@ namespace Magitek.Logic.Warrior
             if (!WarriorSettings.Instance.UsePrimalRend)
                 return false;
 
+            // Primal Rend jumps to the target, so it is a gap closer in everything but name and has to
+            // answer to the same gate — otherwise a movement-punishing mechanic parks navigation and this
+            // moves the character anyway. UsePrimalRendWhenNotMoving below is a separate, opt-in DPS
+            // preference reading MovementManager; it is not a substitute for this.
+            if (!Movement.CanUseGapCloser())
+                return false;
+
             if (!Core.Me.HasAura(Auras.PrimalRendReady))
                 return false;
 

--- a/Magitek/Models/Account/BaseSettings.cs
+++ b/Magitek/Models/Account/BaseSettings.cs
@@ -140,6 +140,14 @@ namespace Magitek.Models.Account
         public bool UseFightLogic { get; set; }
 
         [Setting]
+        [DefaultValue(false)]
+        public bool FightLogicActionAwareness { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool FightLogicGaze { get; set; }
+
+        [Setting]
         [DefaultValue(20.0f)]
         public float FightLogicResponseDelay { get; set; }
 
@@ -400,6 +408,9 @@ namespace Magitek.Models.Account
         [Setting]
         [DefaultValue(true)]
         public bool EnableAoe { get; set; }
+
+
+
         #endregion
 
         #region PvP

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -4782,6 +4782,24 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pause for action/movement mechanics (Pyretic, Acceleration Bomb).
+        /// </summary>
+        public static string Generic_FightLogic_ActionAwareness {
+            get {
+                return ResourceManager.GetString("Generic_FightLogic_ActionAwareness", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Turn away from / toward gaze attacks.
+        /// </summary>
+        public static string Generic_FightLogic_Gaze {
+            get {
+                return ResourceManager.GetString("Generic_FightLogic_Gaze", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fight Logic.
         /// </summary>
         public static string Generic_Fight_Logic {

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4548,6 +4548,12 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Generic_FightLogic" xml:space="preserve">
     <value>FightLogic</value>
   </data>
+  <data name="Generic_FightLogic_ActionAwareness" xml:space="preserve">
+    <value>Pause for action/movement mechanics (Pyretic, Acceleration Bomb)</value>
+  </data>
+  <data name="Generic_FightLogic_Gaze" xml:space="preserve">
+    <value>Turn away from / toward gaze attacks</value>
+  </data>
   <data name="Generic_Pvp" xml:space="preserve">
     <value>Pvp</value>
   </data>
@@ -5372,11 +5378,5 @@ Does not work if Lightspeed is disabled.</value>
   </data>
   <data name="VariantDungeon_Text_VariantEagleEyeShotDescription" xml:space="preserve">
     <value>Ranged attack (25y). 60s cooldown. Available to all roles.</value>
-  </data>
-  <data name="Generic_FightLogic_ActionAwareness" xml:space="preserve">
-    <value>Pause for action/movement mechanics (Pyretic, Acceleration Bomb)</value>
-  </data>
-  <data name="Generic_FightLogic_Gaze" xml:space="preserve">
-    <value>Turn away from / toward gaze attacks</value>
   </data>
 </root>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -5373,4 +5373,10 @@ Does not work if Lightspeed is disabled.</value>
   <data name="VariantDungeon_Text_VariantEagleEyeShotDescription" xml:space="preserve">
     <value>Ranged attack (25y). 60s cooldown. Available to all roles.</value>
   </data>
+  <data name="Generic_FightLogic_ActionAwareness" xml:space="preserve">
+    <value>Pause for action/movement mechanics (Pyretic, Acceleration Bomb)</value>
+  </data>
+  <data name="Generic_FightLogic_Gaze" xml:space="preserve">
+    <value>Turn away from / toward gaze attacks</value>
+  </data>
 </root>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4548,6 +4548,12 @@
   <data name="Generic_FightLogic" xml:space="preserve">
     <value>战斗逻辑</value>
   </data>
+  <data name="Generic_FightLogic_ActionAwareness" xml:space="preserve">
+    <value>行动/移动惩罚机制时暂停（热病、加速度炸弹）</value>
+  </data>
+  <data name="Generic_FightLogic_Gaze" xml:space="preserve">
+    <value>视线攻击时转身背对/面向</value>
+  </data>
   <data name="Generic_Pvp" xml:space="preserve">
     <value>PVP</value>
   </data>
@@ -5600,11 +5606,5 @@
   </data>
   <data name="VariantDungeon_Text_VariantEagleEyeShotDescription" xml:space="preserve">
     <value>远程攻击（25 码）。60 秒冷却。所有职能可用。</value>
-  </data>
-  <data name="Generic_FightLogic_ActionAwareness" xml:space="preserve">
-    <value>行动/移动惩罚机制时暂停（热病、加速度炸弹）</value>
-  </data>
-  <data name="Generic_FightLogic_Gaze" xml:space="preserve">
-    <value>视线攻击时转身背对/面向</value>
   </data>
 </root>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -5601,4 +5601,10 @@
   <data name="VariantDungeon_Text_VariantEagleEyeShotDescription" xml:space="preserve">
     <value>远程攻击（25 码）。60 秒冷却。所有职能可用。</value>
   </data>
+  <data name="Generic_FightLogic_ActionAwareness" xml:space="preserve">
+    <value>行动/移动惩罚机制时暂停（热病、加速度炸弹）</value>
+  </data>
+  <data name="Generic_FightLogic_Gaze" xml:space="preserve">
+    <value>视线攻击时转身背对/面向</value>
+  </data>
 </root>

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -87,8 +87,16 @@ namespace Magitek.Utilities
 
         private static readonly Dictionary<uint, ActionPunishMechanic> ActionPunishAuras = new Dictionary<uint, ActionPunishMechanic>
         {
+            // Every id below was taken from the game's own Status sheet by name, not from encounters we
+            // happened to meet — each Pyretic row reads "Fire-aspected damage is taken with every action" and
+            // each Acceleration Bomb row "any movement when effect wears off will result in detonation", so
+            // the whole set is the same two mechanics. Waiting for the debug logger to surface them would
+            // have left the newer copies — which is most current content — silently unhandled.
             { 639, Pyretic }, { 960, Pyretic }, { 1049, Pyretic }, { 1133, Pyretic },
-            { 1072, AccelerationBomb }, { 1384, AccelerationBomb },
+            { 1599, Pyretic }, { 3522, Pyretic },
+            { 1072, AccelerationBomb }, { 1384, AccelerationBomb }, { 2657, AccelerationBomb },
+            { 3793, AccelerationBomb }, { 3802, AccelerationBomb }, { 4144, AccelerationBomb },
+            { 5546, AccelerationBomb },
             { 4342, BuyersRemorse },
             { 5191, MotionTracker },
         };

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -139,42 +139,8 @@ namespace Magitek.Utilities
 
         private static (Encounter, Enemy, BattleCharacter) GetEnemyLogicAndEnemyCached { get; set; }
 
-        private static uint _layeredCastId;
-        private static bool _layeredResponseUsed;
 
-        /// <summary>
-        /// Reserves the one extra response a single mechanic is allowed.
-        /// <para>
-        /// Normally reacting to a cast marks it handled and blocks anything further, so one mechanic gets
-        /// one answer. That is wrong for a heavy raidwide: instant mitigation is off the global cooldown
-        /// while barriers are on it, so a healer should lay one down and still raise the other. Callers
-        /// pass the result to <see cref="DoAndBuffer(Task{bool}, bool)"/> as <c>layered</c>.
-        /// </para>
-        /// <para>
-        /// Strictly one per cast. Without that cap a job with several instant mitigations — White Mage has
-        /// five — would answer one raidwide with all of them over successive pulses, which is the priority
-        /// dump the throttle exists to prevent.
-        /// </para>
-        /// </summary>
-        private static bool TryConsumeLayeredResponse(uint? castId)
-        {
-            if (!castId.HasValue || castId.Value == 0)
-                return false; // lock-on reactions have no cast to budget against
-
-            if (_layeredCastId != castId.Value)
-            {
-                _layeredCastId = castId.Value;
-                _layeredResponseUsed = false;
-            }
-
-            if (_layeredResponseUsed)
-                return false;
-
-            _layeredResponseUsed = true;
-            return true;
-        }
-
-        public static async Task<bool> DoAndBuffer(Task<bool> task, bool layered = false)
+        public static async Task<bool> DoAndBuffer(Task<bool> task)
         {
             var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
@@ -189,13 +155,6 @@ namespace Magitek.Utilities
             // pulse and dump the whole mitigation priority list. Await the cast, then start the 5s
             // throttle on success regardless; only record the handled cast id when we had a casting enemy.
             if (!await task) return false;
-
-            // A layered response deliberately leaves the mechanic open so the next pulse can follow up with
-            // the other half of the mitigation, neither marking the cast handled nor starting the throttle.
-            // The budget is only spent once the cast actually landed, and only one is granted per mechanic,
-            // so a second layered attempt falls through and closes the reaction as normal.
-            if (layered && TryConsumeLayeredResponse(handledCastId))
-                return true;
 
             if (handledCastId.HasValue)
                 FlHandledCastingSpellId.Add(handledCastId.Value);

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -421,7 +421,7 @@ namespace Magitek.Utilities
             920,  // The Bozjan Southern Front
             975,  // Zadnor
             1252, // Occult Crescent: South Horn
-            1346, // Occult Crescent: Northern Horn
+            1346, // Occult Crescent: North Horn
         };
 
         public static bool InFieldOperation()

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -147,8 +147,42 @@ namespace Magitek.Utilities
 
         private static (Encounter, Enemy, BattleCharacter) GetEnemyLogicAndEnemyCached { get; set; }
 
+        private static uint _layeredCastId;
+        private static bool _layeredResponseUsed;
 
-        public static async Task<bool> DoAndBuffer(Task<bool> task)
+        /// <summary>
+        /// Reserves the one extra response a single mechanic is allowed.
+        /// <para>
+        /// Normally reacting to a cast marks it handled and blocks anything further, so one mechanic gets
+        /// one answer. That is wrong for a heavy raidwide: instant mitigation is off the global cooldown
+        /// while barriers are on it, so a healer should lay one down and still raise the other. Callers
+        /// pass the result to <see cref="DoAndBuffer(Task{bool}, bool)"/> as <c>layered</c>.
+        /// </para>
+        /// <para>
+        /// Strictly one per cast. Without that cap a job with several instant mitigations — White Mage has
+        /// five — would answer one raidwide with all of them over successive pulses, which is the priority
+        /// dump the throttle exists to prevent.
+        /// </para>
+        /// </summary>
+        private static bool TryConsumeLayeredResponse(uint? castId)
+        {
+            if (!castId.HasValue || castId.Value == 0)
+                return false; // lock-on reactions have no cast to budget against
+
+            if (_layeredCastId != castId.Value)
+            {
+                _layeredCastId = castId.Value;
+                _layeredResponseUsed = false;
+            }
+
+            if (_layeredResponseUsed)
+                return false;
+
+            _layeredResponseUsed = true;
+            return true;
+        }
+
+        public static async Task<bool> DoAndBuffer(Task<bool> task, bool layered = false)
         {
             var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
@@ -163,6 +197,13 @@ namespace Magitek.Utilities
             // pulse and dump the whole mitigation priority list. Await the cast, then start the 5s
             // throttle on success regardless; only record the handled cast id when we had a casting enemy.
             if (!await task) return false;
+
+            // A layered response deliberately leaves the mechanic open so the next pulse can follow up with
+            // the other half of the mitigation, neither marking the cast handled nor starting the throttle.
+            // The budget is only spent once the cast actually landed, and only one is granted per mechanic,
+            // so a second layered attempt falls through and closes the reaction as normal.
+            if (layered && TryConsumeLayeredResponse(handledCastId))
+                return true;
 
             if (handledCastId.HasValue)
                 FlHandledCastingSpellId.Add(handledCastId.Value);

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -506,14 +506,24 @@ namespace Magitek.Utilities
                 : null;
         }
 
+        // Units a gaze can come from, refreshed once per frame. Four rotation entry points reach the gaze
+        // checks every pulse, and each was walking the whole object table on its own.
+        //
+        // This cannot reuse Group's cached collections or Combat.Enemies: those keep only what we could
+        // attack, and gaze emitters are routinely things we cannot — the Occult Crescent's Accursed Orbs
+        // and O8N/O8S's Graven Image statues are untargetable, and they are exactly what we need to find.
+        // So it filters on validity and range only.
+        private static readonly FrameCachedObject<IEnumerable<BattleCharacter>> _gazeCandidates =
+            new(() => GameObjectManager.GetObjectsOfType<BattleCharacter>()
+                .Where(x => x != null && x.IsValid && Core.Me.Distance(x) <= 50)
+                .ToList());
+
         // The live object matching a catalogued enemy, used to orient against when the gaze is signalled
         // by a head marker rather than by that enemy's own cast.
         private static BattleCharacter FindCataloguedEnemy(Enemy logic)
         {
-            return GameObjectManager.GetObjectsOfType<BattleCharacter>()
-                .FirstOrDefault(x => x != null && x.IsValid
-                    && (logic.Id == x.NpcId || logic.Name == x.EnglishName)
-                    && Core.Me.Distance(x) <= 50);
+            return _gazeCandidates.Value
+                .FirstOrDefault(x => logic.Id == x.NpcId || logic.Name == x.EnglishName);
         }
 
         // Gazes flagged by a head marker instead of a cast (e.g. Shinryu's Cataclysmic Vortex). RB surfaces
@@ -646,12 +656,9 @@ namespace Magitek.Utilities
             var direction = GazeDirection.None;
             var soonest = double.MaxValue;
 
-            foreach (var unit in GameObjectManager.GetObjectsOfType<BattleCharacter>())
+            foreach (var unit in _gazeCandidates.Value)
             {
-                if (unit == null || !unit.IsValid || !unit.IsCasting)
-                    continue;
-
-                if (Core.Me.Distance(unit) > 50)
+                if (!unit.IsCasting)
                     continue;
 
                 var logic = encounter.Enemies.FirstOrDefault(x => x.Id == unit.NpcId || x.Name == unit.EnglishName);

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -1,5 +1,7 @@
-﻿using Clio.Utilities;
+﻿using Clio.Common;
+using Clio.Utilities;
 using ff14bot;
+using ff14bot.Helpers;
 using ff14bot.Managers;
 using ff14bot.Objects;
 using System;
@@ -46,6 +48,77 @@ namespace Magitek.Utilities
         /// </summary>
         public static string CommonAoeLockOnsDisplay => string.Join(", ", CommonAoeLockOns.OrderBy(x => x));
 
+        #region Action-punishing player debuffs (Pyretic / Acceleration Bomb)
+
+        // Some mechanics apply a debuff that detonates if you ACT or MOVE while it's on you. There's no
+        // enemy cast to react to, and they recur across many zones, so this is a flat watch on the
+        // player's own auras — deliberately NOT zone-gated like the enemy-cast catalogues. Several status
+        // IDs map to the same mechanic because each encounter defines its own copy; seed the ones we know
+        // and expand the set as the debug logger surfaces more.
+        public class ActionPunishMechanic
+        {
+            public string Name;
+            public bool PunishesActions;   // casting / weaponskills / abilities set it off (e.g. Pyretic)
+            public bool PunishesMovement;  // moving sets it off (e.g. Acceleration Bomb)
+            public bool ChecksOnExpiry;    // snapshots our state as it falls off rather than punishing all along
+        }
+
+        // Pyretic is the continuous kind: acting or moving at any point while it ticks hurts.
+        private static readonly ActionPunishMechanic Pyretic =
+            new ActionPunishMechanic { Name = "Pyretic", PunishesActions = true, PunishesMovement = true };
+
+        // Detonates on movement as it expires, so there's no reason to stand frozen for its whole duration.
+        private static readonly ActionPunishMechanic AccelerationBomb =
+            new ActionPunishMechanic { Name = "Acceleration Bomb", PunishesActions = false, PunishesMovement = true, ChecksOnExpiry = true };
+
+        // Occult Crescent, Trade Tortoise: "Ill-gotten Goods" (41518) hands the whole raid an 8s Buyer's
+        // Remorse and the state check lands when it falls off, not while it ticks — combat logs show players
+        // attacking straight through the full 8s at untouched HP. Only the Pyretic-flavoured variant (4342)
+        // is listed. The other two waves are deliberately left out because neither is answerable by holding
+        // still: 4343 is frost, which wants the opposite (keep moving), and 4344 is a forced forward march
+        // that's purely about where you're standing. Both are positioning the player owns, not the routine.
+        private static readonly ActionPunishMechanic BuyersRemorse =
+            new ActionPunishMechanic { Name = "Buyer's Remorse", PunishesActions = true, PunishesMovement = true, ChecksOnExpiry = true };
+
+        // The Clyteum: "Under motion-sensing surveillance." Continuous rather than snapshot-on-expiry —
+        // being seen at any point during it is what counts — so we sit still and quiet for the duration.
+        private static readonly ActionPunishMechanic MotionTracker =
+            new ActionPunishMechanic { Name = "Motion Tracker", PunishesActions = true, PunishesMovement = true };
+
+        private static readonly Dictionary<uint, ActionPunishMechanic> ActionPunishAuras = new Dictionary<uint, ActionPunishMechanic>
+        {
+            { 639, Pyretic }, { 960, Pyretic }, { 1049, Pyretic }, { 1133, Pyretic },
+            { 1072, AccelerationBomb }, { 1384, AccelerationBomb },
+            { 4342, BuyersRemorse },
+            { 5191, MotionTracker },
+        };
+
+        // The action-punishing mechanic currently on the player (plus how long it has left), or null if none.
+        // Cheap: one scan of the player's own auras. Intentionally NOT throttled by IsFlReady — we want to
+        // keep suppressing every pulse the debuff is present, not react a single time and move on.
+        public static ActionPunishMechanic PlayerActionPunishAura(out double msRemaining)
+        {
+            msRemaining = 0;
+
+            var me = Core.Me;
+
+            if (me == null)
+                return null;
+
+            foreach (var aura in me.CharacterAuras)
+            {
+                if (!ActionPunishAuras.TryGetValue(aura.Id, out var mechanic))
+                    continue;
+
+                msRemaining = aura.TimespanLeft.TotalMilliseconds;
+                return mechanic;
+            }
+
+            return null;
+        }
+
+        #endregion
+
         private static TimeSpan FlCooldown
         {
             get
@@ -66,16 +139,66 @@ namespace Magitek.Utilities
 
         private static (Encounter, Enemy, BattleCharacter) GetEnemyLogicAndEnemyCached { get; set; }
 
-        public static async Task<bool> DoAndBuffer(Task<bool> task)
+        private static uint _layeredCastId;
+        private static bool _layeredResponseUsed;
+
+        /// <summary>
+        /// Reserves the one extra response a single mechanic is allowed.
+        /// <para>
+        /// Normally reacting to a cast marks it handled and blocks anything further, so one mechanic gets
+        /// one answer. That is wrong for a heavy raidwide: instant mitigation is off the global cooldown
+        /// while barriers are on it, so a healer should lay one down and still raise the other. Callers
+        /// pass the result to <see cref="DoAndBuffer(Task{bool}, bool)"/> as <c>layered</c>.
+        /// </para>
+        /// <para>
+        /// Strictly one per cast. Without that cap a job with several instant mitigations — White Mage has
+        /// five — would answer one raidwide with all of them over successive pulses, which is the priority
+        /// dump the throttle exists to prevent.
+        /// </para>
+        /// </summary>
+        private static bool TryConsumeLayeredResponse(uint? castId)
+        {
+            if (!castId.HasValue || castId.Value == 0)
+                return false; // lock-on reactions have no cast to budget against
+
+            if (_layeredCastId != castId.Value)
+            {
+                _layeredCastId = castId.Value;
+                _layeredResponseUsed = false;
+            }
+
+            if (_layeredResponseUsed)
+                return false;
+
+            _layeredResponseUsed = true;
+            return true;
+        }
+
+        public static async Task<bool> DoAndBuffer(Task<bool> task, bool layered = false)
         {
             var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
-            if (enemy == null)
-                return false;
+            // Snapshot the cast we're reacting to BEFORE awaiting. The caller passes Spell.Cast(...),
+            // which eagerly starts the cast; awaiting it burns the ~0.6s animation lock, during which the
+            // enemy can move on to its NEXT catalogued cast. Reading enemy.CastingSpellId after the await
+            // would latch THAT next cast as "handled" and suppress its own mitigation.
+            var handledCastId = enemy?.CastingSpellId;
 
+            // Bailing on a null enemy here would NOT stop the action (the cast is already started) — it
+            // would only skip the FL throttle, letting a lock-on reaction (enemy == null) re-fire every
+            // pulse and dump the whole mitigation priority list. Await the cast, then start the 5s
+            // throttle on success regardless; only record the handled cast id when we had a casting enemy.
             if (!await task) return false;
 
-            FlHandledCastingSpellId.Add(enemy.CastingSpellId);
+            // A layered response deliberately leaves the mechanic open so the next pulse can follow up with
+            // the other half of the mitigation, neither marking the cast handled nor starting the throttle.
+            // The budget is only spent once the cast actually landed, and only one is granted per mechanic,
+            // so a second layered attempt falls through and closes the reaction as normal.
+            if (layered && TryConsumeLayeredResponse(handledCastId))
+                return true;
+
+            if (handledCastId.HasValue)
+                FlHandledCastingSpellId.Add(handledCastId.Value);
             FlStopwatch.Start();
             return true;
         }
@@ -98,9 +221,17 @@ namespace Magitek.Utilities
                 ? Group.CastableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
                 : null;
 
+            // Solo: no party tank is the buster's target, but it's aimed at us so we eat it — react on
+            // ourselves. Scoped to out-of-party so an in-party aggro swap doesn't trigger a self-reaction.
+            if (output == null
+                && !Globals.InParty
+                && enemyLogic.TankBusters.Contains(enemy.CastingSpellId)
+                && enemy.TargetCharacter?.ObjectId == Core.Me.ObjectId)
+                output = Core.Me;
+
             if (output != null && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo(
-                    $"[TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name} on {output.CurrentJob} in our party.");
+                    $"[TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name} on {output.CurrentJob}{(Globals.InParty ? " in our party." : " (solo).")}");
 
             return output;
         }
@@ -123,9 +254,16 @@ namespace Magitek.Utilities
                 ? Group.CastableTanks.FirstOrDefault(x => x != enemy.TargetCharacter)
                 : null;
 
+            // Solo: no co-tank to share with, so if it's aimed at us we eat the whole thing — self-mitigate.
+            if (output == null
+                && !Globals.InParty
+                && enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
+                && enemy.TargetCharacter?.ObjectId == Core.Me.ObjectId)
+                output = Core.Me;
+
             if (output != null && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo(
-                    $"[Shared TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name}. Handling for {output.CurrentJob} in our party.");
+                    $"[Shared TankBuster Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name}. Handling for {output.CurrentJob}{(Globals.InParty ? " in our party." : " (solo)")}.");
 
             return output;
 
@@ -260,12 +398,38 @@ namespace Magitek.Utilities
             return output;
         }
 
+        // Field Operations — Eureka, Bozja/Zadnor and the Occult Crescent — are instanced content whose
+        // bosses are worth mitigating exactly like duty bosses, but none of them register as a standard
+        // InActiveDuty (there's no duty-in-progress state), so the gates below would keep FightLogic
+        // dormant there. Admitting these zones is safe: reactions only ever fire on catalogued cast ids,
+        // so they cannot misfire on unmapped field trash. Delubrum Reginae is deliberately absent — it's
+        // a real instanced raid inside Bozja and already satisfies InActiveDuty.
+        private static readonly HashSet<ushort> FieldOperationZoneIds = new HashSet<ushort>
+        {
+            732,  // The Forbidden Land, Eureka Anemos
+            763,  // The Forbidden Land, Eureka Pagos
+            795,  // The Forbidden Land, Eureka Pyros
+            827,  // The Forbidden Land, Eureka Hydatos
+            920,  // The Bozjan Southern Front
+            975,  // Zadnor
+        };
+
+        // The Occult Crescent is deliberately absent from the list above: it owns its own zone detection
+        // (which also matches new Horns by name), so keeping it in one place stops the two drifting apart.
+        public static bool InFieldOperation()
+        {
+            return FieldOperationZoneIds.Contains(WorldManager.ZoneId)
+                || global::Magitek.Logic.Roles.OccultCrescent.IsInOccultCrescent();
+        }
+
         public static bool ZoneHasFightLogic()
         {
             if (!DebugSettings.Instance.UseFightLogic)
                 return false;
 
-            if (!Globals.InActiveDuty)
+            // Admit field operations alongside duties so catalogued reactions (incl. the healer
+            // HealFightLogic paths that gate on this) fire there. Mirrors GetEnemyLogicAndEnemy().
+            if (!Globals.InActiveDuty && !InFieldOperation())
                 return false;
 
             if (!Core.Me.InCombat)
@@ -318,6 +482,251 @@ namespace Magitek.Utilities
             return false;
         }
 
+        #region Gaze mechanics (look away / look toward)
+
+        public enum GazeDirection { None, Away, Toward }
+
+        private static GameObject _gazeSource;
+        private static GazeDirection _gazeDirection;
+        private static DateTime _gazeHoldUntil = DateTime.MinValue;
+
+        /// <summary>
+        /// True while a gaze reaction owns our facing. Cast paths check this before force-facing the
+        /// current target: that auto-face only runs while stationary, which is exactly why turning away
+        /// used to work on the move and fail standing still — the next cast snapped us back at the boss.
+        /// </summary>
+        public static bool GazeHoldActive => DateTime.Now < _gazeHoldUntil;
+
+        /// <summary>
+        /// Latch a gaze hold. Kept alive for a short grace after the gaze stops being detected, because the
+        /// snapshot lands as the cast completes — releasing on the exact frame it ends lets a queued GCD fire
+        /// and re-face us into the gaze before it resolves.
+        /// </summary>
+        public static void LatchGazeHold(GazeDirection direction, GameObject source, int graceMs)
+        {
+            _gazeDirection = direction;
+            _gazeSource = source;
+            _gazeHoldUntil = DateTime.Now.AddMilliseconds(graceMs);
+        }
+
+        /// <summary>
+        /// Re-assert the latched facing during the post-gaze grace window. False once it lapses.
+        /// </summary>
+        public static bool ReassertGazeHold()
+        {
+            if (!GazeHoldActive || _gazeSource == null || !_gazeSource.IsValid)
+                return false;
+
+            FaceForGaze(_gazeDirection, _gazeSource);
+            return true;
+        }
+
+        // The current zone's encounter, but only if something in it actually has catalogued gaze data.
+        // Returning null lets the caller skip the object-manager scan entirely in every other zone.
+        private static Encounter GazeEncounter()
+        {
+            if (!ZoneHasFightLogic())
+                return null;
+
+            var encounter = FightLogicEncounters.Encounters.FirstOrDefault(x => x.ZoneId == WorldManager.RawZoneId);
+
+            if (encounter?.Enemies == null)
+                return null;
+
+            return encounter.Enemies.Any(x => x.LookAwayGazes != null || x.LookTowardGazes != null
+                    || x.LookAwayLockOns != null || x.LookTowardLockOns != null || x.LookAwayFromMarkedLockOns != null)
+                ? encounter
+                : null;
+        }
+
+        // The live object matching a catalogued enemy, used to orient against when the gaze is signalled
+        // by a head marker rather than by that enemy's own cast.
+        private static BattleCharacter FindCataloguedEnemy(Enemy logic)
+        {
+            return GameObjectManager.GetObjectsOfType<BattleCharacter>()
+                .FirstOrDefault(x => x != null && x.IsValid
+                    && (logic.Id == x.NpcId || logic.Name == x.EnglishName)
+                    && Core.Me.Distance(x) <= 50);
+        }
+
+        // Gazes flagged by a head marker instead of a cast (e.g. Shinryu's Cataclysmic Vortex). RB surfaces
+        // these through VfxContainer.LockOns — the same source the AoE lock-on checks read. There's no cast
+        // bar to time against here, so the caller simply holds for as long as the marker is up.
+        private static uint _seenMarkerId;
+        private static DateTime _seenMarkerSince = DateTime.MinValue;
+        private static DateTime _seenMarkerLastPolled = DateTime.MinValue;
+
+        // A marker is polled every pulse while it is up, so a gap means it went away and came back.
+        private const double MarkerGoneAfterMs = 1000;
+
+        /// <summary>
+        /// How long the gaze marker we are currently reacting to has been on us. Markers carry no visible
+        /// timer, unlike a cast bar, so this is the only way to turn late rather than surrendering the
+        /// marker's entire lifetime. Resets whenever a different marker appears.
+        /// </summary>
+        public static double GazeMarkerAgeMs(uint markerId)
+        {
+            var now = DateTime.Now;
+
+            // Watching the id alone is not enough. The same gaze comes round again every cycle, and
+            // without noticing the gap between one and the next the second would be timed from the first,
+            // count as long overdue, and turn instantly for the marker's whole life instead of waiting.
+            if (_seenMarkerId != markerId
+                || (now - _seenMarkerLastPolled).TotalMilliseconds > MarkerGoneAfterMs)
+            {
+                _seenMarkerId = markerId;
+                _seenMarkerSince = now;
+            }
+
+            _seenMarkerLastPolled = now;
+
+            return (now - _seenMarkerSince).TotalMilliseconds;
+        }
+
+        public static GazeDirection GazeLockOnActive(out GameObject source, out uint markerId)
+        {
+            source = null;
+            markerId = 0;
+
+            var encounter = GazeEncounter();
+            var me = Core.Me;
+
+            if (encounter == null || me == null)
+                return GazeDirection.None;
+
+            foreach (var logic in encounter.Enemies)
+            {
+                var away = logic.LookAwayLockOns == null
+                    ? null
+                    : me.VfxContainer.LockOns.FirstOrDefault(l => logic.LookAwayLockOns.Contains(l.Id));
+
+                if (away != null)
+                {
+                    source = FindCataloguedEnemy(logic);
+                    if (source != null)
+                    {
+                        markerId = away.Id;
+                        return GazeDirection.Away;
+                    }
+                }
+
+                var toward = logic.LookTowardLockOns == null
+                    ? null
+                    : me.VfxContainer.LockOns.FirstOrDefault(l => logic.LookTowardLockOns.Contains(l.Id));
+
+                if (toward != null)
+                {
+                    source = FindCataloguedEnemy(logic);
+                    if (source != null)
+                    {
+                        markerId = toward.Id;
+                        return GazeDirection.Toward;
+                    }
+                }
+
+                // Marker sits on somebody else and the rest of the party looks away from THEM. If we're the
+                // marked one there's nothing to turn away from, so we leave our facing alone.
+                if (logic.LookAwayFromMarkedLockOns == null)
+                    continue;
+
+                foreach (var ally in Group.CastableAlliesWithin50)
+                {
+                    if (ally == null || !ally.IsValid || ally.ObjectId == me.ObjectId)
+                        continue;
+
+                    var onAlly = ally.VfxContainer.LockOns.FirstOrDefault(l => logic.LookAwayFromMarkedLockOns.Contains(l.Id));
+
+                    if (onAlly == null)
+                        continue;
+
+                    source = ally;
+                    markerId = onAlly.Id;
+                    return GazeDirection.Away;
+                }
+            }
+
+            return GazeDirection.None;
+        }
+
+        public static bool EnemyHasAnyGazeLogic() => GazeEncounter() != null;
+
+        // Which gaze is being cast right now, and by whom.
+        //
+        // Deliberately scans GameObjectManager instead of Combat.Enemies: the directional gaze is cast by
+        // untargetable mechanic actors (the Gilded Headstone "eye" copies), and Combat.Enemies filters
+        // those out via ValidAttackUnit/IsTargetable — so the cast would never be seen there. Also NOT
+        // throttled by IsFlReady/FlHandledCastingSpellId: facing has to be re-asserted every pulse for the
+        // whole cast rather than reacted to once.
+        public static GazeDirection EnemyIsCastingGaze(out BattleCharacter source)
+        {
+            source = null;
+
+            var encounter = GazeEncounter();
+
+            if (encounter == null)
+                return GazeDirection.None;
+
+            var direction = GazeDirection.None;
+            var soonest = double.MaxValue;
+
+            foreach (var unit in GameObjectManager.GetObjectsOfType<BattleCharacter>())
+            {
+                if (unit == null || !unit.IsValid || !unit.IsCasting)
+                    continue;
+
+                if (Core.Me.Distance(unit) > 50)
+                    continue;
+
+                var logic = encounter.Enemies.FirstOrDefault(x => x.Id == unit.NpcId || x.Name == unit.EnglishName);
+
+                if (logic == null)
+                    continue;
+
+                GazeDirection casting;
+
+                if (logic.LookAwayGazes != null && logic.LookAwayGazes.Contains(unit.CastingSpellId))
+                    casting = GazeDirection.Away;
+                else if (logic.LookTowardGazes != null && logic.LookTowardGazes.Contains(unit.CastingSpellId))
+                    casting = GazeDirection.Toward;
+                else
+                    continue;
+
+                // These come in overlapping waves — copies start ~2s apart with ~4.7s casts, so an avert
+                // and a face gaze are routinely in flight together demanding opposite headings. Obey the
+                // one resolving first; once it lands the next becomes soonest and we flip for that.
+                var remaining = unit.SpellCastInfo.RemainingCastTime.TotalMilliseconds;
+
+                if (remaining >= soonest)
+                    continue;
+
+                soonest = remaining;
+                direction = casting;
+                source = unit;
+            }
+
+            return direction;
+        }
+
+        // Orient relative to the gaze source. Mind the codebase convention: MathHelper.CalculateHeading
+        // returns the heading pointing AWAY from the destination — facing it is that value + PI (see the
+        // InView/RadiansFromPlayerHeading math in GameObjectExtensions). So Away uses the raw heading and
+        // Toward adds PI. SetFacing is instantaneous, so even a late turn lands; it only holds while
+        // stationary, though — if a botbase is driving movement, movement direction wins.
+        public static void FaceForGaze(GazeDirection direction, GameObject source)
+        {
+            if (source == null || direction == GazeDirection.None)
+                return;
+
+            var heading = MathHelper.CalculateHeading(Core.Me.Location, source.Location);
+
+            if (direction == GazeDirection.Toward)
+                heading = MathEx.NormalizeRadian(heading + (float)Math.PI);
+
+            Core.Me.SetFacing(heading);
+        }
+
+        #endregion
+
         public static bool HodlCastTimeRemaining(int hodlTillCastInMs = 0, double hodlTillDurationInPct = 0.0)
         {
             if (hodlTillCastInMs == 0 && hodlTillDurationInPct == 0)
@@ -364,7 +773,9 @@ namespace Magitek.Utilities
             if (!DebugSettings.Instance.UseFightLogic)
                 return SetAndReturn();
 
-            if (!Globals.InActiveDuty)
+            // Admit field operations alongside duties (see FieldOperationZoneIds) so the catalogue load
+            // below runs there rather than leaving FightLogic dormant.
+            if (!Globals.InActiveDuty && !InFieldOperation())
                 return SetAndReturn();
 
             if (!Core.Me.InCombat)
@@ -392,7 +803,19 @@ namespace Magitek.Utilities
                         $"\nYou are currently in {WorldManager.CurrentZoneName} ({WorldManager.RawZoneId})";
                     var currentTarget = Core.Me.CurrentTarget == null ? "No Target" : Core.Me.CurrentTarget.Name;
                     var npcId = Core.Me.CurrentTarget?.NpcId == null ? 0 : Core.Me.CurrentTarget.NpcId;
-                    Debug.Instance.FightLogicData += $"\nCurrent Target: {currentTarget} ({npcId})\n\n\n";
+                    Debug.Instance.FightLogicData += $"\nCurrent Target: {currentTarget} ({npcId})\n";
+
+                    // Live cast discovery: every nearby enemy currently casting, with the raw action id.
+                    // This is how you capture uncatalogued mechanic ids (gazes, etc.) to add to the catalogue —
+                    // read the id off the boss's cast bar here, then it can be catalogued by enemy name.
+                    var castingNow = Combat.Enemies.Where(y => y.IsCasting).ToList();
+                    Debug.Instance.FightLogicData += "\nCasting now:\n";
+                    if (castingNow.Count == 0)
+                        Debug.Instance.FightLogicData += "\t(nothing casting)\n";
+                    else
+                        castingNow.ForEach(y => Debug.Instance.FightLogicData +=
+                            $"\t{y.EnglishName} ({y.NpcId}): {y.SpellCastInfo.Name} ({y.CastingSpellId})\n");
+                    Debug.Instance.FightLogicData += "\n\n";
 
                     if (encounter == null && enemyLogic == null && enemy == null)
                         Debug.Instance.FightLogicData += $"There is no Fight Logic for this zone - {WorldManager.CurrentZoneName} ({WorldManager.RawZoneId}). \n";
@@ -426,6 +849,18 @@ namespace Magitek.Utilities
                                 Debug.Instance.FightLogicData +=
                                     $"\tAoe Lock Ons:\n{string.Join("", element.AoeLockOns.Select(aoeLockOn => $"\t\t({aoeLockOn})\n"))}";
 
+                            if (element.Knockbacks != null)
+                                Debug.Instance.FightLogicData +=
+                                    $"\tKnockbacks:\n{string.Join("", element.Knockbacks.Select(kb => $"\t\t{DataManager.GetSpellData(kb).Name} ({kb})\n"))}";
+
+                            if (element.LookAwayGazes != null)
+                                Debug.Instance.FightLogicData +=
+                                    $"\tLook-Away Gazes:\n{string.Join("", element.LookAwayGazes.Select(g => $"\t\t{DataManager.GetSpellData(g).Name} ({g})\n"))}";
+
+                            if (element.LookTowardGazes != null)
+                                Debug.Instance.FightLogicData +=
+                                    $"\tLook-Toward Gazes:\n{string.Join("", element.LookTowardGazes.Select(g => $"\t\t{DataManager.GetSpellData(g).Name} ({g})\n"))}";
+
                             Debug.Instance.FightLogicData += $"\n";
                         });
                     }
@@ -450,6 +885,14 @@ namespace Magitek.Utilities
         internal List<uint> BigAoes { get; set; }
         internal List<uint> Knockbacks { get; set; }
         internal List<uint> AoeLockOns { get; set; }
+        internal List<uint> LookAwayGazes { get; set; }
+        internal List<uint> LookTowardGazes { get; set; }
+        // Some fights signal the gaze with a head marker on players instead of an enemy cast. The first
+        // two are markers on US and orient against the enemy; the third marks somebody ELSE and everyone
+        // looks away from that player instead of from the boss.
+        internal List<uint> LookAwayLockOns { get; set; }
+        internal List<uint> LookTowardLockOns { get; set; }
+        internal List<uint> LookAwayFromMarkedLockOns { get; set; }
     }
 
     internal class Encounter

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -506,6 +506,12 @@ namespace Magitek.Utilities
         public static bool GazeHoldActive => DateTime.Now < _gazeHoldUntil;
 
         /// <summary>
+        /// The heading the active latch is holding, or None once it lapses. Lets a caller tell an overlapping
+        /// gaze that agrees with the current hold from one that wants the opposite way round.
+        /// </summary>
+        public static GazeDirection GazeHoldDirection => GazeHoldActive ? _gazeDirection : GazeDirection.None;
+
+        /// <summary>
         /// Latch a gaze hold. Kept alive for a short grace after the gaze stops being detected, because the
         /// snapshot lands as the cast completes — releasing on the exact frame it ends lets a queued GCD fire
         /// and re-face us into the gaze before it resolves.

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -586,6 +586,13 @@ namespace Magitek.Utilities
 
         public static void HoldMovement(int ms) => _movementHeldUntil = DateTime.Now.AddMilliseconds(ms);
 
+        /// <summary>
+        /// Drop the hold immediately. The latch is re-armed for a full second on every pulse the mechanic is
+        /// up, so when it finally ends there is up to a second of stale hold left over — long enough to keep
+        /// navigation and gap closers parked after the thing that justified them has gone.
+        /// </summary>
+        public static void ReleaseMovementHold() => _movementHeldUntil = DateTime.MinValue;
+
         private static uint _seenMarkerId;
         private static DateTime _seenMarkerSince = DateTime.MinValue;
         private static DateTime _seenMarkerLastPolled = DateTime.MinValue;

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -552,6 +552,16 @@ namespace Magitek.Utilities
         // Gazes flagged by a head marker instead of a cast (e.g. Shinryu's Cataclysmic Vortex). RB surfaces
         // these through VfxContainer.LockOns — the same source the AoE lock-on checks read. There's no cast
         // bar to time against here, so the caller simply holds for as long as the marker is up.
+        // Some mechanics punish movement but not casting. Those must not consume the pulse — that
+        // would throw away every action in the window — but the rotation re-issues navigation later
+        // in the same pulse, which would undo the MoveStop. This latch lets the rotation keep casting
+        // while navigation stays parked. Short-lived and refreshed each pulse, so it cannot stick on.
+        private static DateTime _movementHeldUntil = DateTime.MinValue;
+
+        public static bool MovementHeld => DateTime.Now < _movementHeldUntil;
+
+        public static void HoldMovement(int ms) => _movementHeldUntil = DateTime.Now.AddMilliseconds(ms);
+
         private static uint _seenMarkerId;
         private static DateTime _seenMarkerSince = DateTime.MinValue;
         private static DateTime _seenMarkerLastPolled = DateTime.MinValue;

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -420,14 +420,13 @@ namespace Magitek.Utilities
             827,  // The Forbidden Land, Eureka Hydatos
             920,  // The Bozjan Southern Front
             975,  // Zadnor
+            1252, // Occult Crescent: South Horn
+            1346, // Occult Crescent: Northern Horn
         };
 
-        // The Occult Crescent is deliberately absent from the list above: it owns its own zone detection
-        // (which also matches new Horns by name), so keeping it in one place stops the two drifting apart.
         public static bool InFieldOperation()
         {
-            return FieldOperationZoneIds.Contains(WorldManager.ZoneId)
-                || global::Magitek.Logic.Roles.OccultCrescent.IsInOccultCrescent();
+            return FieldOperationZoneIds.Contains(WorldManager.ZoneId);
         }
 
         public static bool ZoneHasFightLogic()

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -846,7 +846,13 @@ namespace Magitek.Utilities
                     // Live cast discovery: every nearby enemy currently casting, with the raw action id.
                     // This is how you capture uncatalogued mechanic ids (gazes, etc.) to add to the catalogue —
                     // read the id off the boss's cast bar here, then it can be catalogued by enemy name.
-                    var castingNow = Combat.Enemies.Where(y => y.IsCasting).ToList();
+                    //
+                    // Deliberately the same source the gaze detector uses, NOT Combat.Enemies. That list keeps
+                    // only what we can target and damage, and the casters most worth discovering are neither:
+                    // the Occult Crescent's Accursed Orbs and O8N/O8S's Graven Image statues are untargetable
+                    // emitters. Reading from Combat.Enemies made this blind to exactly the enemies it exists
+                    // to catalogue.
+                    var castingNow = _gazeCandidates.Value.Where(y => y.IsCasting).ToList();
                     Debug.Instance.FightLogicData += "\nCasting now:\n";
                     if (castingNow.Count == 0)
                         Debug.Instance.FightLogicData += "\t(nothing casting)\n";

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -745,7 +745,7 @@ namespace Magitek.Utilities
         // stationary, though — if a botbase is driving movement, movement direction wins.
         public static void FaceForGaze(GazeDirection direction, GameObject source)
         {
-            if (source == null || direction == GazeDirection.None)
+            if (source == null || !source.IsValid || direction == GazeDirection.None || Core.Me == null)
                 return;
 
             var heading = MathHelper.CalculateHeading(Core.Me.Location, source.Location);

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -1409,6 +1409,22 @@ namespace Magitek.Utilities
                             10541 //Ultima Upsurge                            
                         },
                         BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 7132,
+                        Name = "Graven Image",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = null,
+                        BigAoes = null,
+                        // Kefka's statues alternate their demand, so the pair has to be catalogued
+                        // together — answering only one of them is worse than answering neither.
+                        LookAwayGazes = new List<uint> {
+                            10540, // Indolent Will
+                        },
+                        LookTowardGazes = new List<uint> {
+                            10539, // Ave Maria
+                        },
                     }
                 }
             },
@@ -1668,6 +1684,23 @@ namespace Magitek.Utilities
                         SharedTankBusters = null,
                         Aoes = null,
                         BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 7132,
+                        Name = "Graven Image",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = null,
+                        BigAoes = null,
+                        // Savage counterpart of the O8N pair above; same mechanic, different ids. The
+                        // statue casts these, not Kefka, and gaze logic resolves per casting unit — so
+                        // they belong on the statue's own entry or nothing ever matches them.
+                        LookAwayGazes = new List<uint> {
+                            10468, // Indolent Will
+                        },
+                        LookTowardGazes = new List<uint> {
+                            10467, // Ave Maria
+                        },
                     }
                 }
             },

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -174,7 +174,7 @@ namespace Magitek.Utilities.Managers
             if (await CommonFightLogic.FightLogic_Gaze(BaseSettings.Instance.FightLogicGaze))
                 return true;
 
-            if (BotManager.Current.IsAutonomous)
+            if (BotManager.Current.IsAutonomous && !FightLogic.MovementHeld)
             {
                 if (Core.Me.HasTarget)
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, (Core.Me.IsRanged() ? 20 : 0) + Core.Me.CurrentTarget.CombatReach);
@@ -293,7 +293,7 @@ namespace Magitek.Utilities.Managers
             Globals.HealTarget = Group.CastableAlliesWithin30.FirstOrDefault();
             await Chocobo.HandleChocobo();
 
-            if (BotManager.Current.IsAutonomous)
+            if (BotManager.Current.IsAutonomous && !FightLogic.MovementHeld)
             {
                 if (Core.Me.HasTarget)
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, (Core.Me.IsRanged() ? 20 : 2) + Core.Me.CurrentTarget.CombatReach);

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -168,6 +168,12 @@ namespace Magitek.Utilities.Managers
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
 
+            if (await CommonFightLogic.FightLogic_ActionState())
+                return true;
+
+            if (await CommonFightLogic.FightLogic_Gaze(BaseSettings.Instance.FightLogicGaze))
+                return true;
+
             if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
@@ -211,6 +217,12 @@ namespace Magitek.Utilities.Managers
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
 
+            if (await CommonFightLogic.FightLogic_ActionState())
+                return true;
+
+            if (await CommonFightLogic.FightLogic_Gaze(BaseSettings.Instance.FightLogicGaze))
+                return true;
+
             if (Core.Me.IsMounted)
                 return true;
 
@@ -222,6 +234,16 @@ namespace Magitek.Utilities.Managers
             if (await Casting.TrackSpellCast()) return true;
             await Casting.CheckForSuccessfulCast();
             Casting.DoHealthChecks = false;
+
+            // Drain the spell queue here as well as in Combat(). Healer mitigation sequences are started
+            // from Heal(), and Heal() runs first in the pulse — without this the queue would sit untouched
+            // while the rest of the heal (and then the damage) rotation carried on casting around it.
+            if (!SpellQueueLogic.SpellQueue.Any())
+                SpellQueueLogic.InSpellQueue = false;
+
+            if (SpellQueueLogic.SpellQueue.Any())
+                if (await SpellQueueLogic.SpellQueueMethod())
+                    return true;
 
             if (await GambitLogic.Gambit())
                 return true;
@@ -247,6 +269,12 @@ namespace Magitek.Utilities.Managers
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
 
+            if (await CommonFightLogic.FightLogic_ActionState())
+                return true;
+
+            if (await CommonFightLogic.FightLogic_Gaze(BaseSettings.Instance.FightLogicGaze))
+                return true;
+
             return await ExecuteRotationMethod(RotationManager.CurrentRotation, "CombatBuff");
         }
 
@@ -254,6 +282,12 @@ namespace Magitek.Utilities.Managers
         {
             if (!BaseSettings.Instance.ActiveCombatRoutine)
                 return false;
+
+            if (await CommonFightLogic.FightLogic_ActionState())
+                return true;
+
+            if (await CommonFightLogic.FightLogic_Gaze(BaseSettings.Instance.FightLogicGaze))
+                return true;
 
             Group.UpdateAllies(GetGroupExtensionForJob(RotationManager.CurrentRotation));
             Globals.HealTarget = Group.CastableAlliesWithin30.FirstOrDefault();

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -174,7 +174,7 @@ namespace Magitek.Utilities.Managers
             if (await CommonFightLogic.FightLogic_Gaze(BaseSettings.Instance.FightLogicGaze))
                 return true;
 
-            if (BotManager.Current.IsAutonomous && !FightLogic.MovementHeld)
+            if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, (Core.Me.IsRanged() ? 20 : 0) + Core.Me.CurrentTarget.CombatReach);
@@ -293,7 +293,7 @@ namespace Magitek.Utilities.Managers
             Globals.HealTarget = Group.CastableAlliesWithin30.FirstOrDefault();
             await Chocobo.HandleChocobo();
 
-            if (BotManager.Current.IsAutonomous && !FightLogic.MovementHeld)
+            if (BotManager.Current.IsAutonomous)
             {
                 if (Core.Me.HasTarget)
                     Movement.NavigateToUnitLos(Core.Me.CurrentTarget, (Core.Me.IsRanged() ? 20 : 2) + Core.Me.CurrentTarget.CombatReach);

--- a/Magitek/Utilities/Movement.cs
+++ b/Magitek/Utilities/Movement.cs
@@ -49,7 +49,7 @@ namespace Magitek.Utilities
             {
                 if (MovementManager.IsMoving)
                 {
-                    Navigator.PlayerMover.MoveStop();
+                    Navigator.PlayerMover?.MoveStop();
                 }
             }
             else

--- a/Magitek/Utilities/Movement.cs
+++ b/Magitek/Utilities/Movement.cs
@@ -30,6 +30,13 @@ namespace Magitek.Utilities
             if (AvoidanceManager.IsRunningOutOfAvoid)
                 return;
 
+            // A movement-punishing mechanic (Acceleration Bomb, Pyretic) has parked navigation. This belongs
+            // here rather than at the callers: six of the eight navigation sites are job rotations that never
+            // consulted the latch, so stopping in the fight-logic handler was immediately undone by whichever
+            // rotation navigated next in the same pulse.
+            if (FightLogic.MovementHeld)
+                return;
+
             //if (!MovementManager.IsMoving && !unit.InView() && !RoutineManager.IsAnyDisallowed(CapabilityFlags.Facing))
             //   Core.Me.Face(Core.Me.CurrentTarget);
 

--- a/Magitek/Utilities/Movement.cs
+++ b/Magitek/Utilities/Movement.cs
@@ -74,10 +74,17 @@ namespace Magitek.Utilities
 
         /// <summary>
         /// Checks if gap closer abilities can be used based on CapabilityManager flags.
-        /// Gap closers are disabled if either GapCloser or Movement flags are disallowed.
+        /// Gap closers are disabled if either GapCloser or Movement flags are disallowed, or while a
+        /// movement-punishing mechanic has movement parked.
         /// </summary>
         public static bool CanUseGapCloser()
         {
+            // Acceleration Bomb only objects to movement, so the routine deliberately keeps acting through
+            // it — but a gap closer IS movement wearing an action's clothing, and it moves the character
+            // just as surely as the navigator would. Parked here rather than at the fourteen call sites.
+            if (FightLogic.MovementHeld)
+                return false;
+
             return !RoutineManager.IsAnyDisallowed(CapabilityFlags.GapCloser | CapabilityFlags.Movement);
         }
 

--- a/Magitek/Views/UserControls/Bugs/FightLogic.xaml
+++ b/Magitek/Views/UserControls/Bugs/FightLogic.xaml
@@ -25,6 +25,10 @@
             <StackPanel Orientation="Horizontal" Margin="5">
                 <CheckBox Margin="0,0,0,0" Content="{x:Static properties:Resources.Generic_Fight_Logic_Include_Common_Aoe_Lock_Ons}" IsChecked="{Binding Settings.FightLogicIncludeCommonAoeLockOnsTest, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="5">
+                <CheckBox Margin="0,0,10,0" Content="{x:Static properties:Resources.Generic_FightLogic_ActionAwareness}" IsChecked="{Binding Settings.FightLogicActionAwareness, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Margin="0,0,0,0" Content="{x:Static properties:Resources.Generic_FightLogic_Gaze}" IsChecked="{Binding Settings.FightLogicGaze, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+            </StackPanel>
             <StackPanel Margin="5,0,5,5">
                 <TextBlock Margin="3" Style="{DynamicResource TextBlockDefault}" TextWrapping="Wrap" FontSize="9">
                     <Run Text="Common AoE Lock-On IDs: "/>


### PR DESCRIPTION
Adds two fight-logic reactions that respond to mechanics no cast-time mitigation can answer: gaze attacks, and mechanics that punish acting or moving.

- Turns away from gaze attacks and toward the ones that require facing the caster
- Holds actions during Pyretic-style mechanics that detonate when you act
- Parks navigation during mechanics that punish movement, so standing still actually sticks instead of the pulse walking straight back out
- Movement is halted before facing, since movement otherwise overrides it every frame
- Both reactions are off by default and respect the master fight logic toggle

The gaze data itself ships separately, so the gaze reaction is inert until that lands. Included here as the groundwork it depends on.