### PR TITLE
Magitek - Revive fallen party members with Phoenix Down

### DIFF
--- a/Magitek/Extensions/SpellDataExtensions.cs
+++ b/Magitek/Extensions/SpellDataExtensions.cs
@@ -69,6 +69,7 @@ namespace Magitek.Extensions
             Casting.CastingSpell = spell;
             Casting.SpellCastTime = spell.AdjustedCastTime;
             Casting.CastingHeal = false;
+            Casting.CastingRevive = false;
             Casting.SpellTarget = target;
             Casting.CastingTime.Restart();
 
@@ -311,6 +312,7 @@ namespace Magitek.Extensions
             Casting.CastingSpell = spell;
             Casting.SpellCastTime = spell.AdjustedCastTime;
             Casting.CastingHeal = false;
+            Casting.CastingRevive = false;
             Casting.SpellTarget = target;
             Casting.NeedAura = needAura;
             Casting.Aura = aura;
@@ -358,6 +360,7 @@ namespace Magitek.Extensions
             }
 
             Casting.CastingHeal = true;
+            Casting.CastingRevive = false;
             Casting.CastingSpell = spell;
             Casting.SpellCastTime = spell.AdjustedCastTime;
             Casting.SpellTarget = target;

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -22,8 +22,9 @@ namespace Magitek.Logic.Roles
 
         // Per-target throttle. After a Phoenix Down is used the revive takes a server round-trip to land,
         // during which the target still reads CurrentHealth==0 — skip it briefly so we don't fire a
-        // second one before the first registers. Kept well under the death delay so it can never block a
-        // legitimate re-revive (that needs a fresh death plus the full delay again).
+        // second one before the first registers. With the default death delay a legitimate re-revive
+        // needs a fresh death plus the full delay again, which outlasts this window; at very low
+        // user-set delays a rapid re-death may wait out the remainder of the 10s before a second down.
         private static readonly Dictionary<uint, DateTime> _recentUses = new();
         private static readonly TimeSpan UseThrottle = TimeSpan.FromSeconds(10);
 

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -20,14 +20,6 @@ namespace Magitek.Logic.Roles
         private const uint PhoenixDownItemId = 4570;
         private const float PhoenixDownRange = 15f; // Phoenix Down reaches ~15 yalms.
 
-        // Per-target throttle. After a Phoenix Down is used the revive takes a server round-trip to land,
-        // during which the target still reads CurrentHealth==0 — skip it briefly so we don't fire a
-        // second one before the first registers. With the default death delay a legitimate re-revive
-        // needs a fresh death plus the full delay again, which outlasts this window; at very low
-        // user-set delays a rapid re-death may wait out the remainder of the 10s before a second down.
-        private static readonly Dictionary<uint, DateTime> _recentUses = new();
-        private static readonly TimeSpan UseThrottle = TimeSpan.FromSeconds(10);
-
         public static async Task<bool> Execute()
         {
             if (!BaseSettings.Instance.UsePhoenixDown)
@@ -55,8 +47,8 @@ namespace Magitek.Logic.Roles
             // is built from PartyManager.RawMembers). Skip anyone already being raised, require the death
             // to be at least `delaySeconds` old so a real raise gets priority, and require the game to
             // actually allow the use on them (item.CanUse -> real range / line-of-sight / duty rules) so
-            // an unusable higher-priority body can't starve a reachable one. Honour the per-target
-            // throttle. GetResurrectionWeight orders healers first, then tanks, then DPS.
+            // an unusable higher-priority body can't starve a reachable one. GetResurrectionWeight
+            // orders healers first, then tanks, then DPS.
             // u.IsValid short-circuits before every read below. Each of those touches game memory, so a
             // corpse whose object was freed mid-iteration throws ReadWriteMemoryException from inside the
             // predicate and takes down the whole Heal pulse — the same guard Healer.ResurrectionLogic
@@ -70,7 +62,6 @@ namespace Magitek.Logic.Roles
                             && u.IsTargetable
                             && u.WithinSpellRange(PhoenixDownRange)
                             && item.CanUse(u)
-                            && (!_recentUses.TryGetValue(u.ObjectId, out var last) || now - last > UseThrottle)
                             && Group.GetDeathTime(u)?.AddSeconds(delaySeconds) <= now)
                 .OrderByDescending(u => u.GetResurrectionWeight())
                 .FirstOrDefault();
