### PR TITLE
FightLogic - Stop the Doom heal re-firing every pulse while moving

### DIFF
--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -192,8 +192,14 @@ namespace Magitek.Logic.Roles
             // A heal with a cast bar fails instantly while moving, and this check runs ahead of
             // discretionary healing on every pulse — without this guard a Doom carried while
             // moving re-fires the failed cast every pulse (~25/s, seen live) until movement
-            // stops. Swiftcast makes the cast instant, so it is exempt.
-            if (ff14bot.Managers.MovementManager.IsMoving && heal.AdjustedCastTime > System.TimeSpan.Zero && !Core.Me.HasAura(Utilities.Auras.Swiftcast))
+            // stops. Swiftcast and Dualcast both make the cast instant, so both are exempt —
+            // the same pair the shared cast gate whitelists. Dualcast is not RedMage-only:
+            // Occult Crescent's Phantom Red Mage grants the same status on any job, so a
+            // Scholar in the field ops carries it through most of a fight (observed in game).
+            if (ff14bot.Managers.MovementManager.IsMoving
+                && heal.AdjustedCastTime > System.TimeSpan.Zero
+                && !Core.Me.HasAura(Utilities.Auras.Swiftcast)
+                && !Core.Me.HasAura(Utilities.Auras.Dualcast))
                 return false;
 
             var doomed = FightLogic.DoomedHealTarget();

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -189,6 +189,13 @@ namespace Magitek.Logic.Roles
             if (!heal.IsKnownAndReady())
                 return false;
 
+            // A heal with a cast bar fails instantly while moving, and this check runs ahead of
+            // discretionary healing on every pulse — without this guard a Doom carried while
+            // moving re-fires the failed cast every pulse (~25/s, seen live) until movement
+            // stops. Swiftcast makes the cast instant, so it is exempt.
+            if (ff14bot.Managers.MovementManager.IsMoving && heal.AdjustedCastTime > System.TimeSpan.Zero && !Core.Me.HasAura(Utilities.Auras.Swiftcast))
+                return false;
+
             var doomed = FightLogic.DoomedHealTarget();
 
             if (doomed == null)


### PR DESCRIPTION
## What this changes

The heal-to-full Doom response re-fires its heal every pulse while the healer is moving. The heal has a cast bar, so each attempt fails instantly mid-movement, the Doom is still present next pulse, and the response fires again — observed live at ~25 attempts per second, sustained for the full duration of the movement.

The fix: skip the response while moving when the heal has a cast time, unless Swiftcast is up (instant heals still go out on the move). The heal then fires on the first stationary pulse — which is also what actually happened in the incident once movement stopped.

## Tested

Live Forked Tower: Blood run, both Scholar and Sage. Before the guard: one Doom carried while moving produced a sustained ~25/s re-fire storm in the log. After: dozens of Doom cycles across both jobs, every one answered with a single cast line and cleansed.

## Sources

Live log evidence as above; the failure and the fix were both observed in the same session.

## Removals

None — one guard added, matching the cast-while-moving pattern used elsewhere in the codebase.
