### PR TITLE
SCH - Let Physick race a heal-to-full Doom past the discretionary healing gates

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -176,6 +176,26 @@ namespace Magitek.Extensions
 
         }
 
+        /// <summary>
+        /// Whether the unit already carries a magical barrier that another one would waste.
+        /// <para>
+        /// Adloquium and Succor state that the effect "cannot be stacked with certain sage barrier
+        /// effects", so Galvanize and the Eukrasian barriers are mutually exclusive — re-shielding someone
+        /// who has either throws the cast away. Catalyze is deliberately excluded: it sits alongside
+        /// Galvanize rather than replacing it, so its presence says nothing about whether a fresh barrier
+        /// would land.
+        /// </para>
+        /// </summary>
+        /// <param name="msLeft">Only count a barrier with at least this long remaining, so one about to
+        /// lapse doesn't block a replacement.</param>
+        public static bool HasMagicBarrier(this GameObject unit, int msLeft = 0)
+        {
+            return unit != null
+                && (unit.HasAura(Auras.Galvanize, false, msLeft)
+                    || unit.HasAura(Auras.EukrasianPrognosis, false, msLeft)
+                    || unit.HasAura(Auras.EukrasianDiagnosis, false, msLeft));
+        }
+
         // A dispel strips a BENEFICIAL status from an enemy, so a helper used to decide whether to
         // dispel has to ignore debuffs. Named for what it actually asks: the old name read as the
         // opposite of what it did, and let a dispel re-fire forever on an enemy that merely carries a

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -264,9 +264,15 @@ namespace Magitek.Logic.Scholar
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            // Emergency Tactics is an instant oGCD; its aura lands ~200ms later, well before the paired
-            // ~2s shield heal resolves, so the buff still converts. The old Wait(1500) just stalled the pulse.
-            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
+            if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
+                return false;
+
+            // Keep the arm→heal pair atomic: Emergency Tactics is instant (aura ~200ms), and the
+            // paired shield heal must clear its animation lock. One bounded wait per 15s cooldown
+            // is cheaper than the pairing drifting between pulses — a retarget, a co-healer
+            // top-off, or a higher-priority heal could otherwise waste or misdirect the armed
+            // conversion.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
         public static async Task<bool> Aetherflow()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -243,22 +243,28 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> EmergencyTactics()
         {
+            // Never convert a Recitation crit, and never fire into an armed fight-logic queue: a live
+            // run showed ET landing 0.8s after a queued Recitation>Succor armed, eating the crit the
+            // queue had just paid for. These outrank the already-armed short-circuit below, or ET's
+            // ~200ms application tail could greenlight the same theft.
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+                return false;
+
+            // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
+            // run re-cast ET three times inside one Seraphism window because the conversion callers
+            // below had no awareness the aura was already up.
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
+
             if (!ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
-                return false;
-
-            return await Coroutine.Wait(1500, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
-
-            //if (await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics)) {
-            //    return await Coroutine.Wait(1700, () => Core.Me.HasAura(Auras.EmergencyTactics, true));
-            //}
-
-            //return false;
+            // Emergency Tactics is an instant oGCD; its aura lands ~200ms later, well before the paired
+            // ~2s shield heal resolves, so the buff still converts. The old Wait(1500) just stalled the pulse.
+            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
         }
 
         public static async Task<bool> Aetherflow()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -250,14 +250,16 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // The master opt-out outranks the armed short-circuit: a manually applied Emergency
+            // Tactics must not be auto-consumed by the conversion callers while the feature is off.
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
             // run re-cast ET three times inside one Seraphism window because the conversion callers
             // below had no awareness the aura was already up.
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
-
-            if (!ScholarSettings.Instance.EmergencyTactics)
-                return false;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -62,7 +62,9 @@ namespace Magitek.Logic.Scholar
                     return false;
             }
 
-            return await Coroutine.Wait(5000, () => Core.Me.Pet != null);
+            // Summon fired; FairySummonCooldown (10s) + the Pet != null guard at the top prevent a
+            // double-summon, so there's no need to block the pulse waiting for the pet to materialize.
+            return true;
         }
 
         public static async Task<bool> SummonSeraph()
@@ -223,12 +225,10 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> Swiftcast()
         {
-            if (await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast))
-            {
-                return await Coroutine.Wait(15000, () => Core.Me.HasAura(Auras.Swiftcast, true, 7000));
-            }
-
-            return false;
+            // NOTE: this Scholar-local Swiftcast is unused — the live rez path uses Roles.Healer.Swiftcast.
+            // CastAura sends the cast; nothing here reads the aura afterward, so no blocking wait is needed
+            // (the old Wait(15000, ...) could freeze the routine for up to 15s).
+            return await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast);
         }
         public static async Task<bool> ForceSeraph()
         {

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -169,7 +169,7 @@ namespace Magitek.Logic.Scholar
                 // Check if tank needs Adloquium for buff
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasAura(Auras.Galvanize));
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasMagicBarrier());
                     if (tankAdloTarget != null)
                         return true;
                 }
