### PR TITLE
HEALERS - Shield a reachable tank on shared tank busters instead of the wrong one or none

### DIFF
--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -119,8 +119,18 @@ namespace Magitek.Utilities
                 return null;
             FlHandledCastingSpellId.Clear();
 
+            // Every tank stacks for a shared buster, so every tank takes a share and every tank wants
+            // covering. Healers pass this result straight to a cast, so it has to name a tank they can
+            // actually reach — CastableTanks is our own party, not the alliance.
+            //
+            // Prefer the tank being aimed at when they are in our party. In an alliance raid the target is
+            // usually in a different party, and the tank we can reach is ours, stacking in to share the
+            // damage — so fall back to them rather than returning nothing. Returning the target alone left
+            // a healer in another party doing nothing while their tank ate a share; returning a non-target
+            // alone shielded the co-tank while the tank being hit went uncovered.
             var output = enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
-                ? Group.CastableTanks.FirstOrDefault(x => x != enemy.TargetCharacter)
+                ? Group.CastableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
+                  ?? Group.CastableTanks.FirstOrDefault()
                 : null;
 
             if (output != null && DebugSettings.Instance.DebugFightLogic)

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -2,6 +2,7 @@
 using ff14bot;
 using ff14bot.Managers;
 using ff14bot.Objects;
+using Magitek.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -133,7 +134,11 @@ namespace Magitek.Utilities
             // outside heal range. Naming one satisfies the preferred-target branch, skips the fallback and
             // then fails the caller's own CanCast — no mitigation at all. Restrict both branches to tanks
             // inside standard heal range so the fallback can still find the co-tank we can reach.
-            var reachableTanks = Group.CastableTanks.Where(Group.CastableAlliesWithin30.Contains).ToList();
+            //
+            // WithinSpellRange, not the CastableAlliesWithin30 list: that list is built from raw
+            // centre-to-centre distance, so a large tank whose edge is well inside 30y can fall out of it
+            // and be passed over for a co-tank while the game would have allowed the cast.
+            var reachableTanks = Group.CastableTanks.Where(x => x.WithinSpellRange(30)).ToList();
 
             var output = enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
                 ? reachableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -128,9 +128,16 @@ namespace Magitek.Utilities
             // damage — so fall back to them rather than returning nothing. Returning the target alone left
             // a healer in another party doing nothing while their tank ate a share; returning a non-target
             // alone shielded the co-tank while the tank being hit went uncovered.
+            //
+            // CastableTanks is built before Group applies any distance filter, so it can name a tank well
+            // outside heal range. Naming one satisfies the preferred-target branch, skips the fallback and
+            // then fails the caller's own CanCast — no mitigation at all. Restrict both branches to tanks
+            // inside standard heal range so the fallback can still find the co-tank we can reach.
+            var reachableTanks = Group.CastableTanks.Where(Group.CastableAlliesWithin30.Contains).ToList();
+
             var output = enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
-                ? Group.CastableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
-                  ?? Group.CastableTanks.FirstOrDefault()
+                ? reachableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
+                  ?? reachableTanks.FirstOrDefault()
                 : null;
 
             if (output != null && DebugSettings.Instance.DebugFightLogic)


### PR DESCRIPTION
On a shared tank buster every tank stacks in and takes a share, so every tank wants covering. Healers were reliably covering the wrong one.

The check resolved to a tank that was **not** the target. Two callers read that very differently:

- The tank's own defensive only checks whether the result is non-null, so it kept working and tanks still mitigated themselves
- Astrologian, Sage, Scholar and White Mage pass the result straight to a cast, so they shielded the co-tank and left the tank actually being aimed at with no external mitigation

It now prefers the targeted tank when they are in our party, and otherwise falls back to a tank we can reach. That second half matters in alliance raids, where the target is usually in a different party: the tank we can actually cast on is our own, stacking in to share the damage, and returning only the target would have left that healer doing nothing at all.

No change was needed in the healer files; they were asking the right question and getting the wrong answer.

Not yet exercised in game — wants a live shared tank buster, ideally from a healer in a party that does not hold the target.