### PR TITLE
OC - Add Phantom Necromancer support

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -4924,6 +4924,11 @@ namespace Magitek.Logic.Roles
             if (SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // The nuke has a cast time, and a queued cast that cannot start keeps the queue
+            // non-empty - which stalls the whole pulse. Do not open the pair on the move.
+            if (MovementManager.IsMoving && !Core.Me.HasAura(Auras.Swiftcast))
+                return false;
+
             if (!OCSpells.DrainTouch.CanCast())
                 return false;
 
@@ -4961,10 +4966,19 @@ namespace Magitek.Logic.Roles
                 {
                     new QueueSpellCheck
                     {
-                        Name = "Line spell target still valid",
+                        Name = "Nuke target still valid",
                         Check = () => Core.Me.InCombat
                                       && Core.Me.CurrentTarget != null
                                       && Core.Me.CurrentTarget.ValidAttackUnit()
+                    },
+                    // If movement starts after the pair is queued the cast cannot begin, and a
+                    // queued spell that never casts holds the queue - and the pulse with it -
+                    // until the timeout. Drop it instead: the 6s empowerment outlives this, so
+                    // the standalone path spends it as soon as we are standing still again.
+                    new QueueSpellCheck
+                    {
+                        Name = "Standing still for the cast",
+                        Check = () => !MovementManager.IsMoving || Core.Me.HasAura(Auras.Swiftcast)
                     }
                 },
                 Wait = new QueueSpellWait
@@ -5031,7 +5045,10 @@ namespace Magitek.Logic.Roles
             if (!target.WithinSpellRange(OCSpells.Doomsday.Range))
                 return false;
 
-            if (Combat.Enemies.Count(e => e.WithinSpellRange(OCSpells.Doomsday.Range)) < OccultCrescentSettings.Instance.DoomsdayEnemyCount)
+            // Count the cluster around the TARGET, not everything inside casting range: Doomsday
+            // lands as a circle on the target, so a range-wide count spends the recast and the
+            // self-Doom on enemies scattered well outside the blast.
+            if (target.EnemiesNearby(OCSpells.Doomsday.Radius).Count() < OccultCrescentSettings.Instance.DoomsdayEnemyCount)
                 return false;
 
             return await OCSpells.Doomsday.Cast(target);

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -6,6 +6,7 @@ using ff14bot.Objects;
 using Magitek.Extensions;
 using Magitek.Models;
 using Magitek.Models.OccultCrescent;
+using Magitek.Models.QueueSpell;
 using Magitek.Utilities;
 using System.Linq;
 using System.Threading.Tasks;
@@ -71,6 +72,14 @@ namespace Magitek.Logic.Roles
             OccultMightyGuard = 5321,
             // Phantom Ninja. Smoke is +20% evasion for 90s.
             Smoke = 5327,
+            // Phantom Necromancer. Drain Touch is a 6s self-buff: the caster's next Necromancer
+            // spell is empowered while it lasts.
+            DrainTouch = 5326,
+            // Phantom Necromancer's self-Doom: 10 seconds, kills at expiry regardless of HP, and
+            // only reaching FULL HP removes it. Same status the game uses for classic heal-to-full
+            // Dooms (Utilities Auras.Doom, 1769) - aliased here so the Necromancer block reads
+            // against one aura class.
+            Doom = 1769,
             // Image grants three stacks, each nullifying one physical attack, for 30s. Confirmed
             // in game; note it sits outside the 5316-5335 band the rest of North Horn uses.
             Image = 4873;
@@ -201,6 +210,18 @@ namespace Magitek.Logic.Roles
         public static readonly SpellData OccultBlizzardII = DataManager.GetSpellData(49095);
         public static readonly SpellData OccultThunderII = DataManager.GetSpellData(49096);
 
+        // Phantom Necromancer Spells (Job ID: 5335)
+        // Deep Freeze, Hell Wind and Chaos Drive share a single 40s recast timer, cost 10% of max
+        // HP to cast, and mark the caster with a 10s self-Doom that only reaching full HP removes
+        // (see the Phantom Necromancer region for how that bargain is managed). Drain Touch is
+        // instant, heals the caster for part of its damage and empowers the next Necromancer
+        // spell for 6s. Doomsday is a long-recast AoE that carries the same self-Doom.
+        public static readonly SpellData DrainTouch = DataManager.GetSpellData(49097);
+        public static readonly SpellData DeepFreeze = DataManager.GetSpellData(49098);
+        public static readonly SpellData HellWind = DataManager.GetSpellData(49099);
+        public static readonly SpellData ChaosDrive = DataManager.GetSpellData(49100);
+        public static readonly SpellData Doomsday = DataManager.GetSpellData(49101);
+
         // Phantom Blue Mage Spells (Job ID: 5333)
         // Every action except Occult Aero has to be LEARNED from a specific enemy, gated behind
         // the Occult Learning I/II/III traits, so CanCast does the real work here - a freshly
@@ -221,7 +242,8 @@ namespace Magitek.Logic.Roles
 
         // Phantom Summoner Spells (Job ID: 5332)
         // Hellfire, Judgment Bolt and Thunderstorm share a single 60s recast timer. Thunderstorm
-        // is the only Wind attack any implemented phantom job has. No traits on this job.
+        // and Necromancer's Hell Wind are the only Wind attacks the implemented phantom jobs
+        // have. No traits on this job.
         public static readonly SpellData Hellfire = DataManager.GetSpellData(49080);
         public static readonly SpellData JudgmentBolt = DataManager.GetSpellData(49081);
         public static readonly SpellData EarthenWall = DataManager.GetSpellData(49082);
@@ -547,6 +569,7 @@ namespace Magitek.Logic.Roles
                 PhantomJob.Dragoon => await ExecuteDragoonPhantomJob(),
                 PhantomJob.Summoner => await ExecuteSummonerPhantomJob(),
                 PhantomJob.BlueMage => await ExecuteBlueMagePhantomJob(),
+                PhantomJob.Necromancer => await ExecuteNecromancerPhantomJob(),
                 _ => false
             };
 