@@ -187,7 +187,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.Galvanize))
+                    if (unit.HasMagicBarrier())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -204,7 +204,7 @@ namespace Magitek.Logic.Scholar
             }
 
             // Solo check
-            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasAura(Auras.Galvanize))
+            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasMagicBarrier())
                 return true;
 
             return false;
@@ -218,7 +218,7 @@ namespace Magitek.Logic.Scholar
             var aoeNeedHealing = Heal.AoeNeedHealing;
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasAura(Auras.Galvanize)) >= aoeNeedHealing;
+                                                                     !r.HasMagicBarrier()) >= aoeNeedHealing;
 
             return needSuccor;
         }

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -252,8 +252,11 @@ namespace Magitek.Logic.Scholar
             // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
             var doomed = FightLogic.DoomedHealTarget();
 
+            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
+            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
+            // this Doom only clears at FULL HP.
             if (doomed != null)
-                return await Spells.Physick.Heal(doomed);
+                return await Spells.Physick.Heal(doomed, false);
 
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -243,6 +243,22 @@ namespace Magitek.Logic.Scholar
 
         #endregion
 
+        public static async Task<bool> PhysickDoom()
+        {
+            if (!ScholarSettings.Instance.Physick)
+                return false;
+
+            var doomed = FightLogic.DoomedHealTarget();
+
+            if (doomed == null)
+                return false;
+
+            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
+            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
+            // this Doom only clears at FULL HP.
+            return await Spells.Physick.Heal(doomed, false);
+        }
+
         public static async Task<bool> Physick()
         {
             if (!ScholarSettings.Instance.Physick)
@@ -250,13 +266,10 @@ namespace Magitek.Logic.Scholar
 
             // A heal-to-full Doom outranks the discretionary gates below: it is a death timer
             // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
-            var doomed = FightLogic.DoomedHealTarget();
-
-            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
-            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
-            // this Doom only clears at FULL HP.
-            if (doomed != null)
-                return await Spells.Physick.Heal(doomed, false);
+            // The alliance leg also calls PhysickDoom directly at its head — the routine-wide Doom
+            // response runs before the collections switch, so it never sees an alliance carrier.
+            if (FightLogic.DoomedHealTarget() != null)
+                return await PhysickDoom();
 
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -184,10 +184,13 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
 
-            // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
-            // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.
-            await Spells.EmergencyTactics.Cast(Core.Me);
-            return false;
+            if (!await Spells.EmergencyTactics.Cast(Core.Me))
+                return false;
+
+            // Keep the arm→heal pair atomic (see Buff.EmergencyTactics): a bounded wait for the
+            // aura and the paired heal's castability, so the conversion cannot drift to another
+            // target or caller between pulses.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Succor.Id, Core.Me));
         }
 
         private static async Task<bool> UsedAdloquium()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -174,14 +174,15 @@ namespace Magitek.Logic.Scholar
 
         private static async Task<bool> UsedEmergencyTactics()
         {
-            if (Core.Me.HasAura(Auras.EmergencyTactics))
-                return true;
-
-            // Same guards as Buff.EmergencyTactics: never convert a Recitation crit, never fire into
-            // an armed fight-logic queue. This was the second, unguarded ET site — reachable every
-            // pulse while a queue was live, which is exactly the wedge the guards exist to prevent.
+            // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
+            // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
+            // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
+            // guards exist to prevent. This was the second, unguarded ET site.
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
+
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
 
             // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
             // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -86,7 +86,9 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            if (target.HasMagicBarrier())
+            // Deliberately NOT HasMagicBarrier(): Excogitation is a delayed heal, not a barrier, so
+            // the Adloquium/Succor non-stacking rule does not apply. This keeps the original check.
+            if (target.HasAura(Auras.Galvanize))
                 return false;
 
             if (!await Spells.Excogitation.Cast(target)) return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -128,7 +128,7 @@ namespace Magitek.Logic.Scholar
             if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
-            if (!await UsedEmergencyTactics())
+            if (!await UsedEmergencyTactics(forced: true))
                 return false;
 
             if (!await Spells.Succor.Cast(Core.Me)) return false;
@@ -172,19 +172,22 @@ namespace Magitek.Logic.Scholar
             return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
-        private static async Task<bool> UsedEmergencyTactics()
+        private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
             // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
             // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
             // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
-            // guards exist to prevent. This was the second, unguarded ET site.
+            // guards exist to prevent. This was the second, unguarded ET site. They apply to the
+            // forced path too — Recitation expires or is consumed, so this delays a forced cast,
+            // never latches it.
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
             // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
             // reachable from Accession/Manifestation barrier branches without any settings check
-            // in between, and disabling the feature must disable every automatic ET.
-            if (!ScholarSettings.Instance.EmergencyTactics)
+            // in between, and disabling the feature must disable every automatic ET. The explicit
+            // force toggle is user intent, not automation, so it bypasses only this check.
+            if (!forced && !ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
             if (Core.Me.HasAura(Auras.EmergencyTactics))

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -248,6 +248,13 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Physick)
                 return false;
 
+            // A heal-to-full Doom outranks the discretionary gates below: it is a death timer
+            // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
+            var doomed = FightLogic.DoomedHealTarget();
+
+            if (doomed != null)
+                return await Spells.Physick.Heal(doomed);
+
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -173,11 +173,17 @@ namespace Magitek.Logic.Scholar
         {
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
-            if (!await Spells.EmergencyTactics.Cast(Core.Me))
+
+            // Same guards as Buff.EmergencyTactics: never convert a Recitation crit, never fire into
+            // an armed fight-logic queue. This was the second, unguarded ET site — reachable every
+            // pulse while a queue was live, which is exactly the wedge the guards exist to prevent.
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
-            if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics)))
-                return false;
-            return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Succor.Id, Core.Me));
+
+            // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
+            // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.
+            await Spells.EmergencyTactics.Cast(Core.Me);
+            return false;
         }
 
         private static async Task<bool> UsedAdloquium()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -122,7 +122,10 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.ForceEmergencySuccor)
                 return false;
 
