### PR TITLE
SCH - Remove blocking waits that stalled the rotation for seconds after instant casts

### DIFF
--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -264,9 +264,15 @@ namespace Magitek.Logic.Scholar
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            // Emergency Tactics is an instant oGCD; its aura lands ~200ms later, well before the paired
-            // ~2s shield heal resolves, so the buff still converts. The old Wait(1500) just stalled the pulse.
-            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
+            if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
+                return false;
+
+            // Keep the arm→heal pair atomic: Emergency Tactics is instant (aura ~200ms), and the
+            // paired shield heal must clear its animation lock. One bounded wait per 15s cooldown
+            // is cheaper than the pairing drifting between pulses — a retarget, a co-healer
+            // top-off, or a higher-priority heal could otherwise waste or misdirect the armed
+            // conversion.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
         public static async Task<bool> Aetherflow()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -243,22 +243,28 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> EmergencyTactics()
         {
+            // Never convert a Recitation crit, and never fire into an armed fight-logic queue: a live
+            // run showed ET landing 0.8s after a queued Recitation>Succor armed, eating the crit the
+            // queue had just paid for. These outrank the already-armed short-circuit below, or ET's
+            // ~200ms application tail could greenlight the same theft.
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+                return false;
+
+            // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
+            // run re-cast ET three times inside one Seraphism window because the conversion callers
+            // below had no awareness the aura was already up.
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
+
             if (!ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
-                return false;
-
-            return await Coroutine.Wait(1500, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
-
-            //if (await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics)) {
-            //    return await Coroutine.Wait(1700, () => Core.Me.HasAura(Auras.EmergencyTactics, true));
-            //}
-
-            //return false;
+            // Emergency Tactics is an instant oGCD; its aura lands ~200ms later, well before the paired
+            // ~2s shield heal resolves, so the buff still converts. The old Wait(1500) just stalled the pulse.
+            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
         }
 
         public static async Task<bool> Aetherflow()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -250,14 +250,16 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // The master opt-out outranks the armed short-circuit: a manually applied Emergency
+            // Tactics must not be auto-consumed by the conversion callers while the feature is off.
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
             // run re-cast ET three times inside one Seraphism window because the conversion callers
             // below had no awareness the aura was already up.
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
-
-            if (!ScholarSettings.Instance.EmergencyTactics)
-                return false;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -62,7 +62,9 @@ namespace Magitek.Logic.Scholar
                     return false;
             }
 
-            return await Coroutine.Wait(5000, () => Core.Me.Pet != null);
+            // Summon fired; FairySummonCooldown (10s) + the Pet != null guard at the top prevent a
+            // double-summon, so there's no need to block the pulse waiting for the pet to materialize.
+            return true;
         }
 
         public static async Task<bool> SummonSeraph()
@@ -223,12 +225,10 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> Swiftcast()
         {
-            if (await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast))
-            {
-                return await Coroutine.Wait(15000, () => Core.Me.HasAura(Auras.Swiftcast, true, 7000));
-            }
-
-            return false;
+            // NOTE: this Scholar-local Swiftcast is unused — the live rez path uses Roles.Healer.Swiftcast.
+            // CastAura sends the cast; nothing here reads the aura afterward, so no blocking wait is needed
+            // (the old Wait(15000, ...) could freeze the routine for up to 15s).
+            return await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast);
         }
         public static async Task<bool> ForceSeraph()
         {

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -184,10 +184,13 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
 
-            // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
-            // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.
-            await Spells.EmergencyTactics.Cast(Core.Me);
-            return false;
+            if (!await Spells.EmergencyTactics.Cast(Core.Me))
+                return false;
+
+            // Keep the arm→heal pair atomic (see Buff.EmergencyTactics): a bounded wait for the
+            // aura and the paired heal's castability, so the conversion cannot drift to another
+            // target or caller between pulses.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Succor.Id, Core.Me));
         }
 
         private static async Task<bool> UsedAdloquium()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -174,14 +174,15 @@ namespace Magitek.Logic.Scholar
 
         private static async Task<bool> UsedEmergencyTactics()
         {
-            if (Core.Me.HasAura(Auras.EmergencyTactics))
-                return true;
-
-            // Same guards as Buff.EmergencyTactics: never convert a Recitation crit, never fire into
-            // an armed fight-logic queue. This was the second, unguarded ET site — reachable every
-            // pulse while a queue was live, which is exactly the wedge the guards exist to prevent.
+            // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
+            // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
+            // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
+            // guards exist to prevent. This was the second, unguarded ET site.
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
+
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
 
             // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
             // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -128,7 +128,7 @@ namespace Magitek.Logic.Scholar
             if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
-            if (!await UsedEmergencyTactics())
+            if (!await UsedEmergencyTactics(forced: true))
                 return false;
 
             if (!await Spells.Succor.Cast(Core.Me)) return false;
@@ -172,19 +172,22 @@ namespace Magitek.Logic.Scholar
             return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
-        private static async Task<bool> UsedEmergencyTactics()
+        private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
             // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
             // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
             // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
-            // guards exist to prevent. This was the second, unguarded ET site.
+            // guards exist to prevent. This was the second, unguarded ET site. They apply to the
+            // forced path too — Recitation expires or is consumed, so this delays a forced cast,
+            // never latches it.
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
             // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
             // reachable from Accession/Manifestation barrier branches without any settings check
-            // in between, and disabling the feature must disable every automatic ET.
-            if (!ScholarSettings.Instance.EmergencyTactics)
+            // in between, and disabling the feature must disable every automatic ET. The explicit
+            // force toggle is user intent, not automation, so it bypasses only this check.
+            if (!forced && !ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
             if (Core.Me.HasAura(Auras.EmergencyTactics))

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -173,11 +173,17 @@ namespace Magitek.Logic.Scholar
         {
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
-            if (!await Spells.EmergencyTactics.Cast(Core.Me))
+
+            // Same guards as Buff.EmergencyTactics: never convert a Recitation crit, never fire into
+            // an armed fight-logic queue. This was the second, unguarded ET site — reachable every
+            // pulse while a queue was live, which is exactly the wedge the guards exist to prevent.
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
-            if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics)))
-                return false;
-            return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Succor.Id, Core.Me));
+
+            // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
+            // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.
+            await Spells.EmergencyTactics.Cast(Core.Me);
+            return false;
         }
 
         private static async Task<bool> UsedAdloquium()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -122,7 +122,10 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.ForceEmergencySuccor)
                 return false;
 
