### PR TITLE
OC - Add Occult Blink to Phantom White Mage

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -63,6 +63,9 @@ namespace Magitek.Logic.Roles
             IceWeakness = 5323,
             LightningWeakness = 5324,
             WindWeakness = 5325,
+            // Phantom White Mage. Occult Blink nullifies one instance of magic damage for 30s.
+            // Not dispellable, and it carries no stack count - one charge is one charge.
+            OccultBlink = 5316,
             // Occult Toad (Phantom Black Mage). 20s; the target's damage dealt drops by 99% and
             // it cannot use any action but its auto-attack. Plenty of enemies are flatly immune -
             // OccultDebuffImmunityTracker learns which ones.
@@ -252,11 +255,11 @@ namespace Magitek.Logic.Roles
 
         // Phantom White Mage Spells (Job ID: 5329)
         // Phantom Red Mage has its own, different "Occult Cure II" action (49093), so both carry
-        // their job name. Occult Blink (49069) is deliberately not defined - it grants one
-        // magic-damage immunity and is only useful against specific scripted mechanics, which
-        // the routine has no way to anticipate.
+        // their job name. Occult Blink is 30y single target rather than self-only, so it can be
+        // spent on whoever is taking the magic damage instead of only on us.
         public static readonly SpellData WhiteMageOccultCureII = DataManager.GetSpellData(49067);
         public static readonly SpellData WhiteMageOccultCureIII = DataManager.GetSpellData(49068);
+        public static readonly SpellData OccultBlink = DataManager.GetSpellData(49069);
         public static readonly SpellData OccultRaise = DataManager.GetSpellData(49070);
         public static readonly SpellData OccultHoly = DataManager.GetSpellData(49071);
 
@@ -4207,6 +4210,63 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
+        /// Occult Blink - instant, 90s recast, no MP. Renders the target impervious to one instance
+        /// of magic damage for 30s.
+        ///
+        /// 30y single target rather than self-only, so unlike Phantom Ninja's Image this can be
+        /// spent on an ally, and it takes Magic Shell's tanks-then-lowest priority. Which magic
+        /// attack it eats is not something the routine gets to choose - the first one to land
+        /// consumes it - so it waits on a health threshold the way the other reactive defensives
+        /// here do rather than being fired on cooldown.
+        /// </summary>
+        private static async Task<bool> OccultBlink()
+        {
+            if (!OccultCrescentSettings.Instance.UseOccultBlink)
+                return false;
+
+            if (!Core.Me.InCombat)
+                return false;
+
+            if (!OCSpells.OccultBlink.CanCast())
+                return false;
+
+            var threshold = OccultCrescentSettings.Instance.OccultBlinkHealthPercent;
+
+            GameObject blinkTarget = null;
+
+            if (OccultCrescentSettings.Instance.OccultBlinkCastOnAllies)
+            {
+                blinkTarget = Group.CastableAlliesWithin30.Where(ally =>
+                    ally.IsValid &&
+                    ally.IsAlive &&
+                    !ally.HasAura(OCAuras.OccultBlink) &&
+                    ally.CurrentHealthPercent <= threshold)
+                    .OrderByDescending(ally => ally.IsTank())
+                    .ThenBy(ally => ally.CurrentHealthPercent)
+                    .FirstOrDefault();
+
+                if (blinkTarget == null &&
+                    !Core.Me.HasAura(OCAuras.OccultBlink) &&
+                    Core.Me.CurrentHealthPercent <= threshold)
+                    blinkTarget = Core.Me;
+            }
+            else
+            {
+                if (!Core.Me.HasAura(OCAuras.OccultBlink) &&
+                    Core.Me.CurrentHealthPercent <= threshold)
+                    blinkTarget = Core.Me;
+            }
+
+            if (blinkTarget == null)
+                return false;
+
+            if (!blinkTarget.WithinSpellRange(OCSpells.OccultBlink.Range))
+                return false;
+
+            return await OCSpells.OccultBlink.Cast(blinkTarget);
+        }
+
+        /// <summary>
         /// Occult Holy - 2.3s cast, 60s recast. 500 potency of unaspected damage to the target and
         /// everything within 8y of it, rising to 750 against undead.
         /// </summary>
