### PR TITLE
Core - Fix crashes when a spell target dies during a cast

### DIFF
--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -96,12 +96,14 @@ namespace Magitek.Utilities
                 if (!SpellTarget.IsTargetable)
                 {
                     await CancelCast("Target is no Longer Targetable");
+                    return true;
                 }
             }
             catch
             {
                 // Object is invalid in memory (e.g., player died, entity despawned)
                 await CancelCast("Target is no Longer Valid");
+                return true;
             }
 
             if (await GambitLogic.InterruptCast())
@@ -110,25 +112,26 @@ namespace Magitek.Utilities
                 return true;
             }
 
-            // The validity checks above go stale before the reads below run: CancelCast and the
-            // gambit check both await across frames, and the untargetable branch above cancels
-            // without returning — so these checks can run against a target that despawned and
-            // was freed mid-pulse. A freed target keeps a non-null reference: the null checks
-            // pass and the first field read through the stale pointer throws, killing the whole
-            // combat pulse (seen live: "Target is no Longer Targetable", then a crash in the
-            // job interrupt checks 59ms later). Skip the reads once the cast is no longer
-            // tracked, re-check validity, and treat an unreadable target like an invalid one.
+            // The validity checks above go stale before the reads below run: the gambit check
+            // yields across frames, so the target can despawn between those checks and these
+            // reads. A freed target keeps a non-null reference — the null checks pass and the
+            // first field read through the stale pointer throws, killing the whole combat
+            // pulse (seen live: a nuke target died mid-cast between the checks and the job
+            // interrupt switch). Skip the reads once the cast is no longer tracked, then keep
+            // everything that touches the target inside the try: even the IsValid re-check
+            // reads a liveness stamp through the object's pointer and can throw once the
+            // target's memory is unmapped. An unreadable target is treated like an invalid one.
             if (!CastingTime.IsRunning)
                 return true;
 
-            if (SpellTarget == null || !SpellTarget.IsValid)
-            {
-                await CancelCast("Target is no Longer Valid");
-                return true;
-            }
-
             try
             {
+                if (SpellTarget == null || !SpellTarget.IsValid)
+                {
+                    await CancelCast("Target vanished before the interrupt checks");
+                    return true;
+                }
+
                 // A revive (Phoenix Down) targets a body that is dead by definition, and the job checks
                 // below cancel any cast on a dead target unless it is that job's own raise spell — so every
                 // one of them would kill the revive on its first tracked pulse. Exempt the revive here once
@@ -222,10 +225,13 @@ namespace Magitek.Utilities
                         }
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Object is invalid in memory (e.g., player died, entity despawned)
-                await CancelCast("Target is no Longer Valid");
+                // Object is invalid in memory (e.g., player died, entity despawned) — but any
+                // exception thrown by a job's interrupt checks lands here too, so put the real
+                // reason in the log instead of silently blaming the target.
+                Logger.WriteInfo($"[Casting] Interrupt checks failed, cancelling cast: {ex.Message}");
+                await CancelCast("Target is no Longer Readable");
             }
 
             #endregion
@@ -242,13 +248,17 @@ namespace Magitek.Utilities
 
                 if (msg != null)
                     Logger.Error(msg);
-
-                CastingTime.Stop();
-                CastingRevive = false;
             }
             catch (Exception)
             {
                 //Ignore on Purpose
+            }
+            finally
+            {
+                // The IsRunning guard in TrackSpellCast depends on this timer stopping even
+                // when StopCasting or the wait throws mid-transition.
+                CastingTime.Stop();
+                CastingRevive = false;
             }
         }
 

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -110,97 +110,122 @@ namespace Magitek.Utilities
                 return true;
             }
 
