### PR TITLE
FightLogic - Add anti-knockback for three dungeon knockbacks and name two enemies

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -4557,6 +4557,9 @@ namespace Magitek.Utilities
                         Aoes = new List<uint> {
                             25170 //Flames of Decay
                         },
+                        Knockbacks = new List<uint> {
+                            25169 // Cosmic Kiss
+                        },
                         BigAoes = null
                     }
                 }
@@ -4796,7 +4799,7 @@ namespace Magitek.Utilities
                 Expansion = FfxivExpansion.Endwalker,
                 Enemies = new List<Enemy> {
                     new Enemy {
-                        Id = 0, // Assuming an ID for Dark Elf
+                        Id = 12500,
                         Name = "Dark Elf",
                         TankBusters = new List<uint>() {
                             0x8984, // Staff Smite
@@ -4815,7 +4818,7 @@ namespace Magitek.Utilities
                         }
                     },
                     new Enemy {
-                        Id = 0, // Assuming an ID for Damcyan Antlion
+                        Id = 12484,
                         Name = "Damcyan Antlion",
                         TankBusters = new List<uint>() {
                             // No tank busters mentioned in the TypeScript data
@@ -6219,7 +6222,9 @@ namespace Magitek.Utilities
                             37392, // barbed bellow
                         },
                         AoeLockOns = null,
-                        Knockbacks = null,
+                        Knockbacks = new List<uint> {
+                            37390, // Barrel Breaker
+                        },
                         SharedTankBusters = null,
                         BigAoes = null
                     },
@@ -6255,7 +6260,11 @@ namespace Magitek.Utilities
                             543,
                             542,
                         },
-                        Knockbacks = null,
+                        Knockbacks = new List<uint> {
+                            36742, // Greatest Flood — two castable actions share this name; recorded
+                                   // data can't tell which the server fires, so both are listed
+                            36756, // Greatest Flood
+                        },
                         SharedTankBusters = null,
                         BigAoes = null
                     },
@@ -7249,6 +7258,9 @@ namespace Magitek.Utilities
                         Aoes = new List<uint> {
                             43327, // Earthquake
                             43331, // Thunder II
+                            // Ray of Lightning is a line stack: this id marks a single player, then the
+                            // damage lands on everyone stacked with them. Only the marker is castable,
+                            // so it is what fight logic can react to.
                             44825, // Ray of Lightning
                         },
                         AoeLockOns = null,


### PR DESCRIPTION
Additions and corrections to encounter data.

- Cosmic Kiss (Svarbhanu, Vanaspati), Barrel Breaker (Barreltender, Tender Valley) and Greatest Flood (Greatest Serpent of Tural, Tender Valley) are knockbacks with no catalogue coverage before this change; they now draw anti-knockback responses
- Greatest Flood is listed under both of its identically named castable action ids — recorded data alone cannot tell which one the server fires, and an unused id in the list is harmless while a missing one is silently dead
- Names two enemies in the Lunar Subterrane that carried placeholder ids; both already matched by name, so this is bookkeeping rather than a behavior change
- Notes in a comment that Ray of Lightning (Treno Catoblepas, Mistwake) is a line stack rather than a single-target hit, so it stays under party mitigation where it belongs

Classifications were checked against the game's action data (cast type and effect range) and recorded combat logs from these dungeons; none of the entries has live in-game validation yet, which is why Greatest Flood ships both candidate ids.