### PR TITLE
RDM - Fix rotation freezing for 30 seconds after Riposte in level-synced content

### DIFF
--- a/Magitek/Logic/RedMage/Utility.cs
+++ b/Magitek/Logic/RedMage/Utility.cs
@@ -19,17 +19,19 @@ namespace Magitek.Logic.RedMage
             if (!Spells.Riposte.IsKnown())
                 return false;
 
-            if (!Spells.Zwerchhau.IsKnown())
-            {
-                if (RedMageRoutine.CanContinueComboAfter(Spells.Riposte) || RedMageRoutine.CanContinueComboAfter(Spells.EnchantedRiposte))
-                    return true;
-            }
-            else
-            {
-                if (RedMageRoutine.CanContinueComboAfter(Spells.Riposte) || RedMageRoutine.CanContinueComboAfter(Spells.EnchantedRiposte)
-                || RedMageRoutine.CanContinueComboAfter(Spells.Zwerchhau) || RedMageRoutine.CanContinueComboAfter(Spells.EnchantedZwerchhau))
-                    return true;
-            }
+            // Hold GCDs for the melee combo only when the NEXT link actually exists at this level.
+            // Under level sync (deep dungeons go as low as 1) the game still arms the 30s combo
+            // window after Riposte, but with Zwerchhau/Redoublement unlearned there is nothing to
+            // continue with — holding for a continuation that can't exist idles the routine for the
+            // whole window, over and over. At 50+ this is behavior-identical to the old check.
+            if (Spells.Zwerchhau.IsKnown()
+                && (RedMageRoutine.CanContinueComboAfter(Spells.Riposte) || RedMageRoutine.CanContinueComboAfter(Spells.EnchantedRiposte)))
+                return true;
+
+            if (Spells.Redoublement.IsKnown()
+                && (RedMageRoutine.CanContinueComboAfter(Spells.Zwerchhau) || RedMageRoutine.CanContinueComboAfter(Spells.EnchantedZwerchhau)))
+                return true;
+
             return false;
         }
         public static int ManaStacks()


### PR DESCRIPTION
## Summary
- Below level 50 in level-synced content (Deep Dungeons, low-level duties), the rotation froze for up to 30 seconds after each Riposte, then repeated the cycle once mana rebuilt. In Palace of the Dead the routine sat idle for roughly half of every fight, which players experience as the CR not knowing what to do at low levels.
- Cause: the game opens its 30-second combo window after Riposte even when the next combo step (Zwerchhau below 35, Redoublement below 50) is not yet learned at the synced level, so the rotation held every GCD waiting for a continuation that could not exist until the window expired.
- Fix: the melee combo hold now only engages when the next combo step is actually available at the current level. Level 50+ behavior is unchanged.

## Testing
- Reproduced in Palace of the Dead on a synced Red Mage: before the fix, logs show a ~30 second action freeze after every Riposte; after the fix, a full run completed with zero hangs and the next spell always followed within a GCD.
- Likely resolves the recent Discord report of the CR "not knowing what to do at lower levels" in Deep Dungeons.