### PR TITLE
FightLogic - Fix Emanation (Extreme) using the normal trial's zone

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -1942,7 +1942,7 @@ namespace Magitek.Utilities
                 }
             },
             new Encounter {
-                ZoneId = ZoneId.Emanation,
+                ZoneId = ZoneId.EmanationExtreme,
                 Name = "Trial: Emanation (Extreme)",
                 Expansion = FfxivExpansion.Stormblood,
                 Enemies = new List<Enemy> {


### PR DESCRIPTION
## What this changes

The Emanation (Extreme) encounter block was keyed to the normal trial's zone constant, so its fight logic could never trigger in the Extreme instance. One-line fix to the correct zone id.

## Why

Data fix found while auditing encounter zone bindings: the Extreme block was unreachable — its entries loaded for the normal trial's zone, where the Extreme cast ids never occur.

## Game-behavior assumptions I could not verify

None — all behavior claims verified against game data or existing patterns.

## Verified against game data

- The zone constant now matches the Extreme duty's TerritoryType id; the normal trial keeps its own block unchanged.

## In-game test plan

1. Setup: any healer, Emanation (Extreme), unsync.
2. Trigger: pull Lakshmi.
3. Expect: fight-logic responses fire on the Extreme cast ids (they previously could not).
4. If it fails: capture the RB log; check whether the zone id logged on entry matches the encounter block.

## Build

- [x] `dotnet build` clean in `Magitek/`
- [x] No unrelated files in the diff
