### PR TITLE
AST - Draw cards before the pull and give damage cards to DPS before tanks and healers

### DIFF
--- a/Magitek/Extensions/CharacterExtensions.cs
+++ b/Magitek/Extensions/CharacterExtensions.cs
@@ -25,17 +25,14 @@ namespace Magitek.Extensions
 
         public static bool HasAnyCardAura(this Character unit)
         {
+            // The six arcana are the only card auras an ally can carry; Lord and Lady of
+            // Crowns apply no aura to party members.
             return unit.HasAnyAura(new uint[] { Auras.TheBalance,
-                                                        Auras.TheBalance,
                                                         Auras.TheBole,
                                                         Auras.TheArrow,
                                                         Auras.TheSpear,
                                                         Auras.TheEwer,
-                                                        Auras.TheSpire,
-                                                        Auras.LordofCrowns,
-                                                        Auras.LordofCrowns2,
-                                                        Auras.LadyofCrowns,
-                                                        Auras.LadyofCrowns2
+                                                        Auras.TheSpire
             });
         }
 

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -109,7 +109,9 @@ namespace Magitek.Logic.Astrologian
 
         public static async Task<bool> Draw()
         {
-            if (!Core.Me.InCombat)
+            // Cards persist out of combat, so drawing before the pull keeps the opener from
+            // being cardless. Sanctuaries block it so we don't shuffle cards standing in town.
+            if (!Core.Me.InCombat && Globals.InSanctuaryOrSafeZone)
                 return false;
 
             foreach (var card in CurrentCards)
@@ -117,6 +119,12 @@ namespace Magitek.Logic.Astrologian
                 if (card != AstrologianCard.None)
                     return false;
             }
+
+            // The two draws are one alternating button under the hood (shared recast, and the
+            // client swaps the base action to whichever draw is active), so they cannot be
+            // toggled separately — one setting governs drawing as a whole.
+            if (!AstrologianSettings.Instance.DrawCards)
+                return false;
 
             if (Spells.AstralDraw.IsKnownAndReady())
                 return await Spells.AstralDraw.Cast(Core.Me);
@@ -143,15 +151,17 @@ namespace Magitek.Logic.Astrologian
         }
 
         private static GameObject MeleeDpsOrTank()
-        {            
+        {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
-            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(GetWeight);
+            // The Balance gives melee DPS and tanks the full 6%, but a DPS converts the buff
+            // into far more damage than a tank, so DPS sort ahead of tanks inside the bracket.
+            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
 
             //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
-                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(GetWeight);
+                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
                 return extendedAlly.FirstOrDefault(Core.Me);
             }
             return ally.FirstOrDefault(Core.Me);
@@ -161,12 +171,14 @@ namespace Magitek.Logic.Astrologian
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
-            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(GetWeight);
+            // The Spear gives ranged DPS and healers the full 6%; same reasoning as The Balance,
+            // a DPS makes more of the buff than a healer, so DPS sort ahead inside the bracket.
+            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
 
             //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
-                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(GetWeight);
+                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
                 return extendedAlly.FirstOrDefault(Core.Me);
             }
             return ally.FirstOrDefault(Core.Me);

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -156,6 +156,9 @@ namespace Magitek.Logic.Astrologian
             int partySize = Group.CastableAlliesWithin30.Count();
             // The Balance gives melee DPS and tanks the full 6%, but a DPS converts the buff
             // into far more damage than a tank, so DPS sort ahead of tanks inside the bracket.
+            // The pool boundary IS the potency bracket, deliberately: off-role recipients get
+            // only 3%, and a full-potency tank (~two-thirds of a DPS's output at 6%) out-gains
+            // a half-potency ranged DPS — so with no melee DPS alive the tank is the right call.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
 
             //If in light party, allow ally to have more than one card aura.
@@ -173,6 +176,8 @@ namespace Magitek.Logic.Astrologian
             int partySize = Group.CastableAlliesWithin30.Count();
             // The Spear gives ranged DPS and healers the full 6%; same reasoning as The Balance,
             // a DPS makes more of the buff than a healer, so DPS sort ahead inside the bracket.
+            // Same deliberate pool boundary as The Balance: a half-potency melee DPS does not
+            // out-gain a full-potency healer's-bracket recipient, so off-role DPS stay excluded.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
 
             //If in light party, allow ally to have more than one card aura.

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -489,11 +489,7 @@ namespace Magitek.Models.Astrologian
 
         [Setting]
         [DefaultValue(true)]