-            // A revive (Phoenix Down) targets a body that is dead by definition, and the job checks
-            // below cancel any cast on a dead target unless it is that job's own raise spell — so every
-            // one of them would kill the revive on its first tracked pulse. Exempt the revive here once
-            // rather than carving an exception into all seven jobs, but keep the ONE cancel that is
-            // meaningful for it, the same one every healer applies to its own raise: someone else's
-            // raise landed first, so finishing the cast would spend a Phoenix Down on a claimed corpse.
-            // The target-validity checks above still run: a despawned corpse still cancels.
-            if (CastingRevive)
-            {
-                if (SpellTarget is Character corpse
-                    && (corpse.CurrentHealth > 0 || corpse.HasAura(Auras.Raise)))
-                    await CancelCast("Revive target was already raised");
+            // The validity checks above go stale before the reads below run: CancelCast and the
+            // gambit check both await across frames, and the untargetable branch above cancels
+            // without returning — so these checks can run against a target that despawned and
+            // was freed mid-pulse. A freed target keeps a non-null reference: the null checks
+            // pass and the first field read through the stale pointer throws, killing the whole
+            // combat pulse (seen live: "Target is no Longer Targetable", then a crash in the
+            // job interrupt checks 59ms later). Skip the reads once the cast is no longer
+            // tracked, re-check validity, and treat an unreadable target like an invalid one.
+            if (!CastingTime.IsRunning)
+                return true;
 
+            if (SpellTarget == null || !SpellTarget.IsValid)
+            {
+                await CancelCast("Target is no Longer Valid");
                 return true;
             }
 
-            // ReSharper disable once SwitchStatementMissingSomeCases
-            switch (RotationManager.CurrentRotation)
+            try
             {
-                case ClassJobType.BlueMage:
-                    {
-                        if (BlueMage.NeedToInterruptCast())
+                // A revive (Phoenix Down) targets a body that is dead by definition, and the job checks
+                // below cancel any cast on a dead target unless it is that job's own raise spell — so every
+                // one of them would kill the revive on its first tracked pulse. Exempt the revive here once
+                // rather than carving an exception into all seven jobs, but keep the ONE cancel that is
+                // meaningful for it, the same one every healer applies to its own raise: someone else's
+                // raise landed first, so finishing the cast would spend a Phoenix Down on a claimed corpse.
+                // The target-validity checks above still run: a despawned corpse still cancels.
+                if (CastingRevive)
+                {
+                    if (SpellTarget is Character corpse
+                        && (corpse.CurrentHealth > 0 || corpse.HasAura(Auras.Raise)))
+                        await CancelCast("Revive target was already raised");
+
+                    return true;
+                }
+
+                // ReSharper disable once SwitchStatementMissingSomeCases
+                switch (RotationManager.CurrentRotation)
+                {
+                    case ClassJobType.BlueMage:
                         {
-                            await CancelCast();
+                            if (BlueMage.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.Scholar:
-                    {
-                        if (Scholar.NeedToInterruptCast())
+                    case ClassJobType.Scholar:
                         {
-                            await CancelCast();
+                            if (Scholar.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.Arcanist:
-                    {
-                        if (Scholar.NeedToInterruptCast())
+                    case ClassJobType.Arcanist:
                         {
-                            await CancelCast();
+                            if (Scholar.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.WhiteMage:
-                    {
-                        if (WhiteMage.NeedToInterruptCast())
+                    case ClassJobType.WhiteMage:
                         {
-                            await CancelCast();
+                            if (WhiteMage.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.Conjurer:
-                    {
-                        if (WhiteMage.NeedToInterruptCast())
+                    case ClassJobType.Conjurer:
                         {
-                            await CancelCast();
+                            if (WhiteMage.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.Astrologian:
-                    {
-                        if (Astrologian.NeedToInterruptCast())
+                    case ClassJobType.Astrologian:
                         {
-                            await CancelCast();
+                            if (Astrologian.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.Summoner:
-                    {
-                        if (Summoner.NeedToInterruptCast())
+                    case ClassJobType.Summoner:
                         {
-                            await CancelCast();
+                            if (Summoner.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.BlackMage:
-                    {
-                        if (BlackMage.NeedToInterruptCast())
+                    case ClassJobType.BlackMage:
                         {
-                            await CancelCast();
+                            if (BlackMage.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
-                case ClassJobType.Sage:
-                    {
-                        if (Sage.NeedToInterruptCast())
+                    case ClassJobType.Sage:
                         {
-                            await CancelCast();
+                            if (Sage.NeedToInterruptCast())
+                            {
+                                await CancelCast();
+                            }
+                            break;
                         }
-                        break;
-                    }
+                }
+            }
+            catch
+            {
+                // Object is invalid in memory (e.g., player died, entity despawned)
+                await CancelCast("Target is no Longer Valid");
             }
 
             #endregion

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -112,6 +112,13 @@ namespace Magitek.Utilities
                 return true;
             }
 
+            // A cast that finished while the gambit check was yielding is a success, not a
+            // cancellation: bow out the way the entry check does, so the caller still runs
+            // the success bookkeeping (LastSpell, SpellCastHistory) instead of this method
+            // cancelling a cast that no longer exists.
+            if (!Core.Me.IsCasting)
+                return false;
+
             // The validity checks above go stale before the reads below run: the gambit check
             // yields across frames, so the target can despawn between those checks and these
             // reads. A freed target keeps a non-null reference — the null checks pass and the


### PR DESCRIPTION
## What this changes

When a spell's target dies and despawns mid-cast, the routine now cancels the cast cleanly instead of crashing the whole combat pulse. Single-file change to the shared cast-tracking method that runs every job's mid-cast interrupt checks.

## Why

Live crash: `ReadWriteMemoryException ... at addr: 1AC` thrown from the Black Mage interrupt check when its cast target died and despawned mid-cast (Occult Crescent critical encounter). The exception killed the combat pulse. Every caster/healer job's interrupt check reads the same `Casting.SpellTarget`, so any of them could hit it.

Root cause, visible in the log: in `TrackSpellCast`, the "Target is no Longer Targetable" branch cancels the cast but did not return, and `CancelCast` awaits across frames — so the per-job interrupt checks could run after the target had despawned and its memory was freed. A freed target keeps a non-null `SpellTarget` reference, so the existing null-conditional checks pass, and the first field read through the stale pointer throws. The log shows "Target is no Longer Targetable" followed 59 ms later by the crash, in the same pulse.

## Fix

- The untargetable branch (and the catch beside it) now `return true;` after cancelling — the cancel-then-fall-through was the observed crash path, and it also spent gambit bookkeeping on a dead cast.
- `CancelCast` stops the cast timer and clears the revive flag in a `finally`, so the "already cancelled this pulse" guard holds even when StopCasting or its wait throws mid-transition.
- Immediately before the revive check and the per-job interrupt switch: stop if the cast is no longer being tracked, then re-check target validity **inside** the try — `IsValid` reads a liveness stamp through the object's pointer and can itself throw once the target's memory is unmapped, so the re-check sits under the same catch as the reads it guards.
- The catch captures the exception and logs it (`[Casting] Interrupt checks failed, cancelling cast: ...`), and each cancel site emits a distinct message, so log ordering stays diagnosable and a job-check bug is not silently reported as an invalid target.
- The revive block and the job switch are unchanged — only re-indented by the try block. Easiest to review with whitespace changes hidden.

## Game-behavior assumptions I could not verify

None remaining. One claim in the original version of this body was wrong and is corrected above: `IsValid` is not a purely managed liveness check — it short-circuits safely on a zeroed pointer, but otherwise reads a stamp through the pointer and can throw on unmapped memory. That is why the validity re-check lives inside the try.

## In-game test plan

1. Setup: any caster (BLM is easiest), fast-dying trash — open world or Occult Crescent groups.
2. Trigger: keep casting at targets that die mid-cast, repeatedly.
3. Expect: casts stop cleanly with the existing messages ("because HE'S DEAD, JIM!" / "Stopped Cast: Unit Died"), no `ReadWriteMemoryException` in the log, rotation continues normally.
4. Raise path: healer raise where the corpse is claimed by another raiser or released mid-cast — expect the existing "Stopped Resurrection" messages, unchanged.
5. Zone or duty transition mid-cast: cast should cancel without an "Interrupt checks failed" line; if that line ever appears, it now carries the underlying exception message.

Deployed locally during live Occult Crescent play after the change: mid-cast target deaths produce clean interrupts and no exceptions.
