### PR TITLE
OC - Add an optional risky Drain Touch priming rotation for Phantom Necromancer

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -4814,6 +4814,12 @@ namespace Magitek.Logic.Roles
             if (Core.Me.CurrentHealthPercent < OccultCrescentSettings.Instance.NecromancerMinimumHealthPercent)
                 return false;
 
+            // Priming mode (opt-in): attacks fire ONLY inside the Drain Touch window — that's the
+            // 400/520 empowered casts — and every one Dooms us; the user chose to own the
+            // heal-to-full. Never start a second Doom cycle while one is still running.
+            if (OccultCrescentSettings.Instance.NecromancerDrainTouchPriming)
+                return Core.Me.HasAura(OCAuras.DrainTouch) && !Core.Me.HasAura(Auras.Doom);
+
             // Drain Touch is up, so this attack would Doom us.
             return !Core.Me.HasAura(OCAuras.DrainTouch);
         }
@@ -4825,7 +4831,9 @@ namespace Magitek.Logic.Roles
         ///
         /// Free damage and free healing, so it goes out on cooldown for every job. It is ordered
         /// after the attacks in ExecuteNecromancerPhantomJob rather than gated here, so the buff it
-        /// leaves behind never catches one of them and turns it into a Doom.
+        /// leaves behind never catches one of them and turns it into a Doom. (Under the opt-in
+        /// NecromancerDrainTouchPriming toggle that ordering deliberately inverts: it leads, and
+        /// the attacks fire inside its window.)
         /// </summary>
         private static async Task<bool> DrainTouch()
         {
@@ -4912,6 +4920,36 @@ namespace Magitek.Logic.Roles
         }
 
         /// <summary>
+        /// Priming mode wants a spender ready before Drain Touch opens a window: a window that
+        /// closes unspent wastes the 40s Drain Touch recast and buys nothing, and every window
+        /// invites the cast-bar traps that come with it. The attacks are 1.5s casts, so while we
+        /// are moving nothing could spend the window either. The health floor mirrors
+        /// NecromancerCanSpendHealth so a window is not opened that the spend gate would then
+        /// refuse. Range and line-of-sight stay with each spender's own guards.
+        /// </summary>
+        private static bool NecromancerSpenderAvailable()
+        {
+            if (Core.Me.CurrentHealthPercent < OccultCrescentSettings.Instance.NecromancerMinimumHealthPercent)
+                return false;
+
+            if (MovementManager.IsMoving)
+                return false;
+
+            var settings = OccultCrescentSettings.Instance;
+
+            if (settings.UseDoomsday && OCSpells.Doomsday.CanCast())
+                return true;
+
+            if (settings.UseChaosDrive && OCSpells.ChaosDrive.CanCast())
+                return true;
+
+            if (settings.UseHellWind && OCSpells.HellWind.CanCast())
+                return true;
+
+            return settings.UseDeepFreeze && OCSpells.DeepFreeze.CanCast();
+        }
+
+        /// <summary>
         /// Execute Phantom Necromancer phantom job rotation
         ///
         /// The whole shape of this job comes from one fact confirmed in game: the HP-cost attacks