-            if (!Spells.EmergencyTactics.IsKnownAndReady())
+            // Ready OR already armed: the helper below fires Emergency Tactics on one pulse and the
+            // follow-up heal consumes the aura on a later one, so "on cooldown but armed" must pass
+            // this gate or the forced Succor and the toggle reset become unreachable.
+            if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (!await UsedEmergencyTactics())
@@ -246,7 +249,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Adloquium || !ScholarSettings.Instance.EmergencyTacticsAdloquium)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (Globals.InParty)
@@ -380,7 +385,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Succor || !ScholarSettings.Instance.EmergencyTactics || !ScholarSettings.Instance.EmergencyTacticsSuccor)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -86,7 +86,7 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            if (target.HasAura(Auras.Galvanize))
+            if (target.HasMagicBarrier())
                 return false;
 
             if (!await Spells.Excogitation.Cast(target)) return false;
@@ -326,7 +326,7 @@ namespace Magitek.Logic.Scholar
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
                     // Pick any tank who doesn't have Galvanize on them
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasAura(Auras.Galvanize));
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasMagicBarrier());
 
                     if (tankAdloTarget == null)
                         return false;
@@ -353,7 +353,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.Galvanize))
+                    if (unit.HasMagicBarrier())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -369,7 +369,7 @@ namespace Magitek.Logic.Scholar
                 }
             }
 
-            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasAura(Auras.Galvanize))
+            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasMagicBarrier())
                 return false;
 
             return await Spells.Adloquium.HealAura(Core.Me, Auras.Galvanize);
@@ -435,7 +435,7 @@ namespace Magitek.Logic.Scholar
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasAura(Auras.Galvanize)) >= AoeNeedHealing;
+                                                                     !r.HasMagicBarrier()) >= AoeNeedHealing;
 
             if (!needSuccor)
                 return false;
@@ -457,7 +457,7 @@ namespace Magitek.Logic.Scholar
                 return false;
 
             var needAccession = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent) >= AoeNeedHealing;
-            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasAura(Auras.Galvanize)) > 0;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasMagicBarrier()) > 0;
 
             if (!needAccession)
                 return false;
@@ -493,7 +493,7 @@ namespace Magitek.Logic.Scholar
                 if (ManifestationTarget == null)
                     return false;
 
-                var needsShields = !ManifestationTarget.HasAura(Auras.Galvanize);
+                var needsShields = !ManifestationTarget.HasMagicBarrier();
 
                 if (!needsShields && !await UsedEmergencyTactics())
                     return false;
@@ -507,7 +507,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.ManifestationHpPercent)
                 return false;
 