@@ -3854,8 +3877,8 @@ namespace Magitek.Logic.Roles
         /// OCAuras.FireWeakness / IceWeakness / LightningWeakness / WindWeakness, and the matching
         /// element hits for bonus potency - so a matched element wins, but the user's toggles
         /// always veto. Failing a match, the first usable candidate wins, so callers list theirs
-        /// in fallback preference order. Wind is covered only by Phantom Summoner's Thunderstorm
-        /// (and Blue Mage's Aero line, once that job is implemented).
+        /// in fallback preference order. Wind is covered by Phantom Summoner's Thunderstorm,
+        /// Necromancer's Hell Wind and Blue Mage's Aero line.
         /// </summary>
         private static SpellData PickElementalNuke(GameObject target, (SpellData Spell, bool Enabled, uint WeaknessAura)[] candidates)
         {
@@ -4515,7 +4538,8 @@ namespace Magitek.Logic.Roles
         /// revealed weakness. Hellfire unlocks at phantom job level 1, Judgment Bolt at 2,
         /// Thunderstorm at 4.
         ///
-        /// Thunderstorm is this routine's only way to exploit Wind Weakness.
+        /// Thunderstorm and Phantom Necromancer's Hell Wind are this routine's only ways to
+        /// exploit Wind Weakness.
         /// </summary>
         private static Task<bool> SummonerElementalNukes()
         {
@@ -4750,6 +4774,298 @@ namespace Magitek.Logic.Roles
 
             return false;
         }
+        #endregion
+
+        #region Phantom Necromancer (Job ID: 5335)
+
+        /// <summary>
+        /// Every Necromancer nuke is a bargain with death: 10% of max HP up front and a 10-second
+        /// self-Doom that only reaching full HP dispels (the Doom also takes an instant, unlogged
+        /// cut of 10% max HP on application, so being full when it lands does not clear it). The
+        /// Doom is not a malfunction to route around - it is the job's rhythm: cast, get healed to
+        /// full, cast again. These gates enforce that rhythm: healthy enough that one heal can
+        /// clear it, the previous Doom gone before the next cast, and a party around to do the
+        /// clearing unless the user explicitly accepts the solo risk.
+        /// </summary>
+        private static bool NecromancerCanAffordDoomSpell()
+        {
+            if (Core.Me.CurrentHealthPercent < OccultCrescentSettings.Instance.NecromancerSpellHealthPercent)
+                return false;
+
+            if (Core.Me.HasAura(OCAuras.Doom))
+                return false;
+
+            if (!Globals.InParty && !OccultCrescentSettings.Instance.NecromancerDoomSpellsSolo)
+                return false;
+
+            // While a telegraphed raidwide is incoming the healers are about to owe the whole
+            // party, not just us - starting a personal death timer into that window is how the
+            // bargain gets lost.
+            if (FightLogic.EnemyIsCastingBigAoe() || FightLogic.EnemyIsCastingAoe())
+                return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// The self-Doom kills at expiry no matter how much HP remains - reaching FULL HP is the
+        /// only cleanse, so while it ticks, every self-heal the current job can offer outranks
+        /// every damage action. Fired from the Necromancer pipeline because that is the only
+        /// phantom source of this Doom; IsKnownAndReady quietly skips the entries the current job
+        /// lacks. Thrill of Battle is deliberately absent: it RAISES max HP, moving the finish
+        /// line. No InCombat gate - the Doom does not care whether combat has ended.
+        /// </summary>
+        private static async Task<bool> NecromancerDoomRecovery()
+        {
+            if (!OccultCrescentSettings.Instance.UseNecromancerDoomRecovery)
+                return false;
+
+            if (!Core.Me.HasAura(OCAuras.Doom))
+                return false;
+
+            if (Core.Me.CurrentHealth >= Core.Me.MaxHealth)
+                return false;
+
+            if (Spells.Equilibrium.IsKnownAndReady() && await Spells.Equilibrium.Cast(Core.Me))
+                return true;
+
+            if (Spells.Aurora.IsKnownAndReady() && await Spells.Aurora.Cast(Core.Me))
+                return true;
+
+            if (Spells.SecondWind.IsKnownAndReady() && await Spells.SecondWind.Cast(Core.Me))
+                return true;
+
+            if (Spells.Bloodbath.IsKnownAndReady() && await Spells.Bloodbath.Cast(Core.Me))
+                return true;
+
+            // Dark Knight's only real HP restorer - its shields cannot cleanse a Doom that
+            // demands the bar actually reach full. Needs a target in range to drain from.
+            if (Spells.AbyssalDrain.IsKnownAndReady()
+                && Core.Me.CurrentTarget != null && Core.Me.CurrentTarget.ValidAttackUnit()
+                && Core.Me.CurrentTarget.WithinSpellRange(Spells.AbyssalDrain.Range)
+                && await Spells.AbyssalDrain.Cast(Core.Me.CurrentTarget))
+                return true;
+
+            // Drain Touch heals for part of its damage - the one Necromancer tool that is
+            // always on the Doom clock's side.
+            return await DrainTouch(doomRecovery: true);
+        }
+
+        /// <summary>
+        /// Drain Touch - instant line attack that heals the caster for part of its damage
+        /// (measured at roughly a third of the HP bar at tank scale) and empowers the next
+        /// Necromancer spell for 6 seconds. Standalone cast for when the elemental nukes are on
+        /// recast or gated - its damage and self-heal stand on their own. As a Doom-recovery
+        /// rung it must stay available after combat drops - the Doom does not.
+        /// </summary>
+        private static async Task<bool> DrainTouch(bool doomRecovery = false)
+        {
+            if (!OccultCrescentSettings.Instance.UseDrainTouch)
+                return false;
+
+            if (!doomRecovery && !Core.Me.InCombat)
+                return false;
+
+            if (!OCSpells.DrainTouch.CanCast())
+                return false;
+
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null || !target.ValidAttackUnit() || !target.InLineOfSight())
+                return false;
+
+            if (!target.WithinSpellRange(OCSpells.DrainTouch.Range))
+                return false;
+
+            return await OCSpells.DrainTouch.Cast(target);
+        }
+
+        /// <summary>
+        /// The elemental candidates for PickElementalNuke, in fallback preference order for when
+        /// no weakness is revealed: Chaos Drive first - its Drain Touch rider is an 18s Paralysis,
+        /// the strongest of the three. Necromancer cannot cast Occult Libra, so with no Red or
+        /// Black Mage around a revealed weakness may simply never exist - holding the shared
+        /// recast for one would waste every 6s empowerment window (observed live: four
+        /// empowerments, zero nukes, one weakness reveal in five minutes).
+        /// </summary>
+        private static (SpellData Spell, bool Enabled, uint WeaknessAura)[] NecromancerElementalCandidates()
+        {
+            var settings = OccultCrescentSettings.Instance;
+
+            return new[]
+            {
+                (OCSpells.ChaosDrive, settings.UseChaosDrive, (uint)OCAuras.LightningWeakness),
+                (OCSpells.HellWind, settings.UseHellWind, (uint)OCAuras.WindWeakness),
+                (OCSpells.DeepFreeze, settings.UseDeepFreeze, (uint)OCAuras.IceWeakness),
+            };
+        }
+
+        /// <summary>
+        /// Enqueues Drain Touch and an elemental nuke as one unbreakable unit. The 6s empowerment
+        /// loses a race against the main job's rotation when the nuke is left for a later
+        /// pulse - the job grabs the next slot every time (observed live: a Dosis 0.2s after
+        /// every Drain Touch, empowerments expiring unused). The spell queue drains ahead of
+        /// everything else in the pulse, so nothing can wedge between empowerment and spender.
+        /// Every gate the two spells carry individually is checked up front, because the queue
+        /// will fire them without asking.
+        /// </summary>
+        private static bool QueueEmpoweredElementalNuke()
+        {
+            if (!OccultCrescentSettings.Instance.UseDrainTouch)
+                return false;
+
+            if (!Core.Me.InCombat)
+                return false;
+
+            // One pair at a time: with a queue already pending, re-queuing from a hook that runs
+            // before the drain would restart the queue timer every pulse and nothing would ever
+            // cast. SpellQueue.Any() is the pending check - InSpellQueue only turns true after
+            // the first drain runs.
+            if (SpellQueueLogic.SpellQueue.Any())
+                return false;
+
+            if (!OCSpells.DrainTouch.CanCast())
+                return false;
+
+            if (!NecromancerCanAffordDoomSpell())
+                return false;
+
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null || !target.ValidAttackUnit() || !target.InLineOfSight())
+                return false;
+
+            if (!target.WithinSpellRange(OCSpells.DrainTouch.Range))
+                return false;
+
+            var nuke = PickElementalNuke(target, NecromancerElementalCandidates());
+
+            if (nuke == null || !target.WithinSpellRange(nuke.Range))
+                return false;
+
+            // Cancel on combat drop as well as timeout: with the target dead, firing the queued
+            // nuke would open the NEXT pull with a self-Doom under gates up to 8s stale.
+            SpellQueueLogic.SpellQueueReset(() => SpellQueueLogic.Timeout.ElapsedMilliseconds > 8000 || !Core.Me.InCombat);
+
+            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell
+            {
+                Spell = OCSpells.DrainTouch
+            });
+            SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell
+            {
+                Spell = nuke,
+                // Re-checked at drain time: if the target died between the pair's two casts, a
+                // failed check dequeues immediately - without it a null target parks the queue
+                // (and with it the whole Heal pulse) until the timeout.
+                Checks = new List<QueueSpellCheck>
+                {
+                    new QueueSpellCheck
+                    {
+                        Name = "Line spell target still valid",
+                        Check = () => Core.Me.InCombat
+                                      && Core.Me.CurrentTarget != null
+                                      && Core.Me.CurrentTarget.ValidAttackUnit()
+                    }
+                },
+                Wait = new QueueSpellWait
+                {
+                    Name = "Drain Touch empowerment to apply",
+                    WaitTime = 1500,
+                    Check = () => Core.Me.HasAura(OCAuras.DrainTouch)
+                }
+            });
+
+            return true;
+        }
+
+        /// <summary>
+        /// Deep Freeze / Hell Wind / Chaos Drive - one shared 40s recast, 1.5s casts. This
+        /// non-queued path remains for empowerments already in flight (a standalone Drain Touch
+        /// that landed before the pair could be queued) and for the UseDrainTouch=false waiver -
+        /// empowered-only otherwise, because the self-Doom costs the same either way.
+        /// </summary>
+        private static Task<bool> NecromancerElementalNukes()
+        {
+            if (OccultCrescentSettings.Instance.UseDrainTouch && !Core.Me.HasAura(OCAuras.DrainTouch))
+                return Task.FromResult(false);
+
+            if (!NecromancerCanAffordDoomSpell())
+                return Task.FromResult(false);
+
+            if (MovementManager.IsMoving)
+                return Task.FromResult(false);
+
+            return SharedRecastElementalNukes(NecromancerElementalCandidates());
+        }
+
+        /// <summary>
+        /// Doomsday - AoE nuke on its own long recast, carrying the same 10s self-Doom.
+        /// Empowered-only under the same waiver logic as the nukes, and held for a
+        /// worthwhile enemy count.
+        /// </summary>
+        private static async Task<bool> Doomsday()
+        {
+            if (!OccultCrescentSettings.Instance.UseDoomsday)
+                return false;
+
+            if (!Core.Me.InCombat)
+                return false;
+
+            if (!OCSpells.Doomsday.CanCast())
+                return false;
+
+            if (OccultCrescentSettings.Instance.UseDrainTouch && !Core.Me.HasAura(OCAuras.DrainTouch))
+                return false;
+
+            if (!NecromancerCanAffordDoomSpell())
+                return false;
+
+            if (MovementManager.IsMoving)
+                return false;
+
+            var target = Core.Me.CurrentTarget;
+
+            if (target == null || !target.ValidAttackUnit() || !target.InLineOfSight())
+                return false;
+
+            if (!target.WithinSpellRange(OCSpells.Doomsday.Range))
+                return false;
+
+            if (Combat.Enemies.Count(e => e.WithinSpellRange(OCSpells.Doomsday.Range)) < OccultCrescentSettings.Instance.DoomsdayEnemyCount)
+                return false;
+
+            return await OCSpells.Doomsday.Cast(target);
+        }
+
+        /// <summary>
+        /// Execute Phantom Necromancer phantom job rotation
+        /// </summary>
+        /// <returns>True if an action was executed, false otherwise</returns>
+        private static async Task<bool> ExecuteNecromancerPhantomJob()
+        {
+            // The self-Doom is a 10-second race to full HP before anything else matters
+            if (await NecromancerDoomRecovery())
+                return true;
+
+            // Drain Touch + elemental nuke as one unbreakable pair
+            if (QueueEmpoweredElementalNuke())
+                return true;
+
+            // Standalone Drain Touch - damage and self-heal on its own merits
+            if (await DrainTouch())
+                return true;
+
+            // Doomsday - the AoE form of the bargain
+            if (await Doomsday())
+                return true;
+
+            // Line spells for empowerments already in flight, or the no-Drain-Touch waiver
+            if (await NecromancerElementalNukes())
+                return true;
+
+            return false;
+        }
+
         #endregion
     }
 }

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -4841,7 +4841,7 @@ namespace Magitek.Logic.Roles
             // Dark Knight's only real HP restorer - its shields cannot cleanse a Doom that
             // demands the bar actually reach full. Needs a target in range to drain from.
             if (Spells.AbyssalDrain.IsKnownAndReady()
-                && Core.Me.CurrentTarget != null && Core.Me.CurrentTarget.ValidAttackUnit()
+                && Core.Me.CurrentTarget != null && Core.Me.CurrentTarget.ValidDamageTarget()
                 && Core.Me.CurrentTarget.WithinSpellRange(Spells.AbyssalDrain.Range)
                 && await Spells.AbyssalDrain.Cast(Core.Me.CurrentTarget))
                 return true;
