### PR TITLE
FightLogic - Add North Horn critical encounter coverage for the Occult Crescent

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7124,6 +7124,387 @@ namespace Magitek.Utilities
                     },
                 }
             },
+
+            new Encounter {
+                ZoneId = ZoneId.TheOccultCrescentNorthHorn,
+                Name = "The Occult Crescent: North Horn (field Critical Encounters)",
+                Expansion = FfxivExpansion.Dawntrail,
+                // Derived from a recorded run rather than a trigger database — cactbot's file for this zone
+                // is still an empty stub. Coverage is therefore partial: roughly half the critical
+                // engagements, and none of Forked Tower.
+                //
+                // Several bosses cast a mechanic TWICE at once, under two ids: one from the boss and one
+                // from an untargetable 44 HP helper that carries the actual damage. Combat.Enemies drops
+                // untargetable actors, so only the boss-side id can ever be seen — but which id belongs to
+                // which is not certain from a log alone. Both are listed. An id the routine never observes
+                // costs nothing; the wrong single choice kills the mechanic silently.
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 19295,
+                        Name = "Index",
+                        Aoes = new List<uint> {
+                            48418, // All-knowing Flames — unavoidable spread-and-eat (user ruling
+                                   // 2026-08-08); everyone takes a personal hit, so party mitigation
+                                   // earns its keep. Id captured live via Enemy Spell Casts.
+                        },
+                        Knockbacks = new List<uint> {
+                            48406, // Shockwave — a zero-damage punt that killed a player off the
+                                   // platform (confirmed 2026-08-11); 6 castbars / 39 hits that run,
+                                   // castbar and effect share the one id. Previously misfiled in Aoes.
+                                   // No longer inert: the id-keyed untargetable-caster scan sees the
+                                   // Index copies — live 2026-08-16, six simultaneous bars detected
+                                   // and answered with Arm's Length in-window.
+                            48447, // Shockwave — corpus-recorded variant, never seen live; kept per
+                                   // the both-ids policy.
+                        },
+                        BigAoes = new List<uint> {
+                            48394, // Omni-elements
+                            48395, // Omni-elements
+                            48401, // Elementary Chemistry
+                            48402, // Elementary Chemistry
+                            48415, // Flare
+                            48416, // Flare
+                            48417, // Flare
+                            48427, // Omni-elements
+                            48456, // Flare
+                        },
+                    },
+                    new Enemy {
+                        Id = 14505,
+                        Name = "Abductor",
+                        BigAoes = new List<uint> {
+                            47449, // Cyclonic Ring — hit up to 18 players for 117% max HP
+                            47448, // Skydive — hit all 32 players for ~70% max HP
+                            47436, // Hurricane — 55 players hit, every cast
+                            48120, // Hurricane (the id the damage actually lands under)
+                        },
+                        Knockbacks = new List<uint> {
+                            48250, // Buffet
+                            47440, // Buffet (the id the 2026-07-30 corpus recorded — 49 casts; both
+                                   // listed, same both-ids policy as Hurricane above)
+                        },
+                    },
+                    new Enemy {
+                        Id = 19482,
+                        Name = "Blue Head",
+                        TankBusters = new List<uint> {
+                            47745, // Archaeofury — the id cast live (Enemy Spell Casts capture
+                                   // 2026-08-08); the recorded-run ids below never fired
+                            47749, // Archaeofury
+                            47751, // Archaeofury
+                            47752, // Archaeofury
+                        },
+                        BigAoes = new List<uint> {
+                            47735, // Thunderfrost Tempest (observed live 2026-08-07 — variant missing from the recorded run)
+                            47736, // Thunderfrost Tempest (observed live 2026-08-07 — 4.7s cast confirmed via 261 lines)
+                            47737, // Thunderfrost Tempest
+                            47738, // Thunderfrost Tempest
+                            47739, // Thunderfrost Tempest
+                            47740, // Thunderfrost Tempest
+                            47741, // Thunderfrost Tempest
+                        },
+                        // Deliberately absent (player-confirmed 2026-08-11): Two Terrors
+                        // (50655/50658) and Buffet (49726) are dodged, and Hissing Reprise (49722)
+                        // is a forced one-direction knockback that anti-knockback does not help —
+                        // none of them are mitigation problems. This Buffet shares only a NAME with
+                        // the Abductor knockback (47440/48250); ids differ and so does the answer.
+                    },
+                    new Enemy {
+                        Id = 19481,
+                        Name = "Green Head",
+                        TankBusters = new List<uint> {
+                            47745, // Archaeofury — the id cast live (Enemy Spell Casts capture
+                                   // 2026-08-08); the recorded-run ids below never fired
+                            47749, // Archaeofury
+                            47751, // Archaeofury
+                            47752, // Archaeofury
+                        },
+                        BigAoes = new List<uint> {
+                            47735, // Thunderfrost Tempest (observed live 2026-08-07 — variant missing from the recorded run)
+                            47736, // Thunderfrost Tempest (observed live 2026-08-07 — 4.7s cast confirmed via 261 lines)
+                            47737, // Thunderfrost Tempest
+                            47738, // Thunderfrost Tempest
+                            47739, // Thunderfrost Tempest
+                            47740, // Thunderfrost Tempest
+                            47741, // Thunderfrost Tempest
+                            // Thunderfrost user-ruled 2026-08-16: raidwide, MUST be mitigated — the
+                            // wave-1 zero-damage cluster was spread positioning, not a safe-spot
+                            // mechanic; late waves hit ~95% of the raid. Stays in BigAoes.
+                        },
+                        Knockbacks = new List<uint> {
+                            47613, // Storm's Breath — Green Head 7.7s castbar. Damage is noise (~155);
+                                   // the PUNT kills: 3 environment deaths followed one observed wave.
+                                   // Raid-wide warning marker 585/0x249 leads by ~1.4s. User-ruled
+                                   // knockback-prevention candidate 2026-08-16.
+                            47614, // Storm's Breath — parent-director 6.9s mirror bar (both-ids policy)
+                        },
+                    },
+                    new Enemy {
+                        Id = 19431,
+                        Name = "Necrophobia",
+                        TankBusters = new List<uint> {
+                            47459, // Corpse Mangler
+                            47505, // Corpse Mangler
+                        },
+                        Aoes = new List<uint> {
+                            47452, // Hail of Hellflares (raidwide, ~5s self-targeted cast — id from ACT 2026-08-03)
+                            // Dark Current (47476-47478) and Severed Dark Current (47479) are deliberately
+                            // absent: the sweep is dodged, not mitigated (player-confirmed 2026-08-10).
+                            // Ancient Thunder III (47457/47458, twin simultaneous casters — often from the
+                            // untargetable Severing Heads) is also deliberately absent: avoidable
+                            // (player-confirmed 2026-08-11), it just punishes hard when missed (~75k).
+                        },
+                        BigAoes = new List<uint> {
+                            47514, // Fertile Ground
+                            48960, // Fertile Ground
+                        },
+                    },
+                    new Enemy {
+                        Id = 19838,
+                        Name = "Sword Dancer",
+                        BigAoes = new List<uint> {
+                            49617, // Sword Storm — the id cast live (captured twice 2026-08-07 via the
+                                   // Enemy Spell Casts history); the recorded-run ids below never fired
+                            49675, // Sword Storm
+                            49686, // Sword Storm
+                            49609, // Sword Dance — user-confirmed "needs mitigation"; id captured live
+                                   // twice 2026-08-07, kills on both occasions
+                            49610, // Sword Dance — castbar sibling, 2026-08-11 census (the mechanic
+                                   // casts under a five-id family; 49614 was the DOMINANT bar at 8
+                                   // of 11 casts and carried a 96.6k killing resolution)
+                            49612, // Sword Dance — zero-damage marker resolution
+                            49613, // Sword Dance — resolution sibling (20k hits)
+                            49614, // Sword Dance — dominant castbar + heavy resolution
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
+                        Name = "Greater Fan",
+                        Aoes = new List<uint> {
+                            50223, // Aero III — user-confirmed needs AoE mitigation 2026-08-08; id
+                                   // double-sourced (live Enemy Spell Casts capture + 28 corpus casts,
+                                   // 5.7s castbar)
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
+                        Name = "Patient Kuribu",
+                        Aoes = new List<uint> {
+                            49908, // Aero III (20 corpus casts, 3.7s castbar)
+                            50072, // Aero III (29 corpus casts, 4.2s castbar, hit up to 16 players —
+                                   // same user ruling as the Greater Fan's variant)
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
+                        Name = "Arch Kelpie",
+                        Aoes = new List<uint> {
+                            47386, // Water IV — user-confirmed needs AoE mitigation 2026-08-08; id
+                                   // double-sourced (live Enemy Spell Casts capture + 29 corpus casts,
+                                   // 5.2s castbar)
+                        },
+                    },
+                    new Enemy {
+                        Id = 14512, // BNpcName row (XIVAPI) — same id space as Abductor 14505, which
+                                    // was observed detecting live 2026-08-07
+                        Name = "Phantom Necromancer",
+                        BigAoes = new List<uint> {
+                            47182, // Dark Flare — the id cast LIVE (Enemy Spell Casts capture
+                                   // 2026-08-08, during three deaths in 90s); corpus id below never
+                                   // fired, both listed per the both-ids policy
+                            47183, // Dark Flare (user-confirmed raidwide 2026-08-07; 53 observed
+                                   // casts in the 2026-07-30 corpus — Forked Tower)
+                        },
+                    },
+                    new Enemy {
+                        Id = 14523, // BNpcName row (XIVAPI) — same id space as Abductor 14505, which
+                                    // was observed detecting live 2026-08-07
+                        Name = "Phantom Hydra",
+                        Aoes = new List<uint> {
+                            47210, // Discordance (user-confirmed AoE 2026-08-07; 53 observed casts
+                                   // in the 2026-07-30 corpus — Forked Tower)
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
+                        Name = "Dancing Sword",
+                        Aoes = new List<uint> {
+                            49616, // Rush (1,016 observed casts, hit up to 14 players — ACT 2026-08-07)
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
+                        Name = "Algol",
+                        Aoes = new List<uint> {
+                            48111, // Rotten Tomato (median 3 / max 13 players hit)
+                            48112, // Rotten Onion (median 2 / max 12 players hit)
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern)
+                        Name = "Elm Gigas",
+                        Aoes = new List<uint> {
+                            48041, // Ancient Aero III (user-confirmed raidwide; id from ACT 261 memory
+                                   // lines — persisted across 3 ticks at the exact castbar second)
+                        },
+                    },
+                    new Enemy {
+                        Id = 0, // matched by name (OC pattern)
+                        Name = "Tiny Mage",
+                        Aoes = new List<uint> {
+                            48329, // Tiny Thunder III (user-confirmed raidwide; id from ACT 261 memory
+                                   // lines matched to all three castbars 2026-08-07 — network lines were
+                                   // down for the patch's opcode outage)
+                        },
+                    },
+                    new Enemy {
+                        Id = 14507,
+                        Name = "Abductor's Plume",
+                        Aoes = new List<uint> {
+                            47443, // Splinter
+                        },
+                    },
+                    new Enemy {
+                        Id = 14517,
+                        Name = "Conjured Calofisteri",
+                        Aoes = new List<uint> {
+                            47075, // Hair Shears
+                            47076, // Hair Shears
+                            47077, // Hair Shears
+                        },
+                        BigAoes = new List<uint> {
+                            47058, // Dual Cut
+                            47059, // Dual Cut
+                            50691, // Dual Cut — up to 132% max HP
+                            50692, // Dual Cut — up to 109% max HP
+                            47079, // Aura Burst — 58 players hit, the largest raidwide in the zone
+                            47080, // Aura Burst (the id the damage actually lands under)
+                        },
+                    },
+                    new Enemy {
+                        Id = 14518,
+                        Name = "Entanglement",
+                        Knockbacks = new List<uint> {
+                            47072, // Malicious Weave — a draw-in, but the same immunities answer it
+                        },
+                    },
+                    new Enemy {
+                        Id = 14714,
+                        Name = "Pallmagia",
+                        Aoes = new List<uint> {
+                            // 50492/49779 Plaincracker removed — not an AoE to mitigate, dodge it
+                            // (user-confirmed in the field 2026-08-08).
+                        },
+                        BigAoes = new List<uint> {
+                            49798, // Great Whirlwind — the one unavoidable raidwide here, every player, every cast
+                            50450, // Great Whirlwind
+                        },
+                    },
+                    new Enemy {
+                        Id = 14738,
+                        Name = "Sensual Sandy",
+                        Aoes = new List<uint> {
+                            // 48945 Wild Wild Breath and 48946 Wild Wild Wild Wild Wild Breath removed —
+                            // both are the same dodgeable breath (the longer one adds dodgeable poison
+                            // puddles), not raidwides (user-confirmed in the field 2026-08-07); don't
+                            // spend mitigation on either.
+                        },
+                        BigAoes = new List<uint> {
+                            48947, // Extensible Tendrils
+                        },
+                    },
+                    new Enemy {
+                        Id = 14785,
+                        Name = "Cresceregina",
+                        Aoes = new List<uint> {
+                            // 49494/49495 Regal Fulguration REMOVED 2026-08-07 (user ruling): it is a
+                            // DIRECTIONAL attack, not a raidwide — dodge it, don't mitigate it.
+                        },
+                    },
+                    new Enemy {
+                        Id = 14764,
+                        Name = "Patient Kuribu",
+                        Aoes = new List<uint> {
+                            50118, // Shortsword and Sorcery
+                        },
+                    },
+                    new Enemy {
+                        Id = 14767,
+                        Name = "Regnant Chimera",
+                        // The Ram's/Dragon's Voice family (48633/48634 boss bars, 48635/48636 orb
+                        // carriers) is deliberately ABSENT: user-ruled 2026-08-16 — up to 8 scattered
+                        // orbs cast crossing point-source/donut AoEs with one safe spot; overlap
+                        // victims take 2-3 simultaneous hits exceeding max HP. A live run watched the
+                        // catalogued ids detect, burn Sacred Soil, and save nobody. Dodge, never
+                        // mitigate; ledger holds the 'rejected' entry.
+                        Aoes = null,
+                    },
+                    new Enemy {
+                        Id = 14736,
+                        Name = "Demi-Medusa",
+                        Aoes = new List<uint> {
+                            48254, // Lamian Lesion
+                        },
+                    },
+                    // Critical engagement bosses from a second recorded run. Each ability below was
+                    // measured rather than assumed: the damage was matched to its cast by timestamp, and
+                    // only things that struck a real share of the raid for meaningful damage are listed.
+                    // Victim counts are medians across repeated casts.
+                    new Enemy {
+                        Id = 14801,
+                        Name = "Metamorph",
+                        Aoes = new List<uint> {
+                            48360, // Shapeshifting Supercell — 12 players, 23% max HP
+                        },
+                        BigAoes = new List<uint> {
+                            48341, // Tongue of Flame — 21 players for 52% max HP
+                        },
+                    },
+                    new Enemy {
+                        Id = 14791,
+                        Name = "Atlas Carbuncle",
+                        Aoes = new List<uint> {
+                            48284, // Ruby Glow — 13 players, 21%
+                            48291, // Spinebreaking Stampede — 13 players
+                            48294, // Claw to Tail — 12 players, 39%
+                            48298, // Sonic Howl — 13 players, 30%
+                        },
+                    },
+                    new Enemy {
+                        Id = 14790,
+                        Name = "Algol",
+                        Aoes = new List<uint> {
+                            48100, // Cursed Screech — 8 players, 14%
+                            48971, // Cursed Screech — 7 players, 20%
+                            50426, // Shrill Peal — 8 players, 26%
+                            50427, // Shrill Peal — 6 players, 26%
+                        },
+                    },
+                    new Enemy {
+                        Id = 14508,
+                        Name = "Elm Gigas",
+                        Aoes = new List<uint> {
+                            47541, // Spinning Sweep — 5 players, 35%
+                            48041, // Ancient Aero III — 19 players, 20%, seen 18 times
+                        },
+                    },
+                    new Enemy {
+                        Id = 14520,
+                        Name = "Arbatel",
+                        Aoes = new List<uint> {
+                            47296, // Knowledge Level Correction — 32 players
+                            47327, // Marginalia — 15 players, seen 21 times
+                        },
+                    },
+                    new Enemy {
+                        Id = 14509,
+                        Name = "Alabaster Blade",
+                        Aoes = new List<uint> {
+                            47167, // Left-Right Combination — 17 players, 20%
+                        },
+                    },
+                }
+            },
             #endregion
 
             #region Dawntrail: Heavyweight Raids
@@ -7807,6 +8188,7 @@ namespace Magitek.Utilities
             TheNavelExtreme = 296,
             TheNavelHard = 293,
             TheNavelUnreal = 953,
+            TheOccultCrescentNorthHorn = 1346,
             TheOmegaProtocolUltimate = 1122,
             TheOrbonneMonastery = 826,
             TheOrphansAndTheBrokenBlade = 715,

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7391,10 +7391,11 @@ namespace Magitek.Utilities
                     new Enemy {
                         Id = 14785,
                         Name = "Cresceregina",
-                        Aoes = new List<uint> {
-                            // 49494/49495 Regal Fulguration REMOVED 2026-08-07 (user ruling): it is a
-                            // DIRECTIONAL attack, not a raidwide — dodge it, don't mitigate it.
-                        },
+                        // 49494/49495 Regal Fulguration REMOVED 2026-08-07 (user ruling): it is a
+                        // DIRECTIONAL attack, not a raidwide — dodge it, don't mitigate it.
+                        // Null, not an empty list: the engine reads any non-null list as "this boss
+                        // has answerable logic" and suppresses normal healing fallbacks for it.
+                        Aoes = null,
                     },
                     new Enemy {
                         Id = 14764,

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7126,7 +7126,7 @@ namespace Magitek.Utilities
             },
 
             new Encounter {
-                ZoneId = ZoneId.TheOccultCrescentNorthHorn,
+                ZoneId = 1346,
                 Name = "The Occult Crescent: North Horn (field Critical Encounters)",
                 Expansion = FfxivExpansion.Dawntrail,
                 // Derived from a recorded run rather than a trigger database — cactbot's file for this zone
@@ -7288,15 +7288,6 @@ namespace Magitek.Utilities
                     },
                     new Enemy {
                         Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
-                        Name = "Patient Kuribu",
-                        Aoes = new List<uint> {
-                            49908, // Aero III (20 corpus casts, 3.7s castbar)
-                            50072, // Aero III (29 corpus casts, 4.2s castbar, hit up to 16 players —
-                                   // same user ruling as the Greater Fan's variant)
-                        },
-                    },
-                    new Enemy {
-                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
                         Name = "Arch Kelpie",
                         Aoes = new List<uint> {
                             47386, // Water IV — user-confirmed needs AoE mitigation 2026-08-08; id
@@ -7330,22 +7321,6 @@ namespace Magitek.Utilities
                         Name = "Dancing Sword",
                         Aoes = new List<uint> {
                             49616, // Rush (1,016 observed casts, hit up to 14 players — ACT 2026-08-07)
-                        },
-                    },
-                    new Enemy {
-                        Id = 0, // matched by name (OC pattern); id pending an AddCombatant capture
-                        Name = "Algol",
-                        Aoes = new List<uint> {
-                            48111, // Rotten Tomato (median 3 / max 13 players hit)
-                            48112, // Rotten Onion (median 2 / max 12 players hit)
-                        },
-                    },
-                    new Enemy {
-                        Id = 0, // matched by name (OC pattern)
-                        Name = "Elm Gigas",
-                        Aoes = new List<uint> {
-                            48041, // Ancient Aero III (user-confirmed raidwide; id from ACT 261 memory
-                                   // lines — persisted across 3 ticks at the exact castbar second)
                         },
                     },
                     new Enemy {
@@ -7425,6 +7400,9 @@ namespace Magitek.Utilities
                         Id = 14764,
                         Name = "Patient Kuribu",
                         Aoes = new List<uint> {
+                            49908, // Aero III (20 corpus casts, 3.7s castbar)
+                            50072, // Aero III (29 corpus casts, 4.2s castbar, hit up to 16 players —
+                                   // same user ruling as the Greater Fan's variant)
                             50118, // Shortsword and Sorcery
                         },
                     },
@@ -7475,6 +7453,8 @@ namespace Magitek.Utilities
                         Name = "Algol",
                         Aoes = new List<uint> {
                             48100, // Cursed Screech — 8 players, 14%
+                            48111, // Rotten Tomato (median 3 / max 13 players hit)
+                            48112, // Rotten Onion (median 2 / max 12 players hit)
                             48971, // Cursed Screech — 7 players, 20%
                             50426, // Shrill Peal — 8 players, 26%
                             50427, // Shrill Peal — 6 players, 26%
@@ -8188,7 +8168,6 @@ namespace Magitek.Utilities
             TheNavelExtreme = 296,
             TheNavelHard = 293,
             TheNavelUnreal = 953,
-            TheOccultCrescentNorthHorn = 1346,
             TheOmegaProtocolUltimate = 1122,
             TheOrbonneMonastery = 826,
             TheOrphansAndTheBrokenBlade = 715,


### PR DESCRIPTION
## What this changes

Adds a new encounter block for **The Occult Crescent: North Horn (field Critical Encounters)** — the zone currently has no fight logic at all. Coverage is roughly half of the critical engagements (derived from recorded runs; cactbot's file for this zone is still an empty stub), and none of Forked Tower yet. Per-enemy tankbusters, AoEs, big AoEs, and knockbacks, with per-id comments carrying the classification evidence.

Notable calls, documented in the block:

- **Green Head: Storm's Breath catalogued as a knockback** — answered with knockback prevention across three live sessions.
- **Regnant Chimera's orb family (Ram's/Dragon's Voice) deliberately NOT catalogued** — crossing donut AoEs with one safe spot; mitigating them burned cooldowns and saved nobody (recorded overlap hits exceeded max HP). Dodge mechanics stay out of the catalogue; the entry carries the doctrine comment so nobody re-adds them.
- Thunderfront Tempest kept as a mitigated raidwide; Necrosurge left out as a dodge.

## Tested

Live North Horn play across multiple sessions (SCH, SGE, DRK), including a full Two-headed Aevis duel fight: knockback prevention fired on Storm's Breath in three separate sessions, tankbusters answered (The Blackest Night on the marker-telegraphed buster), Reprisal/party mitigation flowing through duel phases. The orb-family omission was validated with a positive control — both orb casts observed live in the log with the routine correctly staying silent.

## Sources

Recorded encounter logs (routine log + network log) from those sessions; XIVAPI for status/action verification where noted in comments. Every id read from an observed cast.

## Removals

None — the zone had no existing entries.