@@ -4240,6 +4300,11 @@ namespace Magitek.Logic.Roles
         /// <returns>True if an action was executed, false otherwise</returns>
         private static async Task<bool> ExecuteWhiteMagePhantomJob()
         {
+            // Occult Blink - instant, so it costs nothing to check first, and a nullified hit is
+            // worth more than healing the same hit back afterwards
+            if (await OccultBlink())
+                return true;
+
             // Occult Cure III - group heal first, so a raid-wide hit is answered in one cast
             if (await WhiteMageOccultCureIII())
                 return true;

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -655,6 +655,18 @@ namespace Magitek.Models.OccultCrescent
 
         [Setting]
         [DefaultValue(true)]
+        public bool UseOccultBlink { get; set; }
+
+        [Setting]
+        [DefaultValue(75.0f)]
+        public float OccultBlinkHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool OccultBlinkCastOnAllies { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool UseOccultHoly { get; set; }
         #endregion
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -8769,6 +8769,15 @@ namespace Magitek.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Use Occult Blink (nullifies one magic attack).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Occult_Blink {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Occult_Blink", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Use Occult Blizzard II.
         /// </summary>
         public static string OccultCrescent_Content_Use_Occult_Blizzard_II {

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2096,6 +2096,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="OccultCrescent_Content_Use_Occult_Holy" xml:space="preserve">
     <value>Use Occult Holy</value>
   </data>
+  <data name="OccultCrescent_Content_Use_Occult_Blink" xml:space="preserve">
+    <value>Use Occult Blink (nullifies one magic attack)</value>
+  </data>
   <data name="OccultCrescent_Text_and_at_least_this_many_hurt" xml:space="preserve">
     <value>and at least this many hurt</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2097,6 +2097,9 @@
   <data name="OccultCrescent_Content_Use_Occult_Holy" xml:space="preserve">
     <value>使用 魔神圣</value>
   </data>
+  <data name="OccultCrescent_Content_Use_Occult_Blink" xml:space="preserve">
+    <value>使用 魔分身 (无效化一次魔法攻击)</value>
+  </data>
   <data name="OccultCrescent_Text_and_at_least_this_many_hurt" xml:space="preserve">
     <value>且受伤人数至少为</value>
   </data>

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -1345,6 +1345,26 @@
 
                                         <StackPanel Margin="5"
                                                     Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Occult_Blink}"
+                                                          IsChecked="{Binding UseOccultBlink, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.OccultCrescent_Text_when_HP_below}"
+                                                           Margin="20,0,0,0"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding OccultBlinkHealthPercent, Mode=TwoWay}"
+                                                                  Margin="5,0,0,0"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="percent"/>
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_On_Allies}"
+                                                          IsChecked="{Binding OccultBlinkCastOnAllies, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
                                                 <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Occult_Holy}"
                                                           IsChecked="{Binding UseOccultHoly, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>


### PR DESCRIPTION
Tested: Tested in game and working. Builds clean; the ability is phantom level 3, so it stays silent below that.

Sources:
- Client action data via ClaudeBridge: 49069, 30y range, radius 0, instant, 90s recast, no cost. Status 5316, not dispellable, no stacks.
- https://ffxiv.consolegameswiki.com/wiki/Phantom_White_Mage — "Renders target impervious to most magic damage for one attack. Duration: 30s"

Design: 30y single target rather than self-only, so it follows Mystic Knight's Magic Shell (tanks first, then lowest HP, "On Allies" toggle) rather than Ninja's self-only Image. Fires reactively on an HP threshold; the routine cannot anticipate the scripted magic mechanic it is nominally for.

Known trade: the charge is consumed by the first magic hit to land, so trash chip damage can burn it for 90s. Same trade Image already ships with. A "bosses only" gate was considered and declined for consistency with Image, Magic Shell and Earthen Wall.

Removed: the comment in OCSpells stating Occult Blink was deliberately not defined, which this change makes false.

Co-Authored-By: Claude <noreply@anthropic.com>
