### PR TITLE
ALL - Restore tank cooldowns that stopped firing when a party has two tanks

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -307,14 +307,35 @@ namespace Magitek.Extensions
             return gameObject != null && Tanks.Contains(gameObject.CurrentJob);
         }
 
+        // "Main tank" is only answerable from a positive signal: this tank is holding what we are pointed
+        // at, or whatever it is fighting is pointed back at it. When no tank we can reach gives that
+        // signal we cannot tell them apart, and then every tank counts rather than none of them — a
+        // party-wide mitigation that never fires is worse than one that fires for the wrong tank.
+        //
+        // The old tie-break was "the party contains exactly one tank", which answers false for BOTH tanks
+        // of a two-tank party. An Occult Crescent critical encounter proved the cost: the boss is held by
+        // someone outside the party, so neither tank ever produced a signal, and Kerachole, Panhaima and
+        // Aquaveil stayed locked off for the whole fight while the ungated barriers kept firing.
+        //
+        // The roster is the castable tanks in heal range, not the raw party list, for the reason spelled
+        // out at FightLogic.SharedTankBuster: a tank we cannot reach must not get a vote on who the
+        // reachable tank is. It also keeps both sides of the comparison in one population, since the
+        // castable lists follow the alliance while we heal it and the raw party list does not.
         public static bool IsMainTank(this GameObject unit)
         {
             var gameObject = unit as Character;
-            return gameObject != null
-                && Tanks.Contains(gameObject.CurrentJob)
-                && (gameObject.BeingTargetedBy(Core.Me.CurrentTarget)
-                    || gameObject.BeingTargetedBy(gameObject.TargetGameObject)
-                    || PartyManager.RawMembers.Where(r => r != null).Select(r => r.BattleCharacter).Count(r => r != null && Tanks.Contains(r.CurrentJob)) == 1);
+
+            if (gameObject == null || !Tanks.Contains(gameObject.CurrentJob))
+                return false;
+
+            if (gameObject.BeingTargetedBy(Core.Me.CurrentTarget)
+                || gameObject.BeingTargetedBy(gameObject.TargetGameObject))
+                return true;
+
+            return !Group.CastableTanks.Any(r => r.ObjectId != gameObject.ObjectId
+                                              && r.WithinSpellRange(30)
+                                              && (r.BeingTargetedBy(Core.Me.CurrentTarget)
+                                                  || r.BeingTargetedBy(r.TargetGameObject)));
         }
 
         public static bool IsTank(this GameObject unit, bool mainTank)


### PR DESCRIPTION
## What this changes

`IsMainTank()` now fails open: when no reachable tank in the party has a positive targeting signal, any castable tank within range is treated as the main tank instead of nobody. Previously the check required an enemy to be actively targeting the tank, and when that signal was absent every main-tank-gated cooldown across the routine silently stopped firing.

## Why

In a two-tank party in Occult Crescent field content, a Sage ran for over two hours with every MainTank-gated setting active and none of those cooldowns ever firing — no Kardia placement on the tank, no Kerachole, no MT-gated heals. When the second tank left the party, everything started working immediately: a clean natural experiment isolating the multi-tank composition as the trigger. The root cause is that with two tanks neither consistently held the targeting signal the old check demanded.

## Game-behavior assumptions I could not verify

None — all behavior claims verified against existing code patterns and live runs; the fix only changes the fallback when the existing positive-signal path finds nothing.

## Verified against game data

- Reproduced live: 2h03m of suppressed MT-gated cooldowns in a 2-tank party, immediate recovery when the party dropped to one tank (RB logs, both states).
- Fix validated live in Containment Bay S1T7 with two tanks: Kardia landed on the aggro-holding tank via the MainTank rule, and Kerachole fired through a `KeracholeOnlyWithMainTank` gate — impossible unless `IsMainTank()` resolves.

## In-game test plan

1. Setup: SGE or WHM in any full party with two tanks (raid roulette works), MT-gated settings on (e.g. Kardia on main tank, Kerachole only with main tank).
2. Trigger: pull any boss; let one tank hold aggro.
3. Expect: MT-gated abilities fire normally on the aggro tank.
4. Trigger: a phase or transition where the boss targets nobody.
5. Expect: MT-gated abilities still fire on a tank rather than suspending.
6. If it fails: capture the RB log window around the pull; note party composition and which tank held aggro.

## Build

- [x] `dotnet build` clean in `Magitek/`
- [x] No unrelated files in the diff