@@ -80,30 +71,21 @@ namespace Magitek.Logic.Roles
 
             // One targeted use per pulse. NOT the shared UseItem() extension: it loops UseItem() with no
             // target and no inter-use delay, which would fire on the wrong unit and re-fire every frame
-            // until the revive lands (burning multiple Phoenix Downs). Stamp the throttle and use once;
-            // the frame-pulsed Execute re-checks the reserve/target next tick.
-            _recentUses[target.ObjectId] = now;
-            PruneThrottle(now);
-
+            // until the revive lands (burning multiple Phoenix Downs).
             Logger.WriteInfo($"[Phoenix Down] Reviving {target.Name} ({target.CurrentJob})");
             item.UseItem(target);
 
             // Starting the item cast is not the same as finishing it. Left untracked, the very next pulse
             // sees nothing in progress and carries on to the movement step, which walks and cancels the
-            // revive. Hold here until the cast actually ends so the rest of the pulse cannot interrupt it.
+            // revive. Hold here until the cast actually ends so the rest of the pulse cannot interrupt
+            // it — this hold, plus the !HasAura(Raise) filter above, is the whole re-fire guard: no
+            // per-corpse timers. The residual window (cast end to the server's Raise status) is one
+            // round-trip; a second down inside it is possible but rare, the same trade the non-party
+            // rez guard makes.
             await Coroutine.Wait(1000, () => Core.Me.IsCasting);
             await Coroutine.Wait(10000, () => !Core.Me.IsCasting);
 
             return true;
-        }
-
-        private static void PruneThrottle(DateTime now)
-        {
-            if (_recentUses.Count < 16)
-                return;
-
-            foreach (var stale in _recentUses.Where(kv => now - kv.Value > UseThrottle).Select(kv => kv.Key).ToList())
-                _recentUses.Remove(stale);
         }
     }
 }

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -56,8 +56,14 @@ namespace Magitek.Logic.Roles
             // actually allow the use on them (item.CanUse -> real range / line-of-sight / duty rules) so
             // an unusable higher-priority body can't starve a reachable one. Honour the per-target
             // throttle. GetResurrectionWeight orders healers first, then tanks, then DPS.
+            // u.IsValid short-circuits before every read below. Each of those touches game memory, so a
+            // corpse whose object was freed mid-iteration throws ReadWriteMemoryException from inside the
+            // predicate and takes down the whole Heal pulse — the same guard Healer.ResurrectionLogic
+            // already carries for this list.
             var target = Group.DeadAllies
