### PR TITLE
ALL - Stop the rotation crashing out when a target dies mid-pulse

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -536,8 +536,12 @@ namespace Magitek.Extensions
         public static float RadiansFromPlayerHeading(this GameObject target)
         {
             var playerLocation = Core.Me.Location;
-            var playerHeading = GameSettingsManager.FaceTargetOnAction && BaseSettings.Instance.UseAutoFaceChecks ?
-                MathEx.NormalizeRadian(MathHelper.CalculateHeading(playerLocation, Core.Me.CurrentTarget.Location) + (float)Math.PI)
+            // Snapshot the current target: this helper runs inside stun/interrupt candidate scans, which is
+            // exactly when enemies are dying — the target can clear between the caller's null check and this
+            // read. With no target to auto-face, the player's actual heading is the truth anyway.
+            var facingTarget = Core.Me.CurrentTarget;
+            var playerHeading = GameSettingsManager.FaceTargetOnAction && BaseSettings.Instance.UseAutoFaceChecks && facingTarget != null ?
+                MathEx.NormalizeRadian(MathHelper.CalculateHeading(playerLocation, facingTarget.Location) + (float)Math.PI)
                 :
                 Core.Me.Heading;
             var targetLocation = target.Location;

--- a/Magitek/Logic/Astrologian/Aoe.cs
+++ b/Magitek/Logic/Astrologian/Aoe.cs
@@ -106,13 +106,21 @@ namespace Magitek.Logic.Astrologian
             if (!Spells.Oracle.IsKnownAndReady())
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= Spells.Oracle.Radius) < AstrologianSettings.Instance.OracleEnemies)
+            // Snapshot the target rather than reading it repeatedly. The game can clear it at any point,
+            // including partway through the Count below, and a null reaching Distance() inside the
+            // predicate throws out of the whole rotation instead of just declining this one action.
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
+                return false;
+
+            if (Combat.Enemies.Count(r => r.Distance(target) <= Spells.Oracle.Radius) < AstrologianSettings.Instance.OracleEnemies)
                 return false;
 
             if (!Core.Me.HasAura(Auras.Divining, true))
                 return false;
 
-            return await Spells.Oracle.Cast(Core.Me.CurrentTarget);
+            return await Spells.Oracle.Cast(target);
 
         }
 

--- a/Magitek/Logic/DarkKnight/Aoe.cs
+++ b/Magitek/Logic/DarkKnight/Aoe.cs
@@ -22,14 +22,16 @@ namespace Magitek.Logic.DarkKnight
             if (!DarkKnightSettings.Instance.UseAbyssalDrain)
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
                 return false;
 
-            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 5);
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(target) <= 5);
             if (enemyCount < DarkKnightSettings.Instance.AbyssalDrainEnemies)
                 return false;
 
-            return await Spells.AbyssalDrain.Cast(Core.Me.CurrentTarget);
+            return await Spells.AbyssalDrain.Cast(target);
         }
 
         public static async Task<bool> SaltedEarth()
@@ -125,10 +127,12 @@ namespace Magitek.Logic.DarkKnight
             if (!DarkKnightSettings.Instance.UseFloodDarknessShadow)
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
                 return false;
 
-            var enemyCount = Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 10 + r.CombatReach);
+            var enemyCount = Combat.Enemies.Count(r => r.Distance(target) <= 10 + r.CombatReach);
             if (enemyCount < DarkKnightSettings.Instance.FloodEnemies)
                 return false;
 
@@ -138,7 +142,7 @@ namespace Magitek.Logic.DarkKnight
             if (Core.Me.CurrentMana < DarkKnightSettings.Instance.SaveXMana + 3000)
                 return false;
 
-            return await Spells.FloodofDarkness.Cast(Core.Me.CurrentTarget);
+            return await Spells.FloodofDarkness.Cast(target);
         }
     }
 }

--- a/Magitek/Logic/Sage/AoE.cs
+++ b/Magitek/Logic/Sage/AoE.cs
@@ -25,11 +25,13 @@ namespace Magitek.Logic.Sage
             if (!Spells.Phlegma.IsKnown())
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
                 return false;
 
             // Phlegma is a great 550 potency single target attack.
-            //if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= Spells.Phlegma.Radius + r.CombatReach) < SageSettings.Instance.AoEEnemies)
+            //if (Combat.Enemies.Count(r => r.Distance(target) <= Spells.Phlegma.Radius + r.CombatReach) < SageSettings.Instance.AoEEnemies)
             //    return false;
             var spell = Spells.PhlegmaIII;
             if (!Spells.PhlegmaIII.IsKnown())
@@ -38,7 +40,7 @@ namespace Magitek.Logic.Sage
             if (spell.Charges == 0)
                 return false;
 
-            return await spell.Cast(Core.Me.CurrentTarget);
+            return await spell.Cast(target);
         }
 
         public static async Task<bool> Dyskrasia()
