### PR TITLE
ALL - Keep Execute LimitBreak set when the limit break fails to go off

### DIFF
--- a/Magitek/Logic/Roles/Healer.cs
+++ b/Magitek/Logic/Roles/Healer.cs
@@ -128,7 +128,11 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoAction(limitBreak3Spell, Core.Me);
+                // Only clear the toggle when the action actually fired. Clearing it on a failed
+                // attempt silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoAction(limitBreak3Spell, Core.Me))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -140,8 +144,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me))
-                    ActionManager.DoAction(limitBreak1Spell, Core.Me);
+                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me)
+                    && !ActionManager.DoAction(limitBreak1Spell, Core.Me))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Roles/MagicDps.cs
+++ b/Magitek/Logic/Roles/MagicDps.cs
@@ -41,7 +41,11 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoActionLocation(limitBreak3Spell.Id, Core.Me.CurrentTarget.Location);
+                // Only clear the toggle when the action actually fired. Clearing it on a failed
+                // attempt silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoActionLocation(limitBreak3Spell.Id, Core.Me.CurrentTarget.Location))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -53,8 +57,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoActionLocation(limitBreak2Spell.Id, Core.Me.CurrentTarget.Location))
-                    ActionManager.DoActionLocation(limitBreak1Spell.Id, Core.Me.CurrentTarget.Location); ;
+                if (!ActionManager.DoActionLocation(limitBreak2Spell.Id, Core.Me.CurrentTarget.Location)
+                    && !ActionManager.DoActionLocation(limitBreak1Spell.Id, Core.Me.CurrentTarget.Location))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Roles/PhysicalDPS.cs
+++ b/Magitek/Logic/Roles/PhysicalDPS.cs
@@ -143,7 +143,11 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoAction(limitBreak3Spell, Core.Me.CurrentTarget);
+                // Only clear the toggle when the action actually fired. Clearing it on a failed
+                // attempt silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoAction(limitBreak3Spell, Core.Me.CurrentTarget))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -155,8 +159,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me.CurrentTarget))
-                    ActionManager.DoAction(limitBreak1Spell, Core.Me.CurrentTarget);
+                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me.CurrentTarget)
+                    && !ActionManager.DoAction(limitBreak1Spell, Core.Me.CurrentTarget))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();

--- a/Magitek/Logic/Roles/Tank.cs
+++ b/Magitek/Logic/Roles/Tank.cs
@@ -116,7 +116,11 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak3Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                ActionManager.DoAction(limitBreak3Spell, Core.Me);
+                // Only clear the toggle when the action actually fired. Clearing it on a failed
+                // attempt silently discards a limit break the user explicitly asked for.
+                if (!ActionManager.DoAction(limitBreak3Spell, Core.Me))
+                    return false;
+
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();
                 return true;
@@ -128,8 +132,9 @@ namespace Magitek.Logic.Roles
                 && !Casting.SpellCastHistory.Any(s => s.Spell == limitBreak2Spell)
                 && gcd.Cooldown.TotalMilliseconds < 500)
             {
-                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me))
-                    ActionManager.DoAction(limitBreak1Spell, Core.Me);
+                if (!ActionManager.DoAction(limitBreak2Spell, Core.Me)
+                    && !ActionManager.DoAction(limitBreak1Spell, Core.Me))
+                    return false;
 
                 BaseSettings.Instance.ForceLimitBreak = false;
                 TogglesManager.ResetToggles();


### PR DESCRIPTION
Split out of #194 per your closing note.

## What this changes

The "Execute LimitBreak" toggle now only clears when the limit break actually went off.

## Why

All four role helpers fire the limit break and then unconditionally clear the toggle and return true, without looking at what `DoAction` / `DoActionLocation` returned. When the call fails — gauge not charged, animation lock from an oGCD woven the pulse before, target out of range — the toggle is cleared anyway. The player ticks the box, nothing happens, and the box unticks itself.

Every other Force* toggle in the codebase already uses the guarded idiom (`PhysicalDps.ArmsLength`, `Bard.Troubadour`, `Gunbreaker.ForceBurstStrike` among others). This brings ForceLimitBreak in line with it.

## Scope

`git grep "ForceLimitBreak = "` returns exactly 8 hits in 4 files — Tank, Healer, MagicDps, PhysicalDPS — and all 8 are fixed here. The ~21 per-job wrappers are one-line delegations to these four, so no job file needs touching. PvP is unaffected; no PvP path reads the setting and the overlay checkbox is hidden on PvP maps.

## The one behaviour change worth reviewing

On *persistent* failure the toggle now stays set, so the routine retries on later pulses instead of giving up after one attempt. That is the intent — the request survives until it is honoured — but it is a real change: previously a failed attempt silently consumed the request. If you would rather it retry only for a bounded window, say so and I will add one.

## In-game test plan

1. Full party, any tank or healer, limit break gauge **empty**. Tick "Execute LimitBreak". After: the checkbox stays ticked, nothing is cast, the rotation continues normally. Before: it unticks itself within a GCD and nothing happens.
2. Keep playing while the gauge charges — the moment a bar is available the LB fires and the checkbox clears.
3. Regression, all four roles: with LB3 charged in an 8-man, confirm LB3 fires and the toggle clears. Repeat in a light party for the LB2/LB1 fallback path.