@@ -4930,6 +4968,23 @@ namespace Magitek.Logic.Roles
         /// <returns>True if an action was executed, false otherwise</returns>
         private static async Task<bool> ExecuteNecromancerPhantomJob()
         {
+            // Priming mode (opt-in): Drain Touch leads, and the attacks fire inside its 6s window
+            // for the empowered potencies — each one Dooming us. NecromancerCanSpendHealth inverts
+            // to REQUIRE the buff (and no live Doom), so between windows the attacks simply wait
+            // for the next Drain Touch: the strict alternation the top field players run.
+            if (OccultCrescentSettings.Instance.NecromancerDrainTouchPriming)
+            {
+                // Only open a window there is something ready to spend inside. The default
+                // order below still uses Drain Touch freely as the heal that repays a cost.
+                if (NecromancerSpenderAvailable() && await DrainTouch())
+                    return true;
+
+                if (await Doomsday())
+                    return true;
+
+                return await NecromancerElementalNukes();
+            }
+
             // Attack unbuffed and let Drain Touch follow as the heal that repays the cost. Both
             // attacks refuse to fire while Drain Touch is up.
             if (await Doomsday())

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -771,6 +771,14 @@ namespace Magitek.Models.OccultCrescent
         [DefaultValue(true)]
         public bool UseDrainTouch { get; set; }
 
+        // Opt-in danger: lead with Drain Touch and attack INSIDE its 6s window for the empowered
+        // potencies (400/520) and riders — accepting the self-Doom every empowered attack applies
+        // (heal to full within 10s or die; the routine cannot promise that heal). Off = the safe
+        // attack-first ordering that never Dooms.
+        [Setting]
+        [DefaultValue(false)]
+        public bool NecromancerDrainTouchPriming { get; set; }
+
         [Setting]
         [DefaultValue(true)]
         public bool UseDeepFreeze { get; set; }

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -8265,6 +8265,15 @@ namespace Magitek.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Attack inside Drain Touch (stronger casts, but every attack Dooms us).
+        /// </summary>
+        public static string OccultCrescent_Content_Drain_Touch_Priming {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Drain_Touch_Priming", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Prefer Inquiring Mind (Freelancer Lv15, all buffs in one cast).
         /// </summary>
         public static string OccultCrescent_Content_Prefer_Inquiring_Mind {

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2159,6 +2159,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="OccultCrescent_Content_Use_Drain_Touch" xml:space="preserve">
     <value>Use Drain Touch (heals us, and powers up the other attacks)</value>
   </data>
+  <data name="OccultCrescent_Content_Drain_Touch_Priming" xml:space="preserve">
+    <value>Attack inside Drain Touch (stronger casts, but every attack Dooms us)</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Deep_Freeze" xml:space="preserve">
     <value>Use Deep Freeze (ice)</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2160,6 +2160,9 @@
   <data name="OccultCrescent_Content_Use_Drain_Touch" xml:space="preserve">
     <value>使用 吸血之触 (治疗自身并强化其他技能)</value>
   </data>
+  <data name="OccultCrescent_Content_Drain_Touch_Priming" xml:space="preserve">
+    <value>在 吸血之触 期间攻击 (伤害更高, 但每次攻击附加死宣)</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Deep_Freeze" xml:space="preserve">
     <value>使用 深度冻结 (冰)</value>
   </data>

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -1585,6 +1585,13 @@
 
                                         <StackPanel Margin="5"
                                                     Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Drain_Touch_Priming}"
+                                                          IsChecked="{Binding NecromancerDrainTouchPriming, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
                                                 <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Deep_Freeze}"
                                                           IsChecked="{Binding UseDeepFreeze, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>


### PR DESCRIPTION
## What this changes

Adds an opt-in "Attack inside Drain Touch" toggle for Phantom Necromancer (default **off**). The default rotation is unchanged: attack unbuffed, then use Drain Touch as the free heal that repays the HP costs, never getting Doomed.

With the toggle on, the ordering inverts to the pattern high-end field players run: Drain Touch leads, and Doomsday / the elemental line spells fire **inside** its 6s window for the empowered potencies (400/520 instead of 300/390), accepting the self-Doom every empowered attack applies. The routine-wide Doom response (heal-to-full) is what pays that back.

Two guards keep the risky mode honest:

- The spend gate inverts to **require** the Drain Touch buff (and no live Doom), so attacks simply wait for the next window rather than firing unempowered — and a second Doom cycle never starts while one is running.
- Drain Touch itself only opens a window when a spender is actually ready to use it — Doomsday or an enabled elemental off recast, health floor met, and not moving (all spenders are 1.5s casts). A window that closes unspent wastes the 40s Drain Touch recast and buys nothing.

## Tested

Live Forked Tower: Blood run (Phantom Necromancer Lv4, from both SCH and SGE bases), watching the log in real time:

- Windows opened only with a spender ready and were spent immediately — the densest observed window held Drain Touch → Doomsday → Doom cleansed → Hell Wind inside seven seconds.
- Doomsday paired at the first window after its ~119s recast in 8 of 8 opportunities post-gate (measured against the client's own recast data).
- Every self-Doom was answered by the existing Doom response (Physick/Diagnosis per job); no deaths to Doom across the run.
- Toggle off: rotation identical to current master (attack-first, no Dooms).

## Sources

- Empowered potencies, HP costs, shared 40s elemental recast, Doomsday's separate ~120s recast, and "attacks Doom only while Drain Touch is up" are all as already documented in the code comments this builds on, and consistent with what the live run produced.

## Removals

- None. The default path is byte-identical; the toggle only adds an alternative ordering.