@@ -4871,7 +4871,7 @@ namespace Magitek.Logic.Roles
 
             var target = Core.Me.CurrentTarget;
 
-            if (target == null || !target.ValidAttackUnit() || !target.InLineOfSight())
+            if (target == null || !target.ValidDamageTarget() || !target.InLineOfSight())
                 return false;
 
             if (!target.WithinSpellRange(OCSpells.DrainTouch.Range))
@@ -4932,7 +4932,7 @@ namespace Magitek.Logic.Roles
 
             var target = Core.Me.CurrentTarget;
 
-            if (target == null || !target.ValidAttackUnit() || !target.InLineOfSight())
+            if (target == null || !target.ValidDamageTarget() || !target.InLineOfSight())
                 return false;
 
             if (!target.WithinSpellRange(OCSpells.DrainTouch.Range))
@@ -4964,7 +4964,7 @@ namespace Magitek.Logic.Roles
                         Name = "Nuke target still valid",
                         Check = () => Core.Me.InCombat
                                       && Core.Me.CurrentTarget != null
-                                      && Core.Me.CurrentTarget.ValidAttackUnit()
+                                      && Core.Me.CurrentTarget.ValidDamageTarget()
                     },
                     // If movement starts after the pair is queued the cast cannot begin, and a
                     // queued spell that never casts holds the queue - and the pulse with it -