@@ -137,7 +139,9 @@ namespace Magitek.Logic.Sage
             if (!Spells.Toxikon.IsKnown())
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
                 return false;
 
             if (Addersting == 0)
@@ -151,7 +155,7 @@ namespace Magitek.Logic.Sage
             }
             else
             {
-                var enemyCountCheck = SageSettings.Instance.AoE && Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= Spells.Toxikon.Radius + r.CombatReach) >= SageSettings.Instance.AoEEnemies;
+                var enemyCountCheck = SageSettings.Instance.AoE && Combat.Enemies.Count(r => r.Distance(target) <= Spells.Toxikon.Radius + r.CombatReach) >= SageSettings.Instance.AoEEnemies;
                 var adderstingCheck = SageSettings.Instance.ToxiconOnFullAddersting && Addersting == 3;
                 var lowManaCheck = SageSettings.Instance.ToxiconOnLowMana && Core.Me.CurrentManaPercent < SageSettings.Instance.MinimumManaPercentToDoDamage;
 
@@ -162,7 +166,7 @@ namespace Magitek.Logic.Sage
             if (doToxicon)
             {
                 var spell = Spells.ToxikonII.IsKnown() ? Spells.ToxikonII : Spells.Toxikon;
-                return await spell.Cast(Core.Me.CurrentTarget);
+                return await spell.Cast(target);
             }
             else
             {
@@ -186,16 +190,18 @@ namespace Magitek.Logic.Sage
             if (SageSettings.Instance.PneumaHealOnly)
                 return false;
 
-            if (Core.Me.CurrentTarget == null)
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= Spells.Pneuma.Radius) < SageSettings.Instance.AoEEnemies)
+            if (Combat.Enemies.Count(r => r.Distance(target) <= Spells.Pneuma.Radius) < SageSettings.Instance.AoEEnemies)
                 return false;
 
             if (Spells.Pneuma.Cooldown != TimeSpan.Zero)
                 return false;
 
-            return await Spells.Pneuma.Cast(Core.Me.CurrentTarget);
+            return await Spells.Pneuma.Cast(target);
         }
 
         public static async Task<bool> Psyche()
@@ -206,13 +212,18 @@ namespace Magitek.Logic.Sage
             if (!SageSettings.Instance.UsedPsyche)
                 return false;
 
-            if (Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= Spells.Psyche.Radius) < SageSettings.Instance.PsycheAoEEnemies)
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null)
+                return false;
+
+            if (Combat.Enemies.Count(r => r.Distance(target) <= Spells.Psyche.Radius) < SageSettings.Instance.PsycheAoEEnemies)
                 return false;
 
             if (!Spells.Psyche.IsKnown())
                 return false;
 
-            return await Spells.Psyche.Cast(Core.Me.CurrentTarget);
+            return await Spells.Psyche.Cast(target);
         }
     }
 }

--- a/Magitek/Logic/WhiteMage/SingleTarget.cs
+++ b/Magitek/Logic/WhiteMage/SingleTarget.cs
@@ -42,10 +42,13 @@ namespace Magitek.Logic.WhiteMage
                 return false;
             if (ActionResourceManager.WhiteMage.BloodLily < 3)
                 return false;
-            if (!BotManager.Current.IsAutonomous && !MovementManager.IsMoving
-                && Combat.Enemies.Count(r => r.Distance(Core.Me.CurrentTarget) <= 5 + r.CombatReach) < WhiteMageSettings.Instance.AfflatusMiseryEnemies)
+            var target = Core.Me.CurrentTarget;
+            if (target == null)
                 return false;
-            return await Spells.AfflatusMisery.Cast(Core.Me.CurrentTarget);
+            if (!BotManager.Current.IsAutonomous && !MovementManager.IsMoving
+                && Combat.Enemies.Count(r => r.Distance(target) <= 5 + r.CombatReach) < WhiteMageSettings.Instance.AfflatusMiseryEnemies)
+                return false;
+            return await Spells.AfflatusMisery.Cast(target);
         }
 
         public static async Task<bool> ForceAfflatusMisery()


### PR DESCRIPTION
A target dying mid-pulse could throw a null reference out of the rotation rather than simply declining the action, taking down the whole combat tick.

- Astrologian Oracle, Sage Phlegma / Toxikon / Pneuma / Psyche, Dark Knight Abyssal Drain and Flood of Darkness, and White Mage Afflatus Misery now capture the target once and use it for the whole action
- Fixes a case where Flood of Darkness could fire at a different enemy than the one its enemy count was validated against, bypassing the threshold
- Observed as a live crash after a target despawned mid-cast

PvP paths are left out of scope here: several carry the same crash shape and deserve the same one-capture treatment in a dedicated PvP pass rather than as riders on this one.