-                .Where(u => u.CurrentHealth == 0
+                .Where(u => u != null
+                            && u.IsValid
+                            && u.CurrentHealth == 0
                             && !u.HasAura(Auras.Raise)
                             && u.IsVisible
                             && u.IsTargetable

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -1,3 +1,4 @@
+using Buddy.Coroutines;
 using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
@@ -79,6 +80,13 @@ namespace Magitek.Logic.Roles
 
             Logger.WriteInfo($"[Phoenix Down] Reviving {target.Name} ({target.CurrentJob})");
             item.UseItem(target);
+
+            // Starting the item cast is not the same as finishing it. Left untracked, the very next pulse
+            // sees nothing in progress and carries on to the movement step, which walks and cancels the
+            // revive. Hold here until the cast actually ends so the rest of the pulse cannot interrupt it.
+            await Coroutine.Wait(1000, () => Core.Me.IsCasting);
+            await Coroutine.Wait(10000, () => !Core.Me.IsCasting);
+
             return true;
         }
 

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -5,7 +5,6 @@ using Magitek.Extensions;
 using Magitek.Models.Account;
 using Magitek.Utilities;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Auras = Magitek.Utilities.Auras;
@@ -25,20 +24,31 @@ namespace Magitek.Logic.Roles
             if (!BaseSettings.Instance.UsePhoenixDown)
                 return false;
 
+            // O(1) gate before anything that touches the bags: DeadAllies is a plain list that
+            // Group.UpdateAllies() already built earlier in this same pulse, while every FilledSlots
+            // walk below reads each bag slot out of game memory (~0.3 ms per scan on a full
+            // inventory). Nobody is dead in the overwhelming majority of pulses, so almost every
+            // pulse ends right here. Only .Count is this cheap — running the full corpse predicate
+            // first would read eight properties per body and cost more than it saves.
+            if (Group.DeadAllies.Count == 0)
+                return false;
+
             // Instanced content only (dungeons/trials/deep dungeons/field ops/etc.). The game's own
             // item.CanUse() then enforces which specific duties actually permit Phoenix Down and when
             // (e.g. blocked in combat in 8-player content), so we don't hardcode those rules.
             if (!DutyManager.InInstance)
                 return false;
 
-            var item = InventoryManager.FilledSlots.FirstOrDefault(r => r.RawItemId == PhoenixDownItemId);
-            if (item == null)
+            // One bag scan, not two: the same walk answers "do we have any" and "how many".
+            // Keep a reserve so we never burn the player's last few (0 = no reserve, use them all).
+            var slots = InventoryManager.FilledSlots.Where(r => r.RawItemId == PhoenixDownItemId).ToList();
+            if (slots.Count == 0)
                 return false;
 
-            // Keep a reserve so we never burn the player's last few (0 = no reserve, use them all).
-            var owned = InventoryManager.FilledSlots.Where(r => r.RawItemId == PhoenixDownItemId).Sum(r => (long)r.Count);
-            if (owned <= BaseSettings.Instance.PhoenixDownReserve)
+            if (slots.Sum(r => (long)r.Count) <= BaseSettings.Instance.PhoenixDownReserve)
                 return false;
+
+            var item = slots[0];
 
             var delaySeconds = BaseSettings.Instance.PhoenixDownDelaySeconds;
             var now = DateTime.Now;
@@ -46,9 +56,14 @@ namespace Magitek.Logic.Roles
             // Dead party members AND Duty Support / Trust NPCs both surface through Group.DeadAllies (it
             // is built from PartyManager.RawMembers). Skip anyone already being raised, require the death
             // to be at least `delaySeconds` old so a real raise gets priority, and require the game to
-            // actually allow the use on them (item.CanUse -> real range / line-of-sight / duty rules) so
-            // an unusable higher-priority body can't starve a reachable one. GetResurrectionWeight
-            // orders healers first, then tanks, then DPS.
+            // actually allow the use on them (item.CanUse -> duty rules) so an unusable higher-priority
+            // body can't starve a reachable one. GetResurrectionWeight orders healers first, then tanks,
+            // then DPS.
+            // Raw Distance, not WithinSpellRange — the raise-range exception in AGENTS.md: a corpse has
+            // no usable CombatReach for the game to measure against, and WithinSpellRange's Distance2D
+            // ignores height entirely, so both errors run permissive and admit bodies that are genuinely
+            // out of reach. Same rule, on this same list, as Healer.ResurrectionLogic. InLineOfSight for
+            // the same reason Healer.cs filters it: nothing verifies that item.CanUse covers LoS.
             // u.IsValid short-circuits before every read below. Each of those touches game memory, so a
             // corpse whose object was freed mid-iteration throws ReadWriteMemoryException from inside the
             // predicate and takes down the whole Heal pulse — the same guard Healer.ResurrectionLogic
@@ -60,7 +75,8 @@ namespace Magitek.Logic.Roles
                             && !u.HasAura(Auras.Raise)
                             && u.IsVisible
                             && u.IsTargetable
-                            && u.WithinSpellRange(PhoenixDownRange)
+                            && u.Distance(Core.Me) <= PhoenixDownRange
+                            && u.InLineOfSight()
                             && item.CanUse(u)
                             && Group.GetDeathTime(u)?.AddSeconds(delaySeconds) <= now)
                 .OrderByDescending(u => u.GetResurrectionWeight())
