### PR TITLE
FightLogic - Fix Windurst bosses being ignored and mitigate the mechanics they were missing

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7026,32 +7026,12 @@ namespace Magitek.Utilities
                         Name = "Shantotto the Demon",
                         TankBusters = new List<uint> {
                             50213, // Vidohunir
+                            50214, // Vidohunir
                         },
                         Aoes = new List<uint> {
                             50215, // Flare Play
                             50210, // Final Exam
-                        },
-                        AoeLockOns = null,
-                        Knockbacks = null,
-                        SharedTankBusters = null,
-                        BigAoes = null
-                    },
-                }
-            },
-            new Encounter {
-                ZoneId = 1368,
-                Name = "Windurst: The Third Walk",
-                Expansion = FfxivExpansion.Dawntrail,
-                Enemies = new List<Enemy> {
-                    new Enemy {
-                        Id = 14778,
-                        Name = "Shantotto the Demon",
-                        TankBusters = new List<uint> {
-                            50213, // Vidohunir
-                        },
-                        Aoes = new List<uint> {
-                            50215, // Flare Play
-                            50210, // Final Exam
+                            50211, // Final Exam
                         },
                         AoeLockOns = null,
                         Knockbacks = null,
@@ -7064,7 +7044,9 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         Aoes = new List<uint> {
                             50161, // Banishga IV
+                            50163, // Banishga IV
                             50157, // Mega Holy
+                            50158, // Mega Holy
                             50153, // Divine Judgment
                         },
                         AoeLockOns = null,
@@ -7072,23 +7054,20 @@ namespace Magitek.Utilities
                         SharedTankBusters = null,
                         BigAoes = null
                     },
-                }
-            },
-            new Encounter {
-                ZoneId = 1368,
-                Name = "Windurst: The Third Walk",
-                Expansion = FfxivExpansion.Dawntrail,
-                Enemies = new List<Enemy> {
                     new Enemy {
                         Id = 14779,
                         Name = "Promathia",
                         TankBusters = new List<uint> {
                             50337, // Comet
+                            50338, // Comet
                         },
                         Aoes = new List<uint> {
                             50317, // Empty Salvation
                             50694, // Deadly Rebirth
+                            50347, // Deadly Rebirth
                             50334, // Infernal Deliverance
+                            50335, // Infernal Deliverance
+                            50565, // Infernal Deliverance
                         },
                         AoeLockOns = null,
                         Knockbacks = null,


### PR DESCRIPTION
Four of the five bosses in Windurst: The Third Walk have fight logic written for them, but none of it has ever run. The zone has three separate `Encounter` blocks all using `ZoneId = 1368`, and `GetEnemyLogicAndEnemy` looks the zone up with `FirstOrDefault`, so only the first block is ever found. Everything after it is unreachable:

- **Shantotto the Demon** — reachable (first block)
- **Alexander Resurrected** — never loaded
- **Promathia** — never loaded
- **Shinryu Paradox** — never loaded
- **Hollow King** — never loaded

This merges the three blocks into one so all five bosses are visible to the detector. The duplicate Shantotto entry from the second block is dropped; its ids are identical to the reachable one.

While confirming the fix against a log, I also found seven mechanics catalogued under only one id of a multi-id family, so the sibling casts slip past detection. These are added alongside the ids already present:

| Boss | Mechanic | Had | Added |
| --- | --- | --- | --- |
| Shantotto the Demon | Vidohunir (tankbuster) | 50213 | 50214 |
| Shantotto the Demon | Final Exam | 50210 | 50211 |
| Alexander Resurrected | Banishga IV | 50161 | 50163 |
| Alexander Resurrected | Mega Holy | 50157 | 50158 |
| Promathia | Comet (tankbuster) | 50337 | 50338 |
| Promathia | Deadly Rebirth | 50694 | 50347 |
| Promathia | Infernal Deliverance | 50334 | 50335, 50565 |

The uncatalogued Comet 50338 is what prompted the check — it landed on me for 218,412 unmitigated while 50337 sat in the list right next to it. Banishga IV 50163 hit for 59,841 and 46,326 in the same clear.

Ids are from combat logs of a full Third Walk clear, and the fix has been run in-game. No behaviour changes outside this encounter.

One thing I left alone: there is a second duplicate `ZoneId` in the file, on `ZoneId.Emanation`, where the Extreme encounter reuses the normal-mode constant. Same defect, but I don't know which enum member is correct for the Extreme instance, so I'd rather not guess at it here.
