### PR TITLE
FightLogic - Aim Feint, Addle, Dismantle and Reprisal at the enemy casting the mechanic

### DIFF
--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -116,24 +116,31 @@ namespace Magitek.Logic.Roles
                 if (!spell.IsKnownAndReady())
                     return false;
 
-                if (Core.Me.CurrentTarget == null)
+                // Debuff the enemy we are REACTING to, not whatever we happen to be hitting — they are
+                // frequently different, and Feint or Addle landing on the wrong one does nothing about the
+                // mechanic. Reprisal is self-centred, so measuring range to the caster is right there too:
+                // if the caster is out of its radius, Reprisal genuinely cannot mitigate this cast.
+                // Falls back to the current target when nothing is mid-cast (lock-on reactions have no caster).
+                var debuffTarget = (GameObject)FightLogic.DetectedCaster() ?? Core.Me.CurrentTarget;
+
+                if (debuffTarget == null)
                     return false;
 
-                // For range-based debuffs (e.g., Reprisal), check if current target is within range
-                if (range > 0f && !Core.Me.CurrentTarget.WithinSpellRange(range))
+                // For range-based debuffs (e.g., Reprisal), check the caster is within range
+                if (range > 0f && !debuffTarget.WithinSpellRange(range))
                     return false;
 
                 // For target-based debuffs, check target aura
-                if (targetAuraCheck && Core.Me.CurrentTarget.HasAura(aura))
+                if (targetAuraCheck && debuffTarget.HasAura(aura))
                     return false;
 
                 if (!FightLogic.HodlCastTimeRemaining(castTimeRemainingMs, BaseSettings.Instance.FightLogicResponseDelay))
                     return false;
 
                 if (BaseSettings.Instance.DebugFightLogic)
-                    Logger.WriteInfo($"[Debuff Response] Cast {spell.Name} on {Core.Me.CurrentTarget.Name}");
+                    Logger.WriteInfo($"[Debuff Response] Cast {spell.Name} on {debuffTarget.Name}");
 
-                return await FightLogic.DoAndBuffer(spell.Cast(Core.Me.CurrentTarget));
+                return await FightLogic.DoAndBuffer(spell.Cast(debuffTarget));
             }
 
             return false;

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -336,10 +336,17 @@ namespace Magitek.Utilities
         /// to whatever we happen to be hitting does nothing about the mechanic we are reacting to.
         /// </para>
         /// <para>
-        /// The cast id has to be one this enemy is catalogued for. An AoE can also be detected from a
-        /// lock-on on the party, with no cast involved at all — and this enemy may still be mid-cast on
-        /// something unrelated. Returning it then would aim the debuff using a cast no detector matched,
-        /// so the id check keeps those reactions on the current-target fallback where they belong.
+        /// The cast id has to be one this enemy is catalogued for, in a category the debuff reactions
+        /// actually answer. An AoE can also be detected from a lock-on on the party, with no cast
+        /// involved at all — and this enemy may still be mid-cast on something unrelated. Returning it
+        /// then would aim the debuff using a cast no detector matched, so the id check keeps those
+        /// reactions on the current-target fallback where they belong.
+        /// </para>
+        /// <para>
+        /// Knockbacks are deliberately NOT counted. FightLogic_Debuff never calls
+        /// EnemyIsCastingKnockback, so a knockback cast cannot be what it is reacting to — and several
+        /// catalogued encounters carry both AoeLockOns and Knockbacks, where counting them would let a
+        /// lock-on detection hand back an enemy that is merely mid-knockback.
         /// </para>
         /// </summary>
         public static BattleCharacter DetectedCaster()
@@ -354,8 +361,7 @@ namespace Magitek.Utilities
             var matched = (enemyLogic.TankBusters?.Contains(castId) ?? false)
                           || (enemyLogic.SharedTankBusters?.Contains(castId) ?? false)
                           || (enemyLogic.Aoes?.Contains(castId) ?? false)
-                          || (enemyLogic.BigAoes?.Contains(castId) ?? false)
-                          || (enemyLogic.Knockbacks?.Contains(castId) ?? false);
+                          || (enemyLogic.BigAoes?.Contains(castId) ?? false);
 
             return matched ? enemy : null;
         }

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -335,12 +335,29 @@ namespace Magitek.Utilities
         /// Core.Me.CurrentTarget: the two are frequently different enemies, and a mitigation debuff applied
         /// to whatever we happen to be hitting does nothing about the mechanic we are reacting to.
         /// </para>