@@ -73,17 +89,39 @@ namespace Magitek.Logic.Roles
             // target and no inter-use delay, which would fire on the wrong unit and re-fire every frame
             // until the revive lands (burning multiple Phoenix Downs).
             Logger.WriteInfo($"[Phoenix Down] Reviving {target.Name} ({target.CurrentJob})");
-            item.UseItem(target);
+            if (!item.UseItem(target))
+                return false;
 
             // Starting the item cast is not the same as finishing it. Left untracked, the very next pulse
             // sees nothing in progress and carries on to the movement step, which walks and cancels the
-            // revive. Hold here until the cast actually ends so the rest of the pulse cannot interrupt
-            // it — this hold, plus the !HasAura(Raise) filter above, is the whole re-fire guard: no
-            // per-corpse timers. The residual window (cast end to the server's Raise status) is one
-            // round-trip; a second down inside it is possible but rare, the same trade the non-party
-            // rez guard makes.
-            await Coroutine.Wait(1000, () => Core.Me.IsCasting);
-            await Coroutine.Wait(10000, () => !Core.Me.IsCasting);
+            // revive. Register the cast the way SpellDataExtensions.Cast() does, so the existing
+            // Casting.TrackSpellCast() hold at the top of Heal() owns it — the pulse keeps running for
+            // everyone else instead of blocking here for the full 8 seconds. This registration, plus the
+            // !HasAura(Raise) filter above, is the whole re-fire guard: no per-corpse timers. The residual
+            // window (cast end to the server's Raise status) is one round-trip; a second down inside it is
+            // possible but rare, the same trade the non-party rez guard makes.
+            //
+            // The wait is part of the pattern, not a hold: DoAction registers only after the cast bar is
+            // confirmed, because IsCasting does not flip on the same frame as the request. Registering
+            // into that gap lets one pulse see !IsCasting with the timer running, which
+            // CheckForSuccessfulCast reads as a failed cast — tracking dropped, and the walk-away bug
+            // this exists to fix comes straight back.
+            if (!await Coroutine.Wait(3000, () => Core.Me.IsCasting))
+                return false;
+
+            // Two deliberate oddities: SpellCastTime is a literal because BackingAction.AdjustedCastTime
+            // reports 0 for Phoenix Down despite the visible 8s cast bar, and the buffer maths in
+            // CheckForSuccessfulCast needs the real duration (its advanced-history early return is
+            // exempted separately, on CastingRevive — the 0 AdjustedCastTime would trip it regardless of
+            // what we put here). CastingRevive marks the cast as a revive for TrackSpellCast: the per-job
+            // interrupt checks cancel any cast on a dead target unless it is that job's own raise spell,
+            // and a revive's target is dead by definition.
+            Casting.CastingSpell = item.Item.BackingAction;
+            Casting.SpellTarget = target;
+            Casting.CastingHeal = true;
+            Casting.CastingRevive = true;
+            Casting.SpellCastTime = TimeSpan.FromMilliseconds(8000);
+            Casting.CastingTime.Restart();
 
             return true;
         }

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -1,0 +1,94 @@
+using ff14bot;
+using ff14bot.Managers;
+using Magitek.Extensions;
+using Magitek.Models.Account;
+using Magitek.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Auras = Magitek.Utilities.Auras;
+
+namespace Magitek.Logic.Roles
+{
+    // Job-agnostic fallback revive: use a Phoenix Down (item 4570) on a fallen party member or
+    // Duty Support / Trust NPC when no one has raised them. Opt-in, duties only, keeps a reserve, and
+    // waits a configurable delay after death so real raise spells get first shot.
+    internal static class PhoenixDown
+    {
+        private const uint PhoenixDownItemId = 4570;
+        private const float PhoenixDownRange = 15f; // Phoenix Down reaches ~15 yalms.
+
+        // Per-target throttle. After a Phoenix Down is used the revive takes a server round-trip to land,
+        // during which the target still reads CurrentHealth==0 — skip it briefly so we don't fire a
+        // second one before the first registers. Kept well under the death delay so it can never block a
+        // legitimate re-revive (that needs a fresh death plus the full delay again).
+        private static readonly Dictionary<uint, DateTime> _recentUses = new();
+        private static readonly TimeSpan UseThrottle = TimeSpan.FromSeconds(10);
+
+        public static async Task<bool> Execute()
+        {
+            if (!BaseSettings.Instance.UsePhoenixDown)
+                return false;
+
+            // Instanced content only (dungeons/trials/deep dungeons/field ops/etc.). The game's own
+            // item.CanUse() then enforces which specific duties actually permit Phoenix Down and when
+            // (e.g. blocked in combat in 8-player content), so we don't hardcode those rules.
+            if (!DutyManager.InInstance)
+                return false;
+
+            var item = InventoryManager.FilledSlots.FirstOrDefault(r => r.RawItemId == PhoenixDownItemId);
+            if (item == null)
+                return false;
+
+            // Keep a reserve so we never burn the player's last few (0 = no reserve, use them all).
+            var owned = InventoryManager.FilledSlots.Where(r => r.RawItemId == PhoenixDownItemId).Sum(r => (long)r.Count);
+            if (owned <= BaseSettings.Instance.PhoenixDownReserve)
+                return false;
+
+            var delaySeconds = BaseSettings.Instance.PhoenixDownDelaySeconds;
+            var now = DateTime.Now;
+
+            // Dead party members AND Duty Support / Trust NPCs both surface through Group.DeadAllies (it
+            // is built from PartyManager.RawMembers). Skip anyone already being raised, require the death
+            // to be at least `delaySeconds` old so a real raise gets priority, and require the game to
+            // actually allow the use on them (item.CanUse -> real range / line-of-sight / duty rules) so
+            // an unusable higher-priority body can't starve a reachable one. Honour the per-target
+            // throttle. GetResurrectionWeight orders healers first, then tanks, then DPS.
+            var target = Group.DeadAllies
+                .Where(u => u.CurrentHealth == 0
+                            && !u.HasAura(Auras.Raise)
+                            && u.IsVisible
+                            && u.IsTargetable
+                            && u.WithinSpellRange(PhoenixDownRange)
+                            && item.CanUse(u)
+                            && (!_recentUses.TryGetValue(u.ObjectId, out var last) || now - last > UseThrottle)
+                            && Group.GetDeathTime(u)?.AddSeconds(delaySeconds) <= now)
+                .OrderByDescending(u => u.GetResurrectionWeight())
+                .FirstOrDefault();
+
+            if (target == null)
+                return false;
+
+            // One targeted use per pulse. NOT the shared UseItem() extension: it loops UseItem() with no
+            // target and no inter-use delay, which would fire on the wrong unit and re-fire every frame
+            // until the revive lands (burning multiple Phoenix Downs). Stamp the throttle and use once;
+            // the frame-pulsed Execute re-checks the reserve/target next tick.
+            _recentUses[target.ObjectId] = now;
+            PruneThrottle(now);
+
+            Logger.WriteInfo($"[Phoenix Down] Reviving {target.Name} ({target.CurrentJob})");
+            item.UseItem(target);
+            return true;
+        }
+
+        private static void PruneThrottle(DateTime now)
+        {
+            if (_recentUses.Count < 16)
+                return;
+
+            foreach (var stale in _recentUses.Where(kv => now - kv.Value > UseThrottle).Select(kv => kv.Key).ToList())
+                _recentUses.Remove(stale);
+        }
+    }
+}

