### PR TITLE
Core - Stop crashes when an enemy or ally despawns during combat checks

### DIFF
--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -355,7 +355,13 @@ namespace Magitek.Utilities
         private static (Encounter, Enemy, BattleCharacter) GetEnemyLogicAndEnemy()
         {
             if (GetEnemyLogicAndEnemyCacheAge.IsRunning && GetEnemyLogicAndEnemyCacheAge.ElapsedMilliseconds < 1000)
-                return GetEnemyLogicAndEnemyCached;
+            {
+                // The enemy can despawn while it sits in this cache, and every selector reads game
+                // memory off it (CastingSpellId etc.) — on a freed object that read throws and kills
+                // the whole combat pulse. A dead entry falls through and recomputes instead.
+                if (GetEnemyLogicAndEnemyCached.Item3 == null || GetEnemyLogicAndEnemyCached.Item3.IsValid)
+                    return GetEnemyLogicAndEnemyCached;
+            }
 
             Encounter encounter = null;
             Enemy enemyLogic = null;

--- a/Magitek/Utilities/Group.cs
+++ b/Magitek/Utilities/Group.cs
@@ -124,7 +124,7 @@ namespace Magitek.Utilities
                 Logger.WriteInfo($"PartyManager: {String.Join(", ",PartyManager.AllMembers.Select(x => x.Name))}");
             }*/
 
-            foreach (var ally in CastableParty.OrderBy(a => a.GetHealingWeight()))
+            foreach (var ally in CastableParty.Where(a => a != null && a.IsValid).OrderBy(a => a.GetHealingWeight()))
             {
 
                 AddAllyToCastable(ally);
@@ -190,7 +190,10 @@ namespace Magitek.Utilities
         {
             ClearCastable();
 
-            foreach (var ally in CastableAlliance.OrderBy(a => a.GetHealingWeight()))
+            // An alliance member can despawn between the list refresh and this sort; the weight
+            // comparer reads their job from game memory, which throws on a freed object and kills
+            // the healer's whole pulse. Skip anything no longer valid.
+            foreach (var ally in CastableAlliance.Where(a => a != null && a.IsValid).OrderBy(a => a.GetHealingWeight()))
             {
                 AddAllyToCastable(ally);
             }
@@ -200,7 +203,7 @@ namespace Magitek.Utilities
         {
             ClearCastable();
 
-            foreach (var ally in CastableParty.OrderBy(a => a.GetHealingWeight()))
+            foreach (var ally in CastableParty.Where(a => a != null && a.IsValid).OrderBy(a => a.GetHealingWeight()))
             {
                 AddAllyToCastable(ally);
             }


### PR DESCRIPTION
## What this changes

Two guards against reading game memory off objects that despawned after being cached:

- The fight-logic enemy cache (1s lifetime) now re-checks that its cached enemy is still valid before handing it to the mechanic selectors; a dead entry falls through and recomputes from the live enemy list.
- The weighted-healing sorts over the cached party/alliance lists now skip members whose objects are no longer valid, in all three places that sort by healing weight.

## Why

Two crash signatures from field sessions this week, both killing the entire combat/heal pulse via `CoroutineUnhandledException`:

- Summoner in a field operation: `ReadWriteMemoryException` from the big-AoE selector reading the casting id of an enemy that had despawned while cached (one incident, whole Combat pulse lost).
- Sage in an alliance raid: `ReadWriteMemoryException` three times from the healing-weight sort reading the job of an alliance member whose object had been freed — each one killed the Heal pulse mid-raid.

Both guards follow the existing `null || !IsValid` pattern already used throughout the aura-check extensions.

## Game-behavior assumptions I could not verify

| # | Assumption | Based on | Confidence | If wrong, the impact is |
|---|-----------|----------|------------|-------------------------|
| 1 | A unit that passes IsValid at the start of a check remains readable for the rest of that pulse | the same assumption made by the existing IsValid guards in the aura extensions | high | crash rate is greatly reduced but not strictly zero; the residual window shrinks from up to 1s to a single pulse |

## In-game test plan

1. Setup: any healer, alliance raid (Jeuno) with weighted healing priority enabled.
2. Play through boss deaths and add phases where alliance members die and release — previously this intermittently logged `ReadWriteMemoryException ... GetHealingWeight` and skipped healing for that pulse.
3. Expected: no `CoroutineUnhandledException` entries in the log with `GetHealingWeight` or `EnemyIsCastingBigAoe` in the stack.
4. Setup 2: any DPS with fight logic on, in content where catalogued bosses despawn mid-cast (field operation critical engagements).
5. Expected: mechanic reactions keep firing normally; no crash lines.