@@ -5034,7 +5034,7 @@ namespace Magitek.Logic.Roles
 
             var target = Core.Me.CurrentTarget;
 
-            if (target == null || !target.ValidAttackUnit() || !target.InLineOfSight())
+            if (target == null || !target.ValidDamageTarget() || !target.InLineOfSight())
                 return false;
 
             if (!target.WithinSpellRange(OCSpells.Doomsday.Range))

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -4947,9 +4947,24 @@ namespace Magitek.Logic.Roles
             // nuke would open the NEXT pull with a self-Doom under gates up to 8s stale.
             SpellQueueLogic.SpellQueueReset(() => SpellQueueLogic.Timeout.ElapsedMilliseconds > 8000 || !Core.Me.InCombat);
 
+            // Everything either entry needs to still be true when the queue actually drains. A queued
+            // spell whose Cast fails is the one SpellQueueMethod exit that neither dequeues nor cancels,
+            // so it would sit at the head holding the pulse until the 8s timeout. A failed Check dequeues
+            // immediately, so every condition that can change between enqueue and execution belongs here.
+            QueueSpellCheck TargetStillCastable(SpellData spell) => new QueueSpellCheck
+            {
+                Name = $"{spell.Name} target still castable",
+                Check = () => Core.Me.InCombat
+                              && Core.Me.CurrentTarget != null
+                              && Core.Me.CurrentTarget.ValidDamageTarget()
+                              && Core.Me.CurrentTarget.InLineOfSight()
+                              && Core.Me.CurrentTarget.WithinSpellRange(spell.Range)
+            };
+
             SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell
             {
-                Spell = OCSpells.DrainTouch
+                Spell = OCSpells.DrainTouch,
+                Checks = new List<QueueSpellCheck> { TargetStillCastable(OCSpells.DrainTouch) }
             });
             SpellQueueLogic.SpellQueue.Enqueue(new QueueSpell
             {
@@ -4959,12 +4974,15 @@ namespace Magitek.Logic.Roles
                 // (and with it the whole Heal pulse) until the timeout.
                 Checks = new List<QueueSpellCheck>
                 {
+                    TargetStillCastable(nuke),
+                    // The bargain has to still be one we would take. The queue can wait on the Drain
+                    // Touch aura and then on the GCD, and in that window our HP can fall below the
+                    // clearability threshold or a raidwide can start — either of which means we should
+                    // not be starting a 10s death timer we may not be able to clear.
                     new QueueSpellCheck
                     {
-                        Name = "Nuke target still valid",
-                        Check = () => Core.Me.InCombat
-                                      && Core.Me.CurrentTarget != null
-                                      && Core.Me.CurrentTarget.ValidDamageTarget()
+                        Name = "Self-Doom still affordable",
+                        Check = NecromancerCanAffordDoomSpell
                     },
                     // If movement starts after the pair is queued the cast cannot begin, and a
                     // queued spell that never casts holds the queue - and the pulse with it -

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -4924,11 +4924,6 @@ namespace Magitek.Logic.Roles
             if (SpellQueueLogic.SpellQueue.Any())
                 return false;
 
-            // The nuke has a cast time, and a queued cast that cannot start keeps the queue
-            // non-empty - which stalls the whole pulse. Do not open the pair on the move.
-            if (MovementManager.IsMoving && !Core.Me.HasAura(Auras.Swiftcast))
-                return false;
-
             if (!OCSpells.DrainTouch.CanCast())
                 return false;
 
@@ -4978,7 +4973,7 @@ namespace Magitek.Logic.Roles
                     new QueueSpellCheck
                     {
                         Name = "Standing still for the cast",
-                        Check = () => !MovementManager.IsMoving || Core.Me.HasAura(Auras.Swiftcast)
+                        Check = () => !MovementManager.IsMoving
                     }
                 },
                 Wait = new QueueSpellWait
@@ -5045,10 +5040,7 @@ namespace Magitek.Logic.Roles
             if (!target.WithinSpellRange(OCSpells.Doomsday.Range))
                 return false;
 
-            // Count the cluster around the TARGET, not everything inside casting range: Doomsday
-            // lands as a circle on the target, so a range-wide count spends the recast and the
-            // self-Doom on enemies scattered well outside the blast.
-            if (target.EnemiesNearby(OCSpells.Doomsday.Radius).Count() < OccultCrescentSettings.Instance.DoomsdayEnemyCount)
+            if (Combat.Enemies.Count(e => e.WithinSpellRange(OCSpells.Doomsday.Range)) < OccultCrescentSettings.Instance.DoomsdayEnemyCount)
                 return false;
 
             return await OCSpells.Doomsday.Cast(target);

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -757,5 +757,46 @@ namespace Magitek.Models.OccultCrescent
         [DefaultValue(70.0f)]
         public float OccultWhiteWindMinimumOwnHealthPercent { get; set; }
         #endregion
+
+        #region Phantom Necromancer
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseDrainTouch { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseNecromancerDoomRecovery { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseDeepFreeze { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseHellWind { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseChaosDrive { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseDoomsday { get; set; }
+
+        [Setting]
+        [DefaultValue(3)]
+        public int DoomsdayEnemyCount { get; set; }
+
+        // The self-Doom kills outright at expiry unless the caster reaches FULL HP within 10s -
+        // clearability, not surviving the 10% cost, is what this threshold protects. Starting
+        // the bargain near full means one heal tick clears it; from 70% it is a coin flip.
+        [Setting]
+        [DefaultValue(95.0f)]
+        public float NecromancerSpellHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(false)]
+        public bool NecromancerDoomSpellsSolo { get; set; }
+        #endregion
     }
 }

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -9642,6 +9642,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Phantom Necromancer.
+        /// </summary>
+        public static string OccultCrescent_Text_Phantom_Necromancer {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Text_Phantom_Necromancer", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Phantom Oracle.
         /// </summary>
         public static string OccultCrescent_Text_Phantom_Oracle {

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -9381,15 +9381,6 @@ namespace Magitek.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to enemies.
-        /// </summary>
-        public static string OccultCrescent_Text_enemies {
-            get {
-                return ResourceManager.GetString("OccultCrescent_Text_enemies", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Grouped abilities share restrictions as noted..
         /// </summary>
         public static string OccultCrescent_Text_Grouped_abilities_share_restri {
@@ -9485,6 +9476,24 @@ namespace Magitek.Properties {
         public static string OccultCrescent_Text_and_our_own_HP_at_least {
             get {
                 return ResourceManager.GetString("OccultCrescent_Text_and_our_own_HP_at_least", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to enemies.
+        /// </summary>
+        public static string OccultCrescent_Text_enemies {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Text_enemies", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to percent.
+        /// </summary>
+        public static string OccultCrescent_Text_percent {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Text_percent", resourceCulture);
             }
         }
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -8292,6 +8292,24 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow Doom spells while solo (no party to heal you to full).
+        /// </summary>
+        public static string OccultCrescent_Content_Necromancer_Allow_Solo {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Necromancer_Allow_Solo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use main job self-heals to recover from the self-Doom.
+        /// </summary>
+        public static string OccultCrescent_Content_Necromancer_Doom_Recovery {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Necromancer_Doom_Recovery", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to On Allies.
         /// </summary>
         public static string OccultCrescent_Content_On_Allies {
@@ -8436,6 +8454,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use Chaos Drive (lightning).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Chaos_Drive {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Chaos_Drive", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use Cleansing when party above.
         /// </summary>
         public static string OccultCrescent_Content_Use_Cleansing_when_party_ab {
@@ -8490,6 +8517,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use Deep Freeze (ice).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Deep_Freeze {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Deep_Freeze", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use Defend.
         /// </summary>
         public static string OccultCrescent_Content_Use_Defend {
@@ -8507,6 +8543,24 @@ namespace Magitek.Properties {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Use Doomsday (AoE, same self-Doom).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Doomsday {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Doomsday", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use Drain Touch (self-heal, empowers the next spell).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Drain_Touch {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Drain_Touch", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use Earthen Wall (party barrier).
         /// </summary>
@@ -8552,6 +8606,15 @@ namespace Magitek.Properties {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Use Hell Wind (wind).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Hell_Wind {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Hell_Wind", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use Hellfire (fire).
         /// </summary>
@@ -9300,11 +9363,29 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cast Doom spells only with our own HP at least.
+        /// </summary>
+        public static string OccultCrescent_Text_Doom_spells_HP_at_least {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Text_Doom_spells_HP_at_least", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to (Emergency protection).
         /// </summary>
         public static string OccultCrescent_Text_Emergency_protection {
             get {
                 return ResourceManager.GetString("OccultCrescent_Text_Emergency_protection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to enemies.
+        /// </summary>
+        public static string OccultCrescent_Text_enemies {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Text_enemies", resourceCulture);
             }
         }
         
@@ -9710,6 +9791,15 @@ namespace Magitek.Properties {
         public static string OccultCrescent_Text_when_target_targeting_us_and_HP_below {
             get {
                 return ResourceManager.GetString("OccultCrescent_Text_when_target_targeting_us_and_HP_below", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to with at least.
+        /// </summary>
+        public static string OccultCrescent_Text_with_at_least {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Text_with_at_least", resourceCulture);
             }
         }
         

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2165,6 +2165,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="OccultCrescent_Text_Phantom_Necromancer" xml:space="preserve">
     <value>Phantom Necromancer</value>
   </data>
+  <data name="OccultCrescent_Text_percent" xml:space="preserve">
+    <value>percent</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Chaos_Drive" xml:space="preserve">
     <value>Use Chaos Drive (lightning)</value>
   </data>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2162,6 +2162,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="OccultCrescent_Text_enemies" xml:space="preserve">
     <value>enemies</value>
   </data>
+  <data name="OccultCrescent_Text_Phantom_Necromancer" xml:space="preserve">
+    <value>Phantom Necromancer</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Chaos_Drive" xml:space="preserve">
     <value>Use Chaos Drive (lightning)</value>
   </data>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2153,6 +2153,36 @@ Does not work if Lightspeed is disabled.</value>
   <data name="OccultCrescent_Text_and_our_own_HP_at_least" xml:space="preserve">
     <value>and our own HP at least</value>
   </data>
+  <data name="OccultCrescent_Content_Use_Drain_Touch" xml:space="preserve">
+    <value>Use Drain Touch (self-heal, empowers the next spell)</value>
+  </data>
+  <data name="OccultCrescent_Content_Necromancer_Doom_Recovery" xml:space="preserve">
+    <value>Use main job self-heals to recover from the self-Doom</value>
+  </data>
+  <data name="OccultCrescent_Text_enemies" xml:space="preserve">
+    <value>enemies</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Chaos_Drive" xml:space="preserve">
+    <value>Use Chaos Drive (lightning)</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Hell_Wind" xml:space="preserve">
+    <value>Use Hell Wind (wind)</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Deep_Freeze" xml:space="preserve">
+    <value>Use Deep Freeze (ice)</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Doomsday" xml:space="preserve">
+    <value>Use Doomsday (AoE, same self-Doom)</value>
+  </data>
+  <data name="OccultCrescent_Text_with_at_least" xml:space="preserve">
+    <value>with at least</value>
+  </data>
+  <data name="OccultCrescent_Text_Doom_spells_HP_at_least" xml:space="preserve">
+    <value>Cast Doom spells only with our own HP at least</value>
+  </data>
+  <data name="OccultCrescent_Content_Necromancer_Allow_Solo" xml:space="preserve">
+    <value>Allow Doom spells while solo (no party to heal you to full)</value>
+  </data>
   <data name="OccultCrescent_Content_Only_use_in_melee_range" xml:space="preserve">
     <value>Only use in melee range</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2154,6 +2154,36 @@
   <data name="OccultCrescent_Text_and_our_own_HP_at_least" xml:space="preserve">
     <value>且自身血量不低于</value>
   </data>
+  <data name="OccultCrescent_Content_Use_Drain_Touch" xml:space="preserve">
+    <value>使用 吸收之触（吸血自愈，强化下一个咒文）</value>
+  </data>
+  <data name="OccultCrescent_Content_Necromancer_Doom_Recovery" xml:space="preserve">
+    <value>使用主职业自愈技能解除自身死宣</value>
+  </data>
+  <data name="OccultCrescent_Text_enemies" xml:space="preserve">
+    <value>个敌人</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Chaos_Drive" xml:space="preserve">
+    <value>使用 混沌驱动（雷）</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Hell_Wind" xml:space="preserve">
+    <value>使用 地狱之风（风）</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Deep_Freeze" xml:space="preserve">
+    <value>使用 深度冻结（冰）</value>
+  </data>
+  <data name="OccultCrescent_Content_Use_Doomsday" xml:space="preserve">
+    <value>使用 末日（范围攻击，附加同样的死宣）</value>
+  </data>
+  <data name="OccultCrescent_Text_with_at_least" xml:space="preserve">
+    <value>且周围至少有</value>
+  </data>
+  <data name="OccultCrescent_Text_Doom_spells_HP_at_least" xml:space="preserve">
+    <value>仅在自身血量不低于此值时使用死宣咒文</value>
+  </data>
+  <data name="OccultCrescent_Content_Necromancer_Allow_Solo" xml:space="preserve">
+    <value>允许单人时使用死宣咒文（无队伍将你治疗回满）</value>
+  </data>
   <data name="OccultCrescent_Content_Only_use_in_melee_range" xml:space="preserve">
     <value>仅在近战距离内使用</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2163,6 +2163,9 @@
   <data name="OccultCrescent_Text_enemies" xml:space="preserve">
     <value>个敌人</value>
   </data>
+  <data name="OccultCrescent_Text_Phantom_Necromancer" xml:space="preserve">
+    <value>辅助死灵法师</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Chaos_Drive" xml:space="preserve">
     <value>使用 混沌驱动（雷）</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2166,6 +2166,9 @@
   <data name="OccultCrescent_Text_Phantom_Necromancer" xml:space="preserve">
     <value>辅助死灵法师</value>
   </data>
+  <data name="OccultCrescent_Text_percent" xml:space="preserve">
+    <value>百分比</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Chaos_Drive" xml:space="preserve">
     <value>使用 混沌驱动（雷）</value>
   </data>

--- a/Magitek/Utilities/Managers/RotationManager.cs
+++ b/Magitek/Utilities/Managers/RotationManager.cs
@@ -223,6 +223,17 @@ namespace Magitek.Utilities.Managers
             await Casting.CheckForSuccessfulCast();
             Casting.DoHealthChecks = false;
 
+            // Drain the spell queue here too: Heal runs before Combat every in-combat pulse and
+            // also reaches OccultCrescent.Execute, which can start a queue (the Necromancer's
+            // Drain Touch pair). Without a drain above that call, a pending queue would be
+            // re-entered before Combat's drain ever runs.
+            if (!SpellQueueLogic.SpellQueue.Any())
+                SpellQueueLogic.InSpellQueue = false;
+
+            if (SpellQueueLogic.SpellQueue.Any())
+                if (await SpellQueueLogic.SpellQueueMethod())
+                    return true;
+
             if (await GambitLogic.Gambit())
                 return true;
             // Heal is pulsed even when not in combat.

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -1623,7 +1623,7 @@
                                                                   Value="{Binding NecromancerSpellHealthPercent, Mode=TwoWay}"
                                                                   Margin="5,0,0,0"/>
                                                 <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="percent"/>
+                                                           Text="{x:Static properties:Resources.OccultCrescent_Text_percent}"/>
                                         </StackPanel>
 
                                         <StackPanel Margin="5"

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -1556,6 +1556,85 @@
                                 </StackPanel>
                         </controls:SettingsBlock>
 
+                        <!-- Phantom Necromancer Settings -->
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <TextBlock Style="{DynamicResource TextBlockSection}"
+                                                   Text="Phantom Necromancer"/>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Drain_Touch}"
+                                                          IsChecked="{Binding UseDrainTouch, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Necromancer_Doom_Recovery}"
+                                                          IsChecked="{Binding UseNecromancerDoomRecovery, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Chaos_Drive}"
+                                                          IsChecked="{Binding UseChaosDrive, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Hell_Wind}"
+                                                          IsChecked="{Binding UseHellWind, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Deep_Freeze}"
+                                                          IsChecked="{Binding UseDeepFreeze, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Doomsday}"
+                                                          IsChecked="{Binding UseDoomsday, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.OccultCrescent_Text_with_at_least}"
+                                                           Margin="20,0,0,0"/>
+                                                <controls:Numeric MaxValue="30"
+                                                                  MinValue="1"
+                                                                  Value="{Binding DoomsdayEnemyCount, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.OccultCrescent_Text_enemies}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.OccultCrescent_Text_Doom_spells_HP_at_least}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding NecromancerSpellHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="percent"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Necromancer_Allow_Solo}"
+                                                          IsChecked="{Binding NecromancerDoomSpellsSolo, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
                 </StackPanel>
         </ScrollViewer>
 </UserControl>

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -1561,7 +1561,7 @@
                                                 Background="{DynamicResource ClassSelectorBackground}">
                                 <StackPanel Margin="5">
                                         <TextBlock Style="{DynamicResource TextBlockSection}"
-                                                   Text="Phantom Necromancer"/>
+                                                   Text="{x:Static properties:Resources.OccultCrescent_Text_Phantom_Necromancer}"/>
 
                                         <StackPanel Margin="5"
                                                     Orientation="Horizontal">


### PR DESCRIPTION
# PR: OC - Add Phantom Necromancer support

## What this changes

Adds Phantom Necromancer support for Occult Crescent: Drain Touch (with its empowerment
pairing), the three elemental nukes (Deep Freeze / Hell Wind / Chaos Drive) with
weakness matching, Doomsday, and recovery handling for the job's self-inflicted
Doom. Includes a settings section (per-spell toggles, a clearability HP threshold, and a
solo opt-in) with UI and localization.

## Why

Necromancer is the last phantom job without support. Its damage is worth the complexity —
Chaos Drive measured ~178k to each of four targets — but every nuke and Doomsday
self-applies a lethal Doom, so the cast logic and the survival logic have to ship together.

## Doom semantics (field-tested — the part that "needs more testing than normal")

All of the following is measured from combat logs across multiple sessions (2026-08-08 to
2026-08-11), on both a healer (Sage) and a tank (Dark Knight):

- The self-Doom is status **1769**, duration **10.0s**, applied by the nukes and
  Doomsday. They additionally cost 10% max HP to cast (separate from the Doom).
- It **kills at expiry regardless of current HP**, and is cleansed **only by reaching
  full HP** before the timer runs out. Esuna does not remove it.
- Application takes an **instant, unlogged ~10% max-HP cut** — being at full HP when it
  lands does not cleanse it; every cleanse needs at least +10% max HP of net healing.
- Death registers ~2s after the expiry removal in logs (relevant when reading deaths).
- Observed cleanse times with the recovery logic: 1.6-2.6s typical (Abyssal Drain at tank
  HP scale, Equilibrium-class heals, healer Diagnosis racing).

## Safety model (deliberately simple)

- **Clearability threshold** (default 95% HP): the bargain is only taken when one heal
  tick can plausibly clear it. User-configurable.
- **Party-gated by default** with a solo opt-in: solo players have no external heals.
- **Incoming-raidwide stand-down**: no new death timer while the healers are about to owe
  the whole party.
- **Self-recovery ladder** when Doomed (own toggle, default on): instant self-heals by
  availability (Equilibrium / Aurora / Second Wind / Bloodbath / Abyssal Drain / Drain
  Touch). The ladder deliberately keeps working after combat drops — the Doom does not
  end with the fight, and for casters Drain Touch is the only rung.

Deeper gating (pressure detection, rotation rerouting) was prototyped, field-tested, and
deliberately removed: the measured data showed it added complexity without closing the
remaining deaths, which are positioning/cooldown situations the player owns.

## The spell queue (one structural note)

Drain Touch's 6s empowerment loses a race against the main job's rotation if the nuke
waits for a later pulse (observed live: a Dosis 0.2s after every Drain Touch,
empowerments expiring unused), so the pair is queued atomically through the existing
SpellQueueLogic. Because Heal runs before Combat every in-combat pulse and also reaches
the phantom executor, this PR adds the same queue drain to the Heal hook that Combat
already has — without it, a pending queue would be re-entered from Heal every pulse and
never cast. Two protections bound the queue's worst case: the pair cancels when combat
drops (never opens the next pull with a stale self-Doom), and the queued nuke
re-checks its target at drain time (a target sniped mid-pair dequeues immediately
instead of parking the Heal pulse until the timeout).

## Game-behavior assumptions I could not verify

| # | Assumption | Based on | Confidence | If wrong, the impact is |
|---|-----------|----------|------------|-------------------------|
| 1 | The Drain Touch empowerment window (aura 5326, 6s) empowers exactly the next Necromancer nuke/Doomsday | observed empowered damage deltas in logs | high | pair ordering wastes the buff; damage-only impact |

## Verified against game data

- Doom = 1769: StatusList + ACT 26-lines across every observed application (dozens).
- Hell Wind carries the same self-Doom and 10% HP cost as its two siblings (confirmed in
  play; it fires rarely by design — the no-weakness fallback prefers Chaos Drive for its
  stronger Drain Touch rider).
- The instant 10% cut: HP snapshots in ability lines bracketing application, two
  independent windows, exact to the digit (178,202 -> 160,382).
- Drain Touch aura 5326, 6.00s duration: ACT 26/30-lines.
- Weakness matching uses the existing shared elemental helper; NEC has no revealing spell
  of its own, so the fallback path must not require a revealed weakness (implemented).

## In-game test plan

1. Setup: any job with Phantom Necromancer set, in South Horn, in a party. Enable the
   Necromancer section (defaults).
2. Pull a mob at full HP: expect Drain Touch, then an elemental nuke inside the 6s empowerment
   window, Doom appears, recovery fires an instant self-heal, Doom clears within ~3s.
3. Drop below the threshold (default 95%): expect the nukes to stop; Drain Touch alone
   continues.
4. Leave the party (solo, opt-in OFF): expect no nukes or Doomsday at any HP.
5. If a Doom expiry death occurs: capture the RB log (recovery lines) + the ACT window;
   the aura timeline will show which rung was or wasn't available.
