### PR TITLE
SCH - Fix Seraphism being detected late and lingering after it ends

### DIFF
--- a/Magitek/Extensions/CharacterExtensions.cs
+++ b/Magitek/Extensions/CharacterExtensions.cs
@@ -75,7 +75,7 @@ namespace Magitek.Extensions
                 Auras.HeliosConjunction,
                 Auras.Kerakeia,
                 Auras.PhysisII,
-                Auras.Seraphism,
+                Auras.SeraphismReceiver,
                 Auras.CrestOfTimeReturned,
                 Auras.Opposition,
                 Auras.WheelOfFortune,

--- a/Magitek/Utilities/Auras.cs
+++ b/Magitek/Utilities/Auras.cs
@@ -437,7 +437,12 @@ namespace Magitek.Utilities
             DragonsFlight = 3845,
 
             //SCH
-            Seraphism = 3885,
+            // Two statuses share the name: 3884 is the caster's 20s STANCE (the Manifestation/
+            // Accession action-mask window, strictly self); 3885 is a 5s satellite regen the stance
+            // re-sprays on self AND nearby allies every ~3s — it appears ~3-4s late, outlives the
+            // stance by up to 5s, and lands from OTHER Scholars. Stance gates key on 3884.
+            Seraphism = 3884,
+            SeraphismReceiver = 3885,
 
             //NIN
             ShadowWalker = 3848,


### PR DESCRIPTION
## What this fixes

Magitek's `Seraphism` constant pointed at the wrong one of **two statuses that share the name "Seraphism"**:

- **3884** is the caster's 20s stance — exactly the window where Adloquium/Succor become Manifestation/Accession, and strictly self-applied.
- **3885** is a short (~5s) regen the stance re-sprays on the caster **and nearby allies** every ~3s. It first appears ~3–4s *after* the stance lands, its last application outlives the stance by up to ~5s, and it lands on you from *another Scholar's* Seraphism too.

With the constant at 3885, the `Accession()`/`Manifestation()` gates were blind for the opening seconds of every Seraphism window (raid log measurement: the first Accession fired 0.7s after the satellite regen finally appeared, while the caster sat at 14% HP — the gate, not healing need, caused the delay), stayed open after the stance ended, and could be opened by another Scholar's regen with no stance at all.

## Changes

- `Seraphism = 3884` (the stance). The existing gates in `Accession()` and `Manifestation()` now track the actual mask window, with no logic change.
- New `SeraphismReceiver = 3885` for the regen; the regen list in `AdjustHealthThresholdByRegen` uses it, so regen-aware heal thresholds behave exactly as before.

## Tested

SCH Lv100, striking dummy — one controlled Seraphism window, client state read directly (rebornbuddy-mcp):

- Before: no Seraphism statuses; masked actions read 185 (Adloquium) / 37013 (Concitation — Succor's Lv96 trait upgrade is the baseline at 100).
- Stance up: **3884 on self at 11.4s remaining alongside 3885 at 3.9s remaining** — the two-status structure in one reading; masks read **37015 Manifestation / 37016 Accession**.
- The moment 3884 expired: masks reverted, both statuses gone.

The mask window tracked 3884 exactly, opening and closing with it. Timing figures above (late onset, stale tail, cross-Scholar application of 3885) observed across two full Windurst: The Third Walk runs.

## Sources

- First-hand in-game observations as described in Tested.

## Removals

- None. No guards or conditions removed — the regen-list entry is renamed to the new constant carrying the same value it always had.