--- a/Magitek/Models/Account/BaseSettings.cs
+++ b/Magitek/Models/Account/BaseSettings.cs
@@ -582,5 +582,17 @@ namespace Magitek.Models.Account
         [DefaultValue(true)]
         public bool MagitekMovement { get; set; }
 
+        [Setting]
+        [DefaultValue(false)]
+        public bool UsePhoenixDown { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int PhoenixDownDelaySeconds { get; set; }
+
+        [Setting]
+        [DefaultValue(3)]
+        public int PhoenixDownReserve { get; set; }
+
     }
 }

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -14550,6 +14550,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use Phoenix Downs to revive fallen allies (duties only).
+        /// </summary>
+        public static string Views_Content_Use_Phoenix_Down {
+            get {
+                return ResourceManager.GetString("Views_Content_Use_Phoenix_Down", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use PvP Aggro Count Overlay.
         /// </summary>
         public static string Views_Content_Use_Pvp_Aggro_Count_Overlay {
@@ -14744,6 +14753,24 @@ namespace Magitek.Properties {
         public static string Views_Text_Overlay_Settings {
             get {
                 return ResourceManager.GetString("Views_Text_Overlay_Settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seconds to wait after a death before using one:.
+        /// </summary>
+        public static string Views_Text_Phoenix_Down_Delay {
+            get {
+                return ResourceManager.GetString("Views_Text_Phoenix_Down_Delay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Keep at least this many in reserve:.
+        /// </summary>
+        public static string Views_Text_Phoenix_Down_Reserve {
+            get {
+                return ResourceManager.GetString("Views_Text_Phoenix_Down_Reserve", resourceCulture);
             }
         }
         

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -5484,4 +5484,13 @@ Does not work if Lightspeed is disabled.</value>
   <data name="VariantDungeon_Text_VariantEagleEyeShotDescription" xml:space="preserve">
     <value>Ranged attack (25y). 60s cooldown. Available to all roles.</value>
   </data>
+  <data name="Views_Content_Use_Phoenix_Down" xml:space="preserve">
+    <value>Use Phoenix Downs to revive fallen allies (duties only)</value>
+  </data>
+  <data name="Views_Text_Phoenix_Down_Delay" xml:space="preserve">
+    <value>Seconds to wait after a death before using one:</value>
+  </data>
+  <data name="Views_Text_Phoenix_Down_Reserve" xml:space="preserve">
+    <value>Keep at least this many in reserve:</value>
+  </data>
 </root>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -5712,4 +5712,13 @@
   <data name="VariantDungeon_Text_VariantEagleEyeShotDescription" xml:space="preserve">
     <value>远程攻击（25 码）。60 秒冷却。所有职能可用。</value>
   </data>
+  <data name="Views_Content_Use_Phoenix_Down" xml:space="preserve">
+    <value>使用凤凰尾复活阵亡的队友（仅副本内）</value>
+  </data>
+  <data name="Views_Text_Phoenix_Down_Delay" xml:space="preserve">
+    <value>队友阵亡后等待多少秒再使用：</value>
+  </data>
+  <data name="Views_Text_Phoenix_Down_Reserve" xml:space="preserve">
+    <value>至少保留的数量：</value>
+  </data>
 </root>

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -25,7 +25,10 @@ namespace Magitek.Utilities
         // True while the tracked cast is a revive (Phoenix Down). The healer NeedToInterruptCast
         // checks cancel any cast whose target is dead unless it is that job's own raise spell —
         // and a revive's target is dead by definition, so they need this to tell the two apart.
-        // Cleared wherever CastingTime stops, so it is true exactly while the revive is tracked.
+        // Cleared wherever CastingTime stops AND at every ordinary-cast registration (the three
+        // CastingTime.Restart sites in SpellDataExtensions, beside their CastingHeal writes) — a
+        // stop is not guaranteed to run if the routine halts or the zone changes mid-revive, and a
+        // latched flag would hand the next cast the revive exemption.
         public static bool CastingRevive;
         public static SpellData CastingSpell;
         public static SpellData LastSpell;

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -22,6 +22,11 @@ namespace Magitek.Utilities
     {
         #region Variables
         public static bool CastingHeal;
+        // True while the tracked cast is a revive (Phoenix Down). The healer NeedToInterruptCast
+        // checks cancel any cast whose target is dead unless it is that job's own raise spell —
+        // and a revive's target is dead by definition, so they need this to tell the two apart.
+        // Cleared wherever CastingTime stops, so it is true exactly while the revive is tracked.
+        public static bool CastingRevive;
         public static SpellData CastingSpell;
         public static SpellData LastSpell;
         public static bool LastSpellSucceeded;
@@ -101,6 +106,15 @@ namespace Magitek.Utilities
                 await CancelCast();
                 return true;
             }
+
+            // A revive (Phoenix Down) targets a body that is dead by definition, and the job checks
+            // below cancel any cast on a dead target unless it is that job's own raise spell — so every
+            // one of them would kill the revive on its first tracked pulse. None of their other cancels
+            // can apply either (each is keyed to the job's own spells), so exempt the revive here once
+            // rather than carving an exception into all seven jobs. The target-validity checks above
+            // still run: a despawned corpse still cancels.
+            if (CastingRevive)
+                return true;
 
             // ReSharper disable once SwitchStatementMissingSomeCases
             switch (RotationManager.CurrentRotation)
@@ -195,6 +209,7 @@ namespace Magitek.Utilities
                     Logger.Error(msg);
 
                 CastingTime.Stop();
+                CastingRevive = false;
             }
             catch (Exception)
             {
@@ -215,6 +230,7 @@ namespace Magitek.Utilities
                 UseRefreshTime = false;
                 DoHealthChecks = false;
                 CastingHeal = false;
+                CastingRevive = false;
                 CastingGambit = false;
                 Callback = null;
                 return;
@@ -225,8 +241,12 @@ namespace Magitek.Utilities
             //This is to ensure that the instant Action we just tried to use
             //was indeed used and not rejected from the server.
             //Logic behind this is, that every Action will trigger some kind of cooldown
+            // !CastingRevive: Phoenix Down's BackingAction reports AdjustedCastTime 0 despite the real
+            // 8s cast bar, so without the exemption this shortcut returns with the timer still running
+            // and the revive flag latched. The revive must fall through to the buffer maths below, which
+            // its literal SpellCastTime was set up for.
             if (BaseSettings.Instance.UseAdvancedSpellHistory2)
-                if (CastingSpell.AdjustedCastTime.TotalMilliseconds == 0 && CastingSpell.Cooldown.TotalMilliseconds == 0)
+                if (CastingSpell.AdjustedCastTime.TotalMilliseconds == 0 && CastingSpell.Cooldown.TotalMilliseconds == 0 && !CastingRevive)
                     return;
 
             // Compare Times
@@ -235,6 +255,7 @@ namespace Magitek.Utilities
 
             // Stop Timer
             CastingTime.Stop();
+            CastingRevive = false;
 
             // Did we successfully cast?
             if (buffer > 800)

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -109,12 +109,19 @@ namespace Magitek.Utilities
 
             // A revive (Phoenix Down) targets a body that is dead by definition, and the job checks
             // below cancel any cast on a dead target unless it is that job's own raise spell — so every
-            // one of them would kill the revive on its first tracked pulse. None of their other cancels
-            // can apply either (each is keyed to the job's own spells), so exempt the revive here once
-            // rather than carving an exception into all seven jobs. The target-validity checks above
-            // still run: a despawned corpse still cancels.
+            // one of them would kill the revive on its first tracked pulse. Exempt the revive here once
+            // rather than carving an exception into all seven jobs, but keep the ONE cancel that is
+            // meaningful for it, the same one every healer applies to its own raise: someone else's
+            // raise landed first, so finishing the cast would spend a Phoenix Down on a claimed corpse.
+            // The target-validity checks above still run: a despawned corpse still cancels.
             if (CastingRevive)
+            {
+                if (SpellTarget is Character corpse
+                    && (corpse.CurrentHealth > 0 || corpse.HasAura(Auras.Raise)))
+                    await CancelCast("Revive target was already raised");
+
                 return true;
+            }
 
             // ReSharper disable once SwitchStatementMissingSomeCases
             switch (RotationManager.CurrentRotation)

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -239,7 +239,12 @@ namespace Magitek.Utilities.Managers
             if (Globals.InSanctuaryOrSafeZone)
                 return false;
 
-            return await ExecuteRotationMethod(RotationManager.CurrentRotation, "Heal");
+            // Phoenix Down is a last resort: run the job's own heal and raise first so free raises
+            // and emergency heals of the living always take priority over spending a consumable.
+            if (await ExecuteRotationMethod(RotationManager.CurrentRotation, "Heal"))
+                return true;
+
+            return await PhoenixDown.Execute();
         }
 
         public override async Task<bool> CombatBuff()

--- a/Magitek/Views/SettingsModal.xaml
+++ b/Magitek/Views/SettingsModal.xaml
@@ -58,6 +58,17 @@
                                 <controls:Numeric MaxValue="5000" MinValue="0" Value="{Binding GeneralSettings.UserLatencyOffset, Mode=TwoWay}" />
                                 <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Views_Text_NoClippyXivAlexander_simulate_a_10ms_pi}" />
                             </StackPanel>
+                            <StackPanel Margin="2" Orientation="Horizontal">
+                                <CheckBox Content="{x:Static properties:Resources.Views_Content_Use_Phoenix_Down}" IsChecked="{Binding GeneralSettings.UsePhoenixDown, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                            </StackPanel>
+                            <StackPanel Margin="2" Orientation="Horizontal">
+                                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Views_Text_Phoenix_Down_Delay}" />
+                                <controls:Numeric MaxValue="300" MinValue="0" Value="{Binding GeneralSettings.PhoenixDownDelaySeconds, Mode=TwoWay}" />
+                            </StackPanel>
+                            <StackPanel Margin="2" Orientation="Horizontal">
+                                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Views_Text_Phoenix_Down_Reserve}" />
+                                <controls:Numeric MaxValue="99" MinValue="0" Value="{Binding GeneralSettings.PhoenixDownReserve, Mode=TwoWay}" />
+                            </StackPanel>
                         </StackPanel>
                     </controls:SettingsBlock>
                     


### PR DESCRIPTION
Uses Phoenix Downs to revive fallen party members and Duty Support NPCs in instanced content, as a last resort after the job's own raise.

- Runs only in instanced content, deferring to the game's own item gating for which duties permit it — the assumption that the item's usability check fully encodes duty legality has not been separately verified in every duty type
- Keeps a configurable reserve so the routine never spends a player's last few
- Waits out the death delay first, so a real raise always takes priority
- Orders targets healers, then tanks, then DPS
- Waits for the item cast to finish rather than treating the start as done, which previously let the next pulse walk away and cancel the revive
- Skips corpses whose object has been freed, which could otherwise throw out of the whole heal step

Off by default. Test plan: enable in a Duty Support dungeon with raises disabled, let an NPC or party member die, and confirm one Phoenix Down is used after the configured delay, the reserve floor is respected, and no second down is spent on the same corpse while the revive registers.