+        /// <para>
+        /// The cast id has to be one this enemy is catalogued for. An AoE can also be detected from a
+        /// lock-on on the party, with no cast involved at all — and this enemy may still be mid-cast on
+        /// something unrelated. Returning it then would aim the debuff using a cast no detector matched,
+        /// so the id check keeps those reactions on the current-target fallback where they belong.
+        /// </para>
         /// </summary>
         public static BattleCharacter DetectedCaster()
         {
-            var (_, _, enemy) = GetEnemyLogicAndEnemy();
+            var (_, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
 
-            return enemy != null && enemy.IsValid && enemy.IsCasting ? enemy : null;
+            if (enemyLogic == null || enemy == null || !enemy.IsValid || !enemy.IsCasting)
+                return null;
+
+            var castId = enemy.CastingSpellId;
+
+            var matched = (enemyLogic.TankBusters?.Contains(castId) ?? false)
+                          || (enemyLogic.SharedTankBusters?.Contains(castId) ?? false)
+                          || (enemyLogic.Aoes?.Contains(castId) ?? false)
+                          || (enemyLogic.BigAoes?.Contains(castId) ?? false)
+                          || (enemyLogic.Knockbacks?.Contains(castId) ?? false);
+
+            return matched ? enemy : null;
         }
 
         public static bool EnemyHasAnyKnockbackLogic()

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -328,6 +328,21 @@ namespace Magitek.Utilities
             return false;
         }
 
+        /// <summary>
+        /// The catalogued enemy whose cast the detectors matched, while it is still casting — or null.
+        /// <para>
+        /// Reactions that debuff the CASTER (Feint, Addle, Dismantle, Reprisal) need this rather than
+        /// Core.Me.CurrentTarget: the two are frequently different enemies, and a mitigation debuff applied
+        /// to whatever we happen to be hitting does nothing about the mechanic we are reacting to.
+        /// </para>
+        /// </summary>
+        public static BattleCharacter DetectedCaster()
+        {
+            var (_, _, enemy) = GetEnemyLogicAndEnemy();
+
+            return enemy != null && enemy.IsValid && enemy.IsCasting ? enemy : null;
+        }
+
         public static bool EnemyHasAnyKnockbackLogic()
         {
             if (ZoneHasFightLogic())


### PR DESCRIPTION
Split out of #194 per your closing note.

## What this changes

Feint, Addle, Dismantle and Reprisal now target the enemy that fight logic detected casting the mechanic, instead of whatever we happen to be hitting.

## Why

`FightLogic_Debuff` reacts to a specific enemy's catalogued cast and then applies the debuff to `Core.Me.CurrentTarget`. In any fight with more than one enemy those are frequently different mobs, so the damage-down lands on an add while the boss's mechanic goes out unmitigated.

Adds one accessor, `FightLogic.DetectedCaster()`, returning the catalogued enemy that is currently casting, or null. The debuff target becomes that caster, falling back to the current target when nothing is mid-cast — lock-on reactions have no caster, so the fallback keeps them working.

## Scope

Two files: the accessor in FightLogic, and the target selection in `FightLogic_Debuff`. No new usings; `Core.Me.CurrentTarget` is already `GameObject`, which every downstream call accepts.

## Two behaviour changes worth reviewing

- **Reprisal will fire less often.** Its range guard is `Spells.Reprisal.Radius` (5y) and it is now measured against the caster rather than the current target. When the caster is out of that radius, Reprisal genuinely cannot mitigate the cast, so declining is correct — but it will look like a regression next to master.
- The debug line now prints the chosen target, which is what makes this testable.

## In-game test plan

Enable Debug Fight Logic; the `[Debuff Response] Cast <spell> on <name>` line is the whole test.

1. **The bug.** A catalogued encounter with a boss plus adds — Jeuno: The First Walk works well. On a Feint job, deliberately target an add and let the boss start a catalogued cast. Pass = the log names the boss. Fail = it names the add. Cross-check in ACT that the damage-down landed on the boss.
2. **Single-boss no-op.** Any catalogued single-boss fight: caster and current target are the same object, so behaviour should be indistinguishable from master.
3. **Lock-on path.** An encounter whose entry uses AoeLockOns rather than a cast id. Nothing is mid-cast, so `DetectedCaster()` returns null and the fallback must fire on the current target, with no exception.
4. **No target.** Stand in a catalogued encounter with no target selected while a mechanic goes off — nothing cast, no exception.