-            if (!Spells.EmergencyTactics.IsKnownAndReady())
+            // Ready OR already armed: the helper below fires Emergency Tactics on one pulse and the
+            // follow-up heal consumes the aura on a later one, so "on cooldown but armed" must pass
+            // this gate or the forced Succor and the toggle reset become unreachable.
+            if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (!await UsedEmergencyTactics())
@@ -246,7 +249,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Adloquium || !ScholarSettings.Instance.EmergencyTacticsAdloquium)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (Globals.InParty)
@@ -380,7 +385,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Succor || !ScholarSettings.Instance.EmergencyTactics || !ScholarSettings.Instance.EmergencyTacticsSuccor)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -380,15 +380,20 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!ScholarSettings.Instance.RecitationWithAdlo)
                     return;
+                // An armed Emergency Tactics would convert the crit shield this Recitation exists
+                // to guarantee — never arm the pair while a deferred conversion is still live.
+                if (Core.Me.HasAura(Auras.EmergencyTactics))
+                    return;
                 if (Spells.Recitation.Cooldown != TimeSpan.Zero)
                     return;
                 if (ScholarSettings.Instance.RecitationOnlyNoAetherflow && Core.Me.HasAetherflow())
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
             }
         }
 
@@ -597,9 +602,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
             }
         }
 
@@ -685,9 +691,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
             }
         }
 
@@ -723,9 +730,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
             }
         }
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -181,6 +181,12 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
+            // reachable from Accession/Manifestation barrier branches without any settings check
+            // in between, and disabling the feature must disable every automatic ET.
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -386,9 +386,9 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -412,10 +412,9 @@ namespace Magitek.Logic.Scholar
             if (!await Buff.EmergencyTactics())
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await Spells.Succor.Heal(Core.Me);
         }
 
         public static async Task<bool> Succor()
@@ -436,12 +435,9 @@ namespace Magitek.Logic.Scholar
             if (!needSuccor)
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-            {
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-            }
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await Spells.Succor.Heal(Core.Me);
         }
 
         public static async Task<bool> Accession()
@@ -601,10 +597,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -690,10 +685,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -729,10 +723,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 


### PR DESCRIPTION
Part of a stacked series of small Scholar changes — merge order matters. This PR's own change is its final commit; the diff includes its predecessors until they merge. Stacks on the Emergency Tactics PR.

Several Scholar paths blocked the pulse waiting on things that either never needed confirming or are confirmed elsewhere: 5s after summoning the fairy, up to 15s after an (unused) local Swiftcast, ~2.5s after Succor confirming LastSpell (the cast-tracker already holds the pulse during the cast), and ~2s after each Recitation waiting for CanCast that the paired heal gates anyway. Recitation's wait drops to a 400ms aura-confirm cap; the rest return immediately.

**Tested:** SCH Lv100 live sessions; rotation cadence visibly tightened, no double-casts observed (each removed wait's re-fire protection is named in a comment).
**Sources:** live log timing, reasons per-site in comments.
**Removals:** only the blocking waits themselves — every cast and guard remains.