### PR TITLE
AST - Plant Earthly Star proactively and remove the Aggro AST Mode toggle

### DIFF
--- a/Magitek/Logic/Astrologian/Aoe.cs
+++ b/Magitek/Logic/Astrologian/Aoe.cs
@@ -9,56 +9,6 @@ namespace Magitek.Logic.Astrologian
 {
     internal static class Aoe
     {
-        public static async Task<bool> AggroAst()
-        {
-            if (!AstrologianSettings.Instance.AggroAst)
-                return false;
-
-            if (!Core.Me.InCombat)
-                return false;
-
-            if (Core.Me.CurrentTarget.IsBoss() || Combat.Enemies.Count() > 4)
-
-                if (await AggroLightSpeed()) return true;
-            if (await AggroEarthlyStar()) return true;
-            return await AggroMacrocosmos();
-        }
-
-        private static async Task<bool> AggroLightSpeed()
-        {
-            if (!Spells.Lightspeed.IsKnownAndReady())
-                return false;
-
-            if (Core.Me.HasAura(Auras.Lightspeed))
-                return false;
-
-            return await Spells.Lightspeed.CastAura(Core.Me, Auras.Lightspeed);
-        }
-
-        private static async Task<bool> AggroEarthlyStar()
-        {
-            if (!Spells.EarthlyStar.IsKnownAndReady())
-                return false;
-
-            if (Core.Me.HasAnyAura(new uint[] { Auras.EarthlyDominance, Auras.GiantDominance }))
-                return false;
-
-
-            if (!await Spells.EarthlyStar.Cast(Core.Me.CurrentTarget)) return false;
-
-            Utilities.Routines.Astrologian.EarthlyStarLocation = Core.Target.Location;
-            return true;
-        }
-        private static async Task<bool> AggroMacrocosmos()
-        {
-            if (!Spells.Macrocosmos.IsKnownAndReady())
-                return false;
-
-            if (Core.Me.HasAura(Auras.Macrocosmos))
-                return false;
-
-            return await Spells.Macrocosmos.Cast(Core.Me.CurrentTarget);
-        }
         public static async Task<bool> Gravity()
         {
             if (!AoeControl.Enabled)

--- a/Magitek/Logic/Astrologian/HealFightLogic.cs
+++ b/Magitek/Logic/Astrologian/HealFightLogic.cs
@@ -37,7 +37,11 @@ namespace Magitek.Logic.Astrologian
                 return await FightLogic.DoAndBuffer(Spells.NeutralSect.Cast(Core.Me));
             }
 
+            // Only pop a matured star: during Earthly Dominance the burst is the weak version,
+            // and with proactive planting a fresh star would otherwise be spent at reduced
+            // potency the moment any raidwide is detected.
             if (AstrologianSettings.Instance.FightLogicEarthlyStar
+                && Core.Me.HasAura(Auras.GiantDominance)
                 && Spells.StellarDetonation.IsKnownAndReady()
                 && Spells.StellarDetonation.CanCast())
             {
@@ -58,26 +62,18 @@ namespace Magitek.Logic.Astrologian
                 return await FightLogic.DoAndBuffer(Spells.StellarDetonation.Cast(target));
             }
 
+            // When Collective Unconscious declines, fall through to the later responses —
+            // an early return here starves Horoscope and Aspected Helios of the mechanic.
             if (AstrologianSettings.Instance.FightLogicCollectiveUnconscious
                 && Spells.CollectiveUnconscious.IsKnownAndReady()
-                && Spells.CollectiveUnconscious.CanCast())
+                && Spells.CollectiveUnconscious.CanCast()
+                && AstrologianSettings.Instance.CollectiveUnconsciousCenterParty
+                && Group.CastableAlliesWithin30.Count() >= AstrologianSettings.Instance.CollectiveUnconsciousAllies)
             {
                 if (BaseSettings.Instance.DebugFightLogic)
                     Logger.WriteInfo($"[AOE Response] Cast Collective Unconscious");
 
-                Character target = Core.Me;
-
-                if (AstrologianSettings.Instance.CollectiveUnconsciousCenterParty)
-                {
-                    var targets = Group.CastableAlliesWithin30.Count();
-
-                    if ( targets >= AstrologianSettings.Instance.CollectiveUnconsciousAllies)
-                    {
-                        return await FightLogic.DoAndBuffer(Spells.CollectiveUnconscious.Cast(Core.Me));
-                    }
-                }
-                return false;
-                
+                return await FightLogic.DoAndBuffer(Spells.CollectiveUnconscious.Cast(Core.Me));
             }
 
             if (AstrologianSettings.Instance.FightLogicHoroscope

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -642,9 +642,6 @@ namespace Magitek.Logic.Astrologian
         #region Delayed Heals
         public static async Task<bool> EarthlyStar()
         {
-            if (!Spells.EarthlyStar.IsKnownAndReady())
-                return false;
-
             if (!Core.Me.InCombat)
                 return false;
 
@@ -653,7 +650,24 @@ namespace Magitek.Logic.Astrologian
 
             var earthlyStarTargets = PartyManager.VisibleMembers.Select(r => r.BattleCharacter).ToList();
 
+            // The pop checks gate on Stellar Detonation's own action: the base Earthly Star
+            // action sits on its 60s recast for the star's whole deployment, so putting these
+            // behind EarthlyStar.IsKnownAndReady() made them unreachable.
+
+            // Pop a cooking star just before the pull ends so the damage half still lands —
+            // auto-detonation after everything is dead whiffs it. A star that will still reach
+            // Giant Dominance before the pull ends is left to mature for the full explosion.
+            if (AstrologianSettings.Instance.StellarDetonation
+                && Spells.StellarDetonation.IsKnownAndReady()
+                && Utilities.Routines.Astrologian.EarthlyStarLocation != Vector3.Zero
+                && Utilities.Combat.CombatTotalTimeLeft > 0
+                && Utilities.Combat.CombatTotalTimeLeft <= AstrologianSettings.Instance.StellarDetonationPullEndingSeconds
+                && (Core.Me.HasAura(Auras.GiantDominance)
+                    || Core.Me.HasAura(Auras.EarthlyDominance, false, Utilities.Combat.CombatTotalTimeLeft * 1000)))
+                return await Spells.StellarDetonation.Heal(Core.Me);
+
             if (Core.Me.HasAura(Auras.EarthlyDominance)
+                && Spells.StellarDetonation.IsKnownAndReady()
                 && Utilities.Routines.Astrologian.EarthlyStarLocation != Vector3.Zero
                 && AstrologianSettings.Instance.StellarDetonation)
             {
@@ -663,6 +677,7 @@ namespace Magitek.Logic.Astrologian
             }
 
             if (Core.Me.HasAura(Auras.GiantDominance)
+                && Spells.StellarDetonation.IsKnownAndReady()
                 && Utilities.Routines.Astrologian.EarthlyStarLocation != Vector3.Zero
                 && AstrologianSettings.Instance.StellarDetonation)
             {
@@ -671,6 +686,9 @@ namespace Magitek.Logic.Astrologian
                     return await Spells.StellarDetonation.Heal(Core.Me);
             }
 
+            if (!Spells.EarthlyStar.IsKnownAndReady())
+                return false;
+
             if (!AstrologianSettings.Instance.EarthlyStar)
                 return false;
 
@@ -678,29 +696,29 @@ namespace Magitek.Logic.Astrologian
             if (!Core.Me.HasTarget)
                 return false;
 
-            switch (Globals.InParty)
-            {
-                case true:
-                    if (Core.Target.EnemiesNearby(30).Count() > AstrologianSettings.Instance.EarthlyStarEnemiesNearTarget
-                        && earthlyStarTargets.Count(r => r.Distance(Core.Target) <= 30
-                        && r.CurrentHealthPercent <= AstrologianSettings.Instance.EarthlyStarPartyMembersNearTargetHealthPercent) > AstrologianSettings.Instance.EarthlyStarPartyMembersNearTarget)
-                        if (await Spells.EarthlyStar.Cast(Core.Target))
-                        {
-                            Utilities.Routines.Astrologian.EarthlyStarLocation = Core.Target.Location;
-                            return true;
-                        }
-                    break;
-                default:
-                    if (Core.Target.EnemiesNearby(30).Count() > AstrologianSettings.Instance.EarthlyStarEnemiesNearTarget
-                        && Core.Me.CurrentHealthPercent <= AstrologianSettings.Instance.EarthlyStarPartyMembersNearTargetHealthPercent
-                        && Core.Target.WithinSpellRange(30))
-                        if (await Spells.EarthlyStar.Cast(Core.Target))
-                        {
-                            Utilities.Routines.Astrologian.EarthlyStarLocation = Core.Target.Location;
-                            return true;
-                        }
-                    break;
-            }
+            // The plant anchors to the hard target's position, so it must be an enemy —
+            // with an ally targeted the star would land at their feet on cooldown.
+            if (!Core.Target.ThoroughCanAttack())
+                return false;
+
+            // Hold the plant until the pull's time-to-death is computable: freshly tracked
+            // enemies report zero and enemies that have not taken damage yet saturate the
+            // total to int.MaxValue (float-to-int conversion saturates on .NET Core), so a
+            // pull still being gathered reads as one or the other — and a star planted
+            // mid-gather lands where the party will not be.
+            if (Utilities.Combat.CombatTotalTimeLeft <= 0 || Utilities.Combat.CombatTotalTimeLeft >= int.MaxValue)
+                return false;
+
+            // Plant proactively: an unpopped star detonates on its own at the end of Giant
+            // Dominance with the full damage + heal, so holding the plant until allies are
+            // hurt only delays it. Heal-need gating lives in the Stellar Detonation checks above.
+            if (Core.Target.EnemiesNearby(30).Count() >= AstrologianSettings.Instance.EarthlyStarEnemiesNearTarget
+                && Core.Target.WithinSpellRange(30))
+                if (await Spells.EarthlyStar.Cast(Core.Target))
+                {
+                    Utilities.Routines.Astrologian.EarthlyStarLocation = Core.Target.Location;
+                    return true;
+                }
             return false;
         }
 

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -657,13 +657,16 @@ namespace Magitek.Logic.Astrologian
             // Pop a cooking star just before the pull ends so the damage half still lands —
             // auto-detonation after everything is dead whiffs it. A star that will still reach
             // Giant Dominance before the pull ends is left to mature for the full explosion.
+            // Wall-clock, not the summed estimate: the pull ends when the last enemy dies, and
+            // in multi-target pulls the sum overstates that badly (four mobs at 3s each sum to
+            // 12s), so a summed check never trips and the star expires after combat unspent.
             if (AstrologianSettings.Instance.StellarDetonation
                 && Spells.StellarDetonation.IsKnownAndReady()
                 && Utilities.Routines.Astrologian.EarthlyStarLocation != Vector3.Zero
-                && Utilities.Combat.CombatTotalTimeLeft > 0
-                && Utilities.Combat.CombatTotalTimeLeft <= AstrologianSettings.Instance.StellarDetonationPullEndingSeconds
+                && Utilities.Combat.CombatWallClockTimeLeft > 0
+                && Utilities.Combat.CombatWallClockTimeLeft <= AstrologianSettings.Instance.StellarDetonationPullEndingSeconds
                 && (Core.Me.HasAura(Auras.GiantDominance)
-                    || Core.Me.HasAura(Auras.EarthlyDominance, false, Utilities.Combat.CombatTotalTimeLeft * 1000)))
+                    || Core.Me.HasAura(Auras.EarthlyDominance, false, Utilities.Combat.CombatWallClockTimeLeft * 1000)))
                 return await Spells.StellarDetonation.Heal(Core.Me);
 
             if (Core.Me.HasAura(Auras.EarthlyDominance)

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -648,7 +648,14 @@ namespace Magitek.Logic.Astrologian
 
             var earthlyStarLocation = Utilities.Routines.Astrologian.EarthlyStarLocation;
 
-            var earthlyStarTargets = PartyManager.VisibleMembers.Select(r => r.BattleCharacter).ToList();
+            // Lazy on purpose: this method runs on every heal pulse, but the only consumers of
+            // the party list are the two dominance-gated pop checks below, which fail their
+            // aura gates on the overwhelming majority of pulses. PartyManager (rather than the
+            // caster-centred cached Group collections) is required here because the star heals
+            // around ITS placement — allies inside the star's radius can be outside the
+            // caster's 30y, and a cached caster-centred list would miss them.
+            List<BattleCharacter> EarthlyStarTargets() =>
+                PartyManager.VisibleMembers.Select(r => r.BattleCharacter).ToList();
 
             // The pop checks gate on Stellar Detonation's own action: the base Earthly Star
             // action sits on its 60s recast for the star's whole deployment, so putting these
@@ -674,7 +681,7 @@ namespace Magitek.Logic.Astrologian
                 && Utilities.Routines.Astrologian.EarthlyStarLocation != Vector3.Zero
                 && AstrologianSettings.Instance.StellarDetonation)
             {
-                if (earthlyStarTargets.Count(r => r.Distance(earthlyStarLocation) <= 30
+                if (EarthlyStarTargets().Count(r => r.Distance(earthlyStarLocation) <= 30
                 && r.CurrentHealthPercent <= AstrologianSettings.Instance.EarthlyDominanceHealthPercent) > AstrologianSettings.Instance.EarthlyDominanceCount)
                     return await Spells.StellarDetonation.Heal(Core.Me);
             }
@@ -684,7 +691,7 @@ namespace Magitek.Logic.Astrologian
                 && Utilities.Routines.Astrologian.EarthlyStarLocation != Vector3.Zero
                 && AstrologianSettings.Instance.StellarDetonation)
             {
-                if (earthlyStarTargets.Count(r => r.Distance(earthlyStarLocation) <= 30
+                if (EarthlyStarTargets().Count(r => r.Distance(earthlyStarLocation) <= 30
                 && r.CurrentHealthPercent <= AstrologianSettings.Instance.GiantDominanceHealthPercent) > AstrologianSettings.Instance.GiantDominanceCount)
                     return await Spells.StellarDetonation.Heal(Core.Me);
             }

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -88,10 +88,6 @@ namespace Magitek.Models.Astrologian
 
         [Setting]
         [DefaultValue(false)]
-        public bool AggroAst { get; set; }
-
-        [Setting]
-        [DefaultValue(false)]
         public bool Oracle { get; set; }
 
         [Setting]
@@ -363,16 +359,12 @@ namespace Magitek.Models.Astrologian
         public int EarthlyStarEnemiesNearTarget { get; set; }
 
         [Setting]
-        [DefaultValue(2)]
-        public int EarthlyStarPartyMembersNearTarget { get; set; }
-
-        [Setting]
-        [DefaultValue(95f)]
-        public float EarthlyStarPartyMembersNearTargetHealthPercent { get; set; }
-
-        [Setting]
         [DefaultValue(true)]
         public bool StellarDetonation { get; set; }
+
+        [Setting]
+        [DefaultValue(5)]
+        public int StellarDetonationPullEndingSeconds { get; set; }
 
         [Setting]
         [DefaultValue(4)]

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -61,15 +61,6 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Aggro Ast Mode.
-        /// </summary>
-        public static string Astrologian_Content_Aggro_Ast_Mode {
-            get {
-                return ResourceManager.GetString("Astrologian_Content_Aggro_Ast_Mode", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Always With Enhanced Benefic.
         /// </summary>
         public static string Astrologian_Content_Always_With_Enhanced_Benefic {
@@ -772,6 +763,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Detonate Earthly Star Early When The Pull Ends Within.
+        /// </summary>
+        public static string Astrologian_Text_Detonate_Early_When_Pull_Ends_Within {
+            get {
+                return ResourceManager.GetString("Astrologian_Text_Detonate_Early_When_Pull_Ends_Within", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to DNC:.
         /// </summary>
         public static string Astrologian_Text_DNC {
@@ -1006,15 +1006,6 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Party Members Near Target That Are Below.
-        /// </summary>
-        public static string Astrologian_Text_Party_Members_Near_Target_That_Are_Below {
-            get {
-                return ResourceManager.GetString("Astrologian_Text_Party_Members_Near_Target_That_Are_Below", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to PCT:.
         /// </summary>
         public static string Astrologian_Text_PCT {
@@ -1173,15 +1164,6 @@ namespace Magitek.Properties {
         public static string Astrologian_Text_WHM {
             get {
                 return ResourceManager.GetString("Astrologian_Text_WHM", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Causes Lightspeed, Earthstar, and Macrocosmos to be used on cooldown in most cases for additional DPS (generally super wasteful)..
-        /// </summary>
-        public static string Astrologian_ToolTip_Causes_Lightspeed_Earthstar_an {
-            get {
-                return ResourceManager.GetString("Astrologian_ToolTip_Causes_Lightspeed_Earthstar_an", resourceCulture);
             }
         }
         

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -666,9 +666,6 @@
   <data name="Astrologian_Content_Interrupt_Damage_to_Heal" xml:space="preserve">
     <value>Interrupt Damage to Heal</value>
   </data>
-  <data name="Astrologian_Content_Aggro_Ast_Mode" xml:space="preserve">
-    <value>Aggro Ast Mode</value>
-  </data>
   <data name="Astrologian_Content_Use_Time_Till_Death_For_Damage" xml:space="preserve">
     <value>Use Time Till Death For Damage Over Time Spells</value>
   </data>
@@ -677,9 +674,6 @@
   </data>
   <data name="Astrologian_Content_Gravity_When_There_Are" xml:space="preserve">
     <value>Gravity When There Are</value>
-  </data>
-  <data name="Astrologian_ToolTip_Causes_Lightspeed_Earthstar_an" xml:space="preserve">
-    <value>Causes Lightspeed, Earthstar, and Macrocosmos to be used on cooldown in most cases for additional DPS (generally super wasteful).</value>
   </data>
   <data name="Astrologian_Text_Ally_Health_Percent" xml:space="preserve">
     <value>Ally Health Percent</value>
@@ -4004,6 +3998,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Astrologian_Text_Dont_Use_DoT_if_Enemy_Dying_Within_10_Seconds" xml:space="preserve">
     <value>Dont Use DoT if Enemy Dying Within 10 Seconds</value>
   </data>
+  <data name="Astrologian_Text_Detonate_Early_When_Pull_Ends_Within" xml:space="preserve">
+    <value>Detonate Earthly Star Early When The Pull Ends Within</value>
+  </data>
   <data name="Astrologian_Content_Dispel_Only_If_Nearby_Players_Health_Is_Above" xml:space="preserve">
     <value>Dispel Only If Nearby Players Health Is Above</value>
   </data>
@@ -4015,9 +4012,6 @@ Does not work if Lightspeed is disabled.</value>
   </data>
   <data name="Astrologian_Content_Prevent_Usage_of_Swiftcast_Alone" xml:space="preserve">
     <value>Prevent Usage of Swiftcast Alone</value>
-  </data>
-  <data name="Astrologian_Text_Party_Members_Near_Target_That_Are_Below" xml:space="preserve">
-    <value>Party Members Near Target That Are Below</value>
   </data>
   <data name="Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below" xml:space="preserve">
     <value>Party Members Near Earthly Star Are Below</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -666,9 +666,6 @@
   <data name="Astrologian_Content_Interrupt_Damage_to_Heal" xml:space="preserve">
     <value>停手专心治疗</value>
   </data>
-  <data name="Astrologian_Content_Aggro_Ast_Mode" xml:space="preserve">
-    <value>占星术士仇恨模式</value>
-  </data>
   <data name="Astrologian_Content_Use_Time_Till_Death_For_Damage" xml:space="preserve">
     <value>根据目标血量决定DOT的使用</value>
   </data>
@@ -677,9 +674,6 @@
   </data>
   <data name="Astrologian_Content_Gravity_When_There_Are" xml:space="preserve">
     <value>当有   时使用重力</value>
-  </data>
-  <data name="Astrologian_ToolTip_Causes_Lightspeed_Earthstar_an" xml:space="preserve">
-    <value>“光速”、“地星”、“小宇宙”好了就用（非常浪费）.</value>
   </data>
   <data name="Astrologian_Text_Ally_Health_Percent" xml:space="preserve">
     <value>队友HP%百分比</value>
@@ -4005,6 +3999,9 @@
   <data name="Astrologian_Text_Dont_Use_DoT_if_Enemy_Dying_Within_10_Seconds" xml:space="preserve">
     <value>如果敌人在10秒内即将死亡，则不使用DoT</value>
   </data>
+  <data name="Astrologian_Text_Detonate_Early_When_Pull_Ends_Within" xml:space="preserve">
+    <value>战斗剩余时间少于以下秒数时提前引爆地星</value>
+  </data>
   <data name="Astrologian_Content_Dispel_Only_If_Nearby_Players_Health_Is_Above" xml:space="preserve">
     <value>仅当附近玩家血量高于[xx]时驱散</value>
   </data>
@@ -4016,9 +4013,6 @@
   </data>
   <data name="Astrologian_Content_Prevent_Usage_of_Swiftcast_Alone" xml:space="preserve">
     <value>防止单独使用即刻咏唱</value>
-  </data>
-  <data name="Astrologian_Text_Party_Members_Near_Target_That_Are_Below" xml:space="preserve">
-    <value>目标附近的队友血量低于</value>
   </data>
   <data name="Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below" xml:space="preserve">
     <value>地星范围内的队友血量低于</value>

--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -177,7 +177,6 @@ namespace Magitek.Rotations
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            if (await Aoe.AggroAst()) return true;
             //if (await Aoe.LordOfCrown()) return true;
             if (await Aoe.Gravity()) return true;
             if (await SingleTarget.Combust()) return true;

--- a/Magitek/Utilities/Combat.cs
+++ b/Magitek/Utilities/Combat.cs
@@ -16,6 +16,11 @@ namespace Magitek.Utilities
         public static readonly Stopwatch MovingInCombatTime = new Stopwatch();
         public static readonly Stopwatch NotMovingInCombatTime = new Stopwatch();
         public static int CombatTotalTimeLeft;
+        // Wall-clock estimate of when the PULL ends: the longest single enemy time-to-die.
+        // CombatTotalTimeLeft sums every enemy's estimate, which overstates the pull's real
+        // duration whenever enemies die concurrently (four mobs at 3s each sum to 12s) — use
+        // this for "is the fight about to end" checks and the sum for total-effort checks.
+        public static int CombatWallClockTimeLeft;
         public static readonly Stopwatch DutyTime = new Stopwatch();
         public static double CurrentTargetCombatTimeLeft;
 

--- a/Magitek/Utilities/Tracking.cs
+++ b/Magitek/Utilities/Tracking.cs
@@ -225,10 +225,14 @@ namespace Magitek.Utilities
             if (!EnemyInfos.Any())
             {
                 Combat.CombatTotalTimeLeft = 0;
+                Combat.CombatWallClockTimeLeft = 0;
             }
             else
             {
                 Combat.CombatTotalTimeLeft = (int)Math.Max(0, EnemyInfos.Select(r => r.CombatTimeLeft).Sum());
+                // The pull ends when the LAST enemy dies, not after the serial sum of every
+                // enemy's estimate — under concurrent damage the max is the honest wall clock.
+                Combat.CombatWallClockTimeLeft = (int)Math.Max(0, EnemyInfos.Select(r => r.CombatTimeLeft).Max());
             }
 
 

--- a/Magitek/Views/UserControls/Astrologian/Combat.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Combat.xaml
@@ -40,7 +40,6 @@
                     <controls:Numeric Margin="2,0,2,0" Increment="1" MaxValue="60" MinValue="1" Value="{Binding AstrologianSettings.DoDamageIfTimeLeftLessThan, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Seconds}" />
                 </StackPanel>
-                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Aggro_Ast_Mode}" IsChecked="{Binding AstrologianSettings.AggroAst, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_Causes_Lightspeed_Earthstar_an}"/>
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Astrologian/Healing.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Healing.xaml
@@ -222,13 +222,6 @@
                     <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Enemies_Near_Target}" />
                 </StackPanel>
                 <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="With" />
-                    <controls:Numeric Margin="2,3" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.EarthlyStarPartyMembersNearTarget, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Target_That_Are_Below}" />
-                    <controls:Numeric Margin="2,3" Increment="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.EarthlyStarPartyMembersNearTargetHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
                     <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Stellar_Detonation}" IsChecked="{Binding AstrologianSettings.StellarDetonation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
                 </StackPanel>
                 <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
@@ -244,6 +237,11 @@
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}" />
                     <controls:Numeric Margin="2,3" Increment="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.GiantDominanceHealthPercent, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Detonate_Early_When_Pull_Ends_Within}" />
+                    <controls:Numeric Margin="2,3" MaxValue="15" MinValue="1" Value="{Binding AstrologianSettings.StellarDetonationPullEndingSeconds, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Seconds}" />
                 </StackPanel>
             </StackPanel>
 


### PR DESCRIPTION
## What this changes

Earthly Star is planted proactively on cooldown instead of waiting for damage, and the fight-logic AoE response detonates a matured star when a raidwide is detected — so the star's healing lands on the mechanic rather than whenever the timer happens to expire. Also removes the Aggro AST Mode toggle, which no longer had a supported use.

## Why

A star placed reactively is usually still immature when the raidwide hits, and one left to auto-detonate wastes its burst on nothing. Planting on cooldown and detonating on detection turns it into reliable raidwide mitigation. Without proactive planting, a fresh star would otherwise be spent at reduced potency the moment any raidwide is detected.

## Game-behavior assumptions I could not verify

None — all behavior claims verified against existing code patterns and live runs.

## Verified against game data

- Earthly Star maturation (Giant Dominance at 10s, ~20s auto-detonation) matches live observation: placement to Stellar Explosion timing confirmed in ACT.
- Validated live in a full Windurst: The Third Walk alliance clear as Astrologian: six-plus plants on clean cooldown cadence and seven-plus reactive Stellar Detonations fired against detected raidwides (Meteoric Rhyme, Banishga IV, Celestial Trail, and others), each landing inside the cast window. Both logs confirm cast and effect.

## In-game test plan

1. Setup: AST 100, any raid with regular raidwides, Earthly Star + fight-logic responses enabled.
2. Trigger: enter combat and observe the first 30 seconds.
3. Expect: a star is planted early without waiting for damage, and replanted on cooldown.
4. Trigger: a telegraphed raidwide while a matured star is down.
5. Expect: Stellar Detonation fires during the enemy cast, before impact.
6. If it fails: capture both logs — RB shows the response decision, ACT shows whether the detonation landed before the hit.

## Build

- [x] `dotnet build` clean in `Magitek/`
- [x] No unrelated files in the diff