-        public bool AstralDraw { get; set; }
-
-        [Setting]
-        [DefaultValue(true)]
-        public bool UmbralDraw { get; set; }
+        public bool DrawCards { get; set; }
 
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -250,6 +250,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Draw cards automatically (Astral and Umbral alternate).
+        /// </summary>
+        public static string Astrologian_Content_Draw_Cards {
+            get {
+                return ResourceManager.GetString("Astrologian_Content_Draw_Cards", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Earthly Star.
         /// </summary>
         public static string Astrologian_Content_Earthly_Star {
@@ -601,15 +610,6 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use Astral Draw.
-        /// </summary>
-        public static string Astrologian_Content_Use_Astral_Draw {
-            get {
-                return ResourceManager.GetString("Astrologian_Content_Use_Astral_Draw", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Use Divination at least.
         /// </summary>
         public static string Astrologian_Content_Use_Divination_at_least {
@@ -651,15 +651,6 @@ namespace Magitek.Properties {
         public static string Astrologian_Content_Use_Time_Till_Death_For_Damage {
             get {
                 return ResourceManager.GetString("Astrologian_Content_Use_Time_Till_Death_For_Damage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Use Umbral Draw.
-        /// </summary>
-        public static string Astrologian_Content_Use_Umbral_Draw {
-            get {
-                return ResourceManager.GetString("Astrologian_Content_Use_Umbral_Draw", resourceCulture);
             }
         }
         

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -577,7 +577,7 @@
     <value>Seconds Left in Combat.</value>
   </data>
   <data name="Astrologian_Text_Card_Priority_First_to_Last" xml:space="preserve">
-    <value>Card Priority (First to Last)</value>
+    <value>Card weights (lower = first). Damage cards go to DPS before tanks/healers; weights break ties.</value>
   </data>
   <data name="Astrologian_Text_MNK" xml:space="preserve">
     <value>MNK:</value>
@@ -645,11 +645,8 @@
   <data name="Astrologian_Text_VPR" xml:space="preserve">
     <value>VPR:</value>
   </data>
-  <data name="Astrologian_Content_Use_Astral_Draw" xml:space="preserve">
-    <value>Use Astral Draw</value>
-  </data>
-  <data name="Astrologian_Content_Use_Umbral_Draw" xml:space="preserve">
-    <value>Use Umbral Draw</value>
+  <data name="Astrologian_Content_Draw_Cards" xml:space="preserve">
+    <value>Draw cards automatically (Astral and Umbral alternate)</value>
   </data>
   <data name="Astrologian_Content_Lord_Of_Crowns_at_least" xml:space="preserve">
     <value>Lord Of Crowns at least</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -577,7 +577,7 @@
     <value>倒计时.</value>
   </data>
   <data name="Astrologian_Text_Card_Priority_First_to_Last" xml:space="preserve">
-    <value>卡片优先级（从第一张到最后一张）</value>
+    <value>卡片权重（数值越低越优先）。攻击卡优先给DPS，其次坦克/治疗；权重用于同类之间排序。</value>
   </data>
   <data name="Astrologian_Text_MNK" xml:space="preserve">
     <value>武僧：</value>
@@ -645,11 +645,8 @@
   <data name="Astrologian_Text_VPR" xml:space="preserve">
     <value>蝰蛇剑士：</value>
   </data>
-  <data name="Astrologian_Content_Use_Astral_Draw" xml:space="preserve">
-    <value>使用星极抽卡</value>
-  </data>
-  <data name="Astrologian_Content_Use_Umbral_Draw" xml:space="preserve">
-    <value>使用灵极抽卡</value>
+  <data name="Astrologian_Content_Draw_Cards" xml:space="preserve">
+    <value>自动抽卡（星极与灵极交替）</value>
   </data>
   <data name="Astrologian_Content_Lord_Of_Crowns_at_least" xml:space="preserve">
     <value>至少使用一次王冠之领主</value>

--- a/Magitek/Views/UserControls/Astrologian/Cards.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Cards.xaml
@@ -23,8 +23,7 @@
 
         <controls:SettingsBlock Margin="0,2" Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Orientation="Horizontal">
-                <CheckBox Margin="5" Content="{x:Static properties:Resources.Astrologian_Content_Use_Astral_Draw}" IsChecked="{Binding AstrologianSettings.AstralDraw, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <CheckBox Margin="5" Content="{x:Static properties:Resources.Astrologian_Content_Use_Umbral_Draw}" IsChecked="{Binding AstrologianSettings.UmbralDraw, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <CheckBox Margin="5" Content="{x:Static properties:Resources.Astrologian_Content_Draw_Cards}" IsChecked="{Binding AstrologianSettings.DrawCards, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
             </StackPanel>
         </controls:SettingsBlock>
 


### PR DESCRIPTION
## What this changes

Astrologian card play gets two behavior improvements: cards are drawn before the pull instead of waiting for combat, and damage cards prefer DPS recipients before falling back to tanks and healers. Card-related settings and both localizations updated to match.

## Why

Cards drawn after the pull lose uptime on the opener, and damage cards landing on tanks while DPS stand unbuffed is wasted potency. Both were visible in ordinary play as cards arriving late and on the wrong targets.

## Game-behavior assumptions I could not verify

None — all behavior claims verified against existing code patterns and the in-game card tooltips.

## Verified against game data

- Card aura ids and play mechanics verified against the current 7.x card system (in-game tooltips, read 2026-08-10).
- Validated live in a full Windurst: The Third Walk alliance clear as Astrologian: 33 draws produced 103 card plays with all six cards distributed evenly (17 each plus a Lord of Crowns) across the run — no stuck draws, no dropped plays.

## In-game test plan

1. Setup: AST 100, any dungeon or raid, cards enabled.
2. Trigger: approach a boss out of combat.
3. Expect: a draw happens before the pull; the opener includes an immediate play.
4. Trigger: run a full fight with mixed party roles.
5. Expect: damage cards go to DPS while any are alive and in range; tanks/healers only receive them as fallback.
6. If it fails: capture the RB log and note party composition; card target selection lines show the chosen recipient.

## Build

- [x] `dotnet build` clean in `Magitek/`
- [x] No unrelated files in the diff
