### PR TITLE
DNC - Stop erroring when a dance finishes with no target

### DIFF
--- a/Magitek/Logic/Dancer/Dances.cs
+++ b/Magitek/Logic/Dancer/Dances.cs
@@ -160,7 +160,12 @@ namespace Magitek.Logic.Dancer
                 switch (ActionResourceManager.Dancer.CurrentStep)
                 {
                     case ActionResourceManager.Dancer.DanceStep.Finish:
-                        if (DancerSettings.Instance.OnlyFinishStepInRange && Core.Me.CurrentTarget.Distance(Core.Me) > 15 + Core.Me.CurrentTarget.CombatReach)
+                        // The finish is cast on ourselves, so it can still be reached with no target:
+                        // gambits and openers call in here ahead of the rotation's own target guard.
+                        // Treat "no target" as out of range instead of throwing into the catch below.
+                        if (DancerSettings.Instance.OnlyFinishStepInRange
+                            && (Core.Me.CurrentTarget == null
+                                || Core.Me.CurrentTarget.Distance(Core.Me) > 15 + Core.Me.CurrentTarget.CombatReach))
                             return false;
 
                         if (Core.Me.HasAura(Auras.StandardStep))


### PR DESCRIPTION
Split out of #194 per your closing note.

## What this changes

Guards the Dancer dance-finish range check against a null target.

## Why

`Dances.DanceStep()` reads `Core.Me.CurrentTarget.Distance(...)` when "Finish Step only when in range" is on. The finish is cast on *ourselves*, so the method is reachable with no target at all — gambits and openers call into it ahead of the rotation's own target guard. With no target, that line throws.

Worth being precise about the symptom, because it is not a crash: the throw lands in the pre-existing bare `catch` a few lines below, which returns false. So today the failure is silent — the dance finish just never happens, once per pulse, until you retarget. The guard makes "no target" mean "out of range", which is what the setting already means everywhere else.

## Scope

One file, one condition. No behaviour change when a target exists.

## In-game test plan

1. DNC with "Finish Step only when in range" enabled.
2. Add a Gambit whose action is Dance Finish with a condition true out of combat.
3. Start Standard Step on a dummy, then clear your target while the dance aura is up. The routine pulses into `DanceStep()` with no target.
4. Before: a NullReferenceException is raised on every pulse and swallowed by the catch. After: no exception, the finish is simply held.
5. Retarget and confirm the finish fires in range, and is still held past 15y + combat reach.
6. With the setting disabled, confirm finishes still fire — that branch short-circuits before the target read and is untouched.