-            var needsShieldsMe = !Core.Me.HasAura(Auras.Galvanize);
+            var needsShieldsMe = !Core.Me.HasMagicBarrier();
 
             if (!needsShieldsMe && !await UsedEmergencyTactics())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -380,15 +380,20 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!ScholarSettings.Instance.RecitationWithAdlo)
                     return;
+                // An armed Emergency Tactics would convert the crit shield this Recitation exists
+                // to guarantee — never arm the pair while a deferred conversion is still live.
+                if (Core.Me.HasAura(Auras.EmergencyTactics))
+                    return;
                 if (Spells.Recitation.Cooldown != TimeSpan.Zero)
                     return;
                 if (ScholarSettings.Instance.RecitationOnlyNoAetherflow && Core.Me.HasAetherflow())
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
             }
         }
 
@@ -597,9 +602,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
             }
         }
 
@@ -685,9 +691,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
             }
         }
 
@@ -723,9 +730,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
             }
         }
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -181,6 +181,12 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
+            // reachable from Accession/Manifestation barrier branches without any settings check
+            // in between, and disabling the feature must disable every automatic ET.
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -386,9 +386,9 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -412,10 +412,9 @@ namespace Magitek.Logic.Scholar
             if (!await Buff.EmergencyTactics())
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await Spells.Succor.Heal(Core.Me);
         }
 
         public static async Task<bool> Succor()
@@ -436,12 +435,9 @@ namespace Magitek.Logic.Scholar
             if (!needSuccor)
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-            {
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-            }
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await Spells.Succor.Heal(Core.Me);
         }
 
         public static async Task<bool> Accession()
@@ -601,10 +597,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -690,10 +685,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -729,10 +723,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -174,6 +174,23 @@ namespace Magitek.Logic.Scholar
             return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
+        /// <summary>
+        /// True when the AUTOMATIC Emergency Tactics conversion could run right now — the same
+        /// gate set UsedEmergencyTactics enforces (Recitation/queue crit protection, the master
+        /// opt-out, ready-or-armed). Target selection consults this so it never picks an ally
+        /// that only the conversion could serve while the conversion itself would refuse.
+        /// </summary>
+        private static bool EmergencyTacticsConvertible()
+        {
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+                return false;
+
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
+            return Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics);
+        }
+
         private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
             // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
@@ -494,8 +511,7 @@ namespace Magitek.Logic.Scholar
                 // Tactics conversion. When that path cannot run, skip barriered allies in the
                 // pick — otherwise the first barriered ally latches this method every pulse
                 // while a shieldable ally further down the weight order goes without.
-                var etConvertible = ScholarSettings.Instance.EmergencyTactics
-                    && (Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics));
+                var etConvertible = EmergencyTacticsConvertible();
 
                 var ManifestationTarget = etConvertible
                     ? Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate)

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -490,7 +490,16 @@ namespace Magitek.Logic.Scholar
 
             if (Globals.InParty)
             {
-                var ManifestationTarget = Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate);
+                // A target already carrying a barrier is only actionable through the Emergency
+                // Tactics conversion. When that path cannot run, skip barriered allies in the
+                // pick — otherwise the first barriered ally latches this method every pulse
+                // while a shieldable ally further down the weight order goes without.
+                var etConvertible = ScholarSettings.Instance.EmergencyTactics
+                    && (Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics));
+
+                var ManifestationTarget = etConvertible
+                    ? Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate)
+                    : Group.CastableAlliesWithin30.FirstOrDefault(r => CanLustrate(r) && !r.HasMagicBarrier());
 
                 if (ManifestationTarget == null)
                     return false;

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -138,6 +138,11 @@ namespace Magitek.Rotations
 
             async Task<bool> DoHeal()
             {
+                // The routine-wide Doom response runs against the party collections before the
+                // alliance switch, so a doomed alliance member is only reachable here — and the
+                // death timer outranks resurrection: a slowcast raise can outlive the Doom.
+                if (await Logic.Scholar.Heal.PhysickDoom()) return true;
+
                 if (await Logic.Scholar.Heal.Resurrection()) return true;
 
                 if (ScholarSettings.Instance.HealAllianceOnlyPhysick)


### PR DESCRIPTION
Part of a stacked series of small Scholar changes — merge order matters. This PR's own change is its final commit; the diff includes its predecessors until they merge. Stacks on the magic-barrier PR.

A heal-to-full Doom is a death timer cleansed only by reaching full HP, but Physick's discretionary holds (AoE-needed suppression, health thresholds) could silence the heal racing it. A Doomed ally now short-circuits those gates.

**Tested:** SCH/SGE live in Doom-heavy field content (the Doom response machinery exercised dozens of times in one session).
**Sources:** Doom behavior as already documented on the routine-wide Doom response.
**Removals:** none.