### PR TITLE
OC - Only use Occult Dispel when the enemy actually has a buff to remove

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -563,7 +563,7 @@ namespace Magitek.Logic.BlackMage
   - `HasAnyAura(uint[]/List<uint> auras, bool isMyAura = false, int msLeft = 0)`: Check if unit has any of the specified auras
   - `HasAllAuras(List<uint> auras, bool areMyAuras = false, int msLeft = 0)`: Check if unit has all specified auras
   - `CountAuras(List<uint> auras, bool isMyAura = false, int msLeft = 0)`: Count matching auras on unit
-  - `HasDispellableAura()`: Check if unit has a dispellable debuff
+  - `HasDispellableBuff()`: Check if an enemy carries a dispellable beneficial status (what a dispel can actually strip)
 - **Range and Distance:**
   - `WithinSpellRange(float/double range)`: Edge-to-edge distance check accounting for CombatReach (use for ALL range checks)
   - `EnemiesNearby(float distance)`: Get enemies within radius (uses cached Combat.Enemies)

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -176,14 +176,19 @@ namespace Magitek.Extensions
 
         }
 
-        public static bool HasDispellableAura(this GameObject unit)
+        // A dispel strips a BENEFICIAL status from an enemy, so a helper used to decide whether to
+        // dispel has to ignore debuffs. Named for what it actually asks: the old name read as the
+        // opposite of what it did, and let a dispel re-fire forever on an enemy that merely carries a
+        // dispellable debuff no dispel can remove. Cleansing an ally is a separate concern, served by
+        // HasAnyDispellableAura on CharacterExtensions.
+        public static bool HasDispellableBuff(this GameObject unit)
         {
             var unitAsCharacter = unit as Character;
 
             if (unitAsCharacter == null || !unitAsCharacter.IsValid)
                 return false;
 
-            return unitAsCharacter.CharacterAuras.Any(r => r.TimespanLeft.TotalMilliseconds >= 0 && r.IsDispellable);
+            return unitAsCharacter.CharacterAuras.Any(r => r.TimespanLeft.TotalMilliseconds >= 0 && r.IsDispellable && !r.IsDebuff);
         }
 
         public static bool HasAnyAura(this GameObject unit, List<uint> auras, bool isMyAura = false, int msLeft = 0)

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2372,7 +2372,7 @@ namespace Magitek.Logic.Roles
             if (!Core.Me.CurrentTarget.ValidAttackUnit() || !Core.Me.CurrentTarget.InLineOfSight())
                 return false;
 
-            if (!Core.Me.CurrentTarget.HasDispellableAura())
+            if (!Core.Me.CurrentTarget.HasDispellableBuff())
                 return false;
 
             // if (!Core.Me.CurrentTarget.HasAnyAura(OCAuras.DispellableAuras))


### PR DESCRIPTION
Split out of #194 per your closing note.

## What this changes

Occult Dispel now only fires when the enemy actually carries a beneficial status. The helper it uses is renamed `HasDispellableAura` -> `HasDispellableBuff` and gains a `!IsDebuff` term.

## Why

A dispel strips a *beneficial* status from an enemy, but the helper matched any dispellable aura including debuffs. So once the routine's own Occult Slowga or Occult Mage Masher landed, the target permanently satisfied the check and Occult Dispel re-fired on every recast, removing nothing. Because that branch returns true it also starved the rest of the Phantom Time Mage block underneath it.

The old name read as the opposite of what the code did, which is how the bug survived — and AGENTS.md documented it as "check if unit has a dispellable **debuff**". That line is corrected here too.

## Scope

Three hunks: the helper, its single call site, and the AGENTS.md line. The healer cleanse path is a different helper (`HasAnyDispellableAura` on CharacterExtensions, 14 call sites) and is deliberately untouched — it correctly matches debuffs.

## Expected visible change

Occult Dispel will fire **less often**. That is the fix, not a regression: the casts it stops making were removing nothing.

## In-game test plan

1. Occult Crescent, Phantom Time Mage, with Dispel + Slowga + Mage Masher all enabled.
2. Pull an ordinary enemy carrying no beneficial statuses and let it run 60s. Before: once Slowga or Mage Masher lands, Dispel casts on every recast forever. After: it should not cast at all, and Comet/Slowga/Mage Masher proceed normally.
3. Positive check that it is not simply dead — find an enemy that self-buffs and confirm Dispel fires once, strips it, then stops.
4. Regression guard: run a healer through content with a dispellable debuff on the party and confirm Esuna still fires, proving the wrong helper was not renamed.
