### PR TITLE
SCH - Fix Emergency Tactics crit theft, wasted shields, Sacred Soil placement, Doom priority, and Seraphism instant casting

### DIFF
--- a/Magitek/Extensions/CharacterExtensions.cs
+++ b/Magitek/Extensions/CharacterExtensions.cs
@@ -99,6 +99,27 @@ namespace Magitek.Extensions
             Auras.TheSpire,
         };
 
+        // The subset of HealerShields that OVERWRITE one another rather than stacking, so a target
+        // carrying any one of them cannot usefully be given another. Confirmed in game: our own
+        // Galvanize was replaced in the same millisecond a Sage's Eukrasian Prognosis landed, with
+        // 29s still on it. Cross-class, which is why this cannot be a per-job list.
+        public static uint[] PrimaryShields = new uint[]
+        {
+            Auras.Galvanize,
+            Auras.EukrasianDiagnosis,
+            Auras.EukrasianPrognosis,
+        };
+
+        /// <summary>
+        /// True when the unit already carries a primary shield from ANY healer, ours or another's.
+        /// Deliberately not own-aura only: these overwrite each other, so someone else's shield
+        /// still makes ours redundant.
+        /// </summary>
+        public static bool HasPrimaryShield(this Character unit, int msLeft = 0)
+        {
+            return unit != null && unit.HasAnyAura(PrimaryShields, false, msLeft);
+        }
+
         public static uint[] BuffIgnore = new uint[]
         {
             Auras.DancePartner,

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -176,6 +176,26 @@ namespace Magitek.Extensions
 
         }
 
+        /// <summary>
+        /// Whether the unit already carries a magical barrier that another one would waste.
+        /// <para>
+        /// Adloquium and Succor state that the effect "cannot be stacked with certain sage barrier
+        /// effects", so Galvanize and the Eukrasian barriers are mutually exclusive — re-shielding someone
+        /// who has either throws the cast away. Catalyze is deliberately excluded: it sits alongside
+        /// Galvanize rather than replacing it, so its presence says nothing about whether a fresh barrier
+        /// would land.
+        /// </para>
+        /// </summary>
+        /// <param name="msLeft">Only count a barrier with at least this long remaining, so one about to
+        /// lapse doesn't block a replacement.</param>
+        public static bool HasMagicBarrier(this GameObject unit, int msLeft = 0)
+        {
+            return unit != null
+                && (unit.HasAura(Auras.Galvanize, false, msLeft)
+                    || unit.HasAura(Auras.EukrasianPrognosis, false, msLeft)
+                    || unit.HasAura(Auras.EukrasianDiagnosis, false, msLeft));
+        }
+
         // A dispel strips a BENEFICIAL status from an enemy, so a helper used to decide whether to
         // dispel has to ignore debuffs. Named for what it actually asks: the old name read as the
         // opposite of what it did, and let a dispel re-fire forever on an enemy that merely carries a

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -188,14 +188,6 @@ namespace Magitek.Extensions
         /// </summary>
         /// <param name="msLeft">Only count a barrier with at least this long remaining, so one about to
         /// lapse doesn't block a replacement.</param>
-        public static bool HasMagicBarrier(this GameObject unit, int msLeft = 0)
-        {
-            return unit != null
-                && (unit.HasAura(Auras.Galvanize, false, msLeft)
-                    || unit.HasAura(Auras.EukrasianPrognosis, false, msLeft)
-                    || unit.HasAura(Auras.EukrasianDiagnosis, false, msLeft));
-        }
-
         // A dispel strips a BENEFICIAL status from an enemy, so a helper used to decide whether to
         // dispel has to ignore debuffs. Named for what it actually asks: the old name read as the
         // opposite of what it did, and let a dispel re-fire forever on an enemy that merely carries a

--- a/Magitek/Logic/Sage/Heal.cs
+++ b/Magitek/Logic/Sage/Heal.cs
@@ -170,10 +170,10 @@ namespace Magitek.Logic.Sage
                     if (unit.CurrentHealthPercent > SageSettings.Instance.EukrasianDiagnosisHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.EukrasianDiagnosis))
-                        return false;
-
-                    if (unit.HasAura(Auras.Galvanize))
+                    // Any primary shield, ours or another healer's. This previously checked
+                    // Eukrasian Diagnosis and Galvanize but not Eukrasian Prognosis, so a target
+                    // already carrying Prognosis could have it overwritten by Diagnosis.
+                    if (unit.HasPrimaryShield())
                         return false;
 
                     if (!SageSettings.Instance.EukrasianDiagnosisOnlyHealer && !SageSettings.Instance.EukrasianDiagnosisOnlyTank)
@@ -243,9 +243,7 @@ namespace Magitek.Logic.Sage
                 return false;
 
             var targets = Group.CastableAlliesWithin20.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.EukrasianPrognosisHealthPercent &&
-                                                                !r.HasAura(Auras.EukrasianDiagnosis) &&
-                                                                !r.HasAura(Auras.EukrasianPrognosis) &&
-                                                                !r.HasAura(Auras.Galvanize));
+                                                                !r.HasPrimaryShield());
 
             var needEukrasianPrognosis = targets.Count() >= AoeNeedHealing;
 

--- a/Magitek/Logic/Sage/HealFightLogic.cs
+++ b/Magitek/Logic/Sage/HealFightLogic.cs
@@ -90,9 +90,7 @@ namespace Magitek.Logic.Sage
                 && Spells.Eukrasia.IsKnown()
                 && Heal.IsEukrasiaReady())
             {
-                var targets = Group.CastableAlliesWithin20.Where(r => !r.HasAura(Auras.EukrasianDiagnosis)
-                                                                && !r.HasAura(Auras.EukrasianPrognosis)
-                                                                && !r.HasAura(Auras.Galvanize));
+                var targets = Group.CastableAlliesWithin20.Where(r => !r.HasPrimaryShield());
                 var tankCheck = !SageSettings.Instance.FightLogic_RespectOnlyTank
                     || targets.Any(r => r.IsTank());
 
@@ -154,9 +152,7 @@ namespace Magitek.Logic.Sage
 
             if (SageSettings.Instance.FightLogic_EukrasianDiagnosis
                 && Spells.Eukrasia.IsKnown()
-                && !target.HasAura(Auras.EukrasianDiagnosis)
-                && !target.HasAura(Auras.Galvanize)
-                && !target.HasAura(Auras.EukrasianPrognosis)
+                && !target.HasPrimaryShield()
                 && Heal.IsEukrasiaReady())
             {
                 if (BaseSettings.Instance.DebugFightLogic)

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -110,6 +110,13 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Seraphism)
                 return false;
 
+            // Never land Seraphism into an armed fight-logic queue: the queue's enqueued Adloquium/
+            // Succor are base ids, and the stance masking them to instants mid-queue re-creates the
+            // 3s cast-confirm wedge on a mechanic already latched as handled — the trigger state
+            // for this cast (party hurt) is exactly the state that armed the queue.
+            if (SpellQueueLogic.SpellQueue.Any())
+                return false;
+
             if (Core.Me.Pet == null)
                 return false;
 

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -215,12 +215,17 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Succor)
                 return false;
 
+            // Mirrors the gate in Heal.Succor so this stays a truthful prediction of whether Succor
+            // would actually fire: health decides the threshold, shields only decide whether the
+            // barrier is worth anything.
             var aoeNeedHealing = Heal.AoeNeedHealing;
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
-                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasPrimaryShield()) >= aoeNeedHealing;
+                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent) >= aoeNeedHealing;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
+                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
+                                                                      !r.HasPrimaryShield()) > 0;
 
-            return needSuccor;
+            return needSuccor && needShields;
         }
 
         public static async Task<bool> Swiftcast()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -304,9 +304,14 @@ namespace Magitek.Logic.Scholar
                 return false;
             if (Spells.DeploymentTactics.Cooldown.TotalMilliseconds > 1500)
                 return false;
+            // Deployment Tactics copies the barrier with only the time left on the original, and does not
+            // refresh it, so spreading one that is about to lapse spends a two minute cooldown on a shield
+            // that vanishes moments later. Require enough left on it to be worth the cooldown.
+            var minimumShieldMs = ScholarSettings.Instance.DeploymentTacticsMinimumShieldSeconds * 1000;
+
             // Find someone who has the right amount of allies around them based on the users settings
             var deploymentTacticsTarget = Group.CastableAlliesWithin30.FirstOrDefault(r =>
-                r.HasAura(Auras.Galvanize, true)
+                r.HasAura(Auras.Galvanize, true, minimumShieldMs)
                 && r.HasAura(Auras.Catalyze, true)
                 //Range now 30y
                 && Group.CastableAlliesWithin30.Count(x => x.Distance(r) <= 30 + x.CombatReach) >= ScholarSettings.Instance.DeploymentTacticsAllyInRange);

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -264,9 +264,15 @@ namespace Magitek.Logic.Scholar
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            // Emergency Tactics is an instant oGCD; its aura lands ~200ms later, well before the paired
-            // ~2s shield heal resolves, so the buff still converts. The old Wait(1500) just stalled the pulse.
-            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
+            if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
+                return false;
+
+            // Keep the arm→heal pair atomic: Emergency Tactics is instant (aura ~200ms), and the
+            // paired shield heal must clear its animation lock. One bounded wait per 15s cooldown
+            // is cheaper than the pairing drifting between pulses — a retarget, a co-healer
+            // top-off, or a higher-priority heal could otherwise waste or misdirect the armed
+            // conversion.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
         public static async Task<bool> Aetherflow()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -176,7 +176,7 @@ namespace Magitek.Logic.Scholar
                 // Check if tank needs Adloquium for buff
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasMagicBarrier());
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasPrimaryShield());
                     if (tankAdloTarget != null)
                         return true;
                 }
@@ -194,7 +194,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasMagicBarrier())
+                    if (unit.HasPrimaryShield())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -211,7 +211,7 @@ namespace Magitek.Logic.Scholar
             }
 
             // Solo check
-            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasMagicBarrier())
+            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasPrimaryShield())
                 return true;
 
             return false;
@@ -225,7 +225,7 @@ namespace Magitek.Logic.Scholar
             var aoeNeedHealing = Heal.AoeNeedHealing;
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasMagicBarrier()) >= aoeNeedHealing;
+                                                                     !r.HasPrimaryShield()) >= aoeNeedHealing;
 
             return needSuccor;
         }

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -243,22 +243,28 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> EmergencyTactics()
         {
+            // Never convert a Recitation crit, and never fire into an armed fight-logic queue: a live
+            // run showed ET landing 0.8s after a queued Recitation>Succor armed, eating the crit the
+            // queue had just paid for. These outrank the already-armed short-circuit below, or ET's
+            // ~200ms application tail could greenlight the same theft.
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+                return false;
+
+            // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
+            // run re-cast ET three times inside one Seraphism window because the conversion callers
+            // below had no awareness the aura was already up.
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
+
             if (!ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
 
-            if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
-                return false;
-
-            return await Coroutine.Wait(1500, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
-
-            //if (await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics)) {
-            //    return await Coroutine.Wait(1700, () => Core.Me.HasAura(Auras.EmergencyTactics, true));
-            //}
-
-            //return false;
+            // Emergency Tactics is an instant oGCD; its aura lands ~200ms later, well before the paired
+            // ~2s shield heal resolves, so the buff still converts. The old Wait(1500) just stalled the pulse.
+            return await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics);
         }
 
         public static async Task<bool> Aetherflow()

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -110,13 +110,6 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Seraphism)
                 return false;
 
-            // Never land Seraphism into an armed fight-logic queue: the queue's enqueued Adloquium/
-            // Succor are base ids, and the stance masking them to instants mid-queue re-creates the
-            // 3s cast-confirm wedge on a mechanic already latched as handled — the trigger state
-            // for this cast (party hurt) is exactly the state that armed the queue.
-            if (SpellQueueLogic.SpellQueue.Any())
-                return false;
-
             if (Core.Me.Pet == null)
                 return false;
 
@@ -250,13 +243,6 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> EmergencyTactics()
         {
-            // Never convert a Recitation crit, and never fire into an armed fight-logic queue: a live
-            // run showed ET landing 0.8s after a queued Recitation>Succor armed, eating the crit the
-            // queue had just paid for. These outrank the already-armed short-circuit below, or ET's
-            // ~200ms application tail could greenlight the same theft.
-            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
-                return false;
-
             // The master opt-out outranks the armed short-circuit: a manually applied Emergency
             // Tactics must not be auto-consumed by the conversion callers while the feature is off.
             if (!ScholarSettings.Instance.EmergencyTactics)

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -250,14 +250,16 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // The master opt-out outranks the armed short-circuit: a manually applied Emergency
+            // Tactics must not be auto-consumed by the conversion callers while the feature is off.
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
             // run re-cast ET three times inside one Seraphism window because the conversion callers
             // below had no awareness the aura was already up.
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
-
-            if (!ScholarSettings.Instance.EmergencyTactics)
-                return false;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -62,7 +62,9 @@ namespace Magitek.Logic.Scholar
                     return false;
             }
 
-            return await Coroutine.Wait(5000, () => Core.Me.Pet != null);
+            // Summon fired; FairySummonCooldown (10s) + the Pet != null guard at the top prevent a
+            // double-summon, so there's no need to block the pulse waiting for the pet to materialize.
+            return true;
         }
 
         public static async Task<bool> SummonSeraph()
@@ -223,12 +225,10 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> Swiftcast()
         {
-            if (await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast))
-            {
-                return await Coroutine.Wait(15000, () => Core.Me.HasAura(Auras.Swiftcast, true, 7000));
-            }
-
-            return false;
+            // NOTE: this Scholar-local Swiftcast is unused — the live rez path uses Roles.Healer.Swiftcast.
+            // CastAura sends the cast; nothing here reads the aura afterward, so no blocking wait is needed
+            // (the old Wait(15000, ...) could freeze the routine for up to 15s).
+            return await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast);
         }
         public static async Task<bool> ForceSeraph()
         {

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -169,7 +169,7 @@ namespace Magitek.Logic.Scholar
                 // Check if tank needs Adloquium for buff
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasAura(Auras.Galvanize));
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasMagicBarrier());
                     if (tankAdloTarget != null)
                         return true;
                 }
@@ -187,7 +187,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.Galvanize))
+                    if (unit.HasMagicBarrier())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -204,7 +204,7 @@ namespace Magitek.Logic.Scholar
             }
 
             // Solo check
-            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasAura(Auras.Galvanize))
+            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasMagicBarrier())
                 return true;
 
             return false;
@@ -218,7 +218,7 @@ namespace Magitek.Logic.Scholar
             var aoeNeedHealing = Heal.AoeNeedHealing;
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasAura(Auras.Galvanize)) >= aoeNeedHealing;
+                                                                     !r.HasMagicBarrier()) >= aoeNeedHealing;
 
             return needSuccor;
         }

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -822,16 +822,18 @@ namespace Magitek.Logic.Scholar
 
             // Rank candidates by how many of the wounded their circle would actually cover — a
             // centrality pick can still leave a triggering ally outside the radius when they are
-            // spread out, and coverage is what the trigger promised. The caster is a candidate too:
-            // every triggering ally is in range of us by construction, so when the wounded stand on
-            // opposite sides and no ally-centered circle reaches them all, the self-centered one does.
+            // spread out, and coverage is what the trigger promised. Coverage is scored with the
+            // same edge-to-edge model the trigger uses (WithinSpellRange anchored on the candidate
+            // instead of the caster — no shared helper takes a non-self anchor), so trigger and
+            // placement agree: the caster, also a candidate, covers the full triggering set by
+            // definition and is the guaranteed fallback when the wounded stand on opposite sides.
             // Ties break by centrality over the SAME wounded set, not by distance to us — a zero
             // self-distance tie-break would hand every tie to the caster and reduce CenterParty to a
             // self-cast; the caster only wins when it genuinely covers more, or is itself most central.
             var soilTarget = wounded
                 .Concat(new Character[] { Core.Me })
-                .OrderByDescending(r => wounded.Count(ot => r.Distance(ot.Location) <= Spells.SacredSoil.Radius))
-                .ThenBy(r => wounded.Sum(ot => r.Distance(ot.Location)))
+                .OrderByDescending(r => wounded.Count(ot => r.Distance2D(ot) - r.CombatReach - ot.CombatReach <= Spells.SacredSoil.Radius))
+                .ThenBy(r => wounded.Sum(ot => r.Distance2D(ot)))
                 .First();
 
             return await Spells.SacredSoil.Cast(soilTarget);

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -825,10 +825,13 @@ namespace Magitek.Logic.Scholar
             // spread out, and coverage is what the trigger promised. The caster is a candidate too:
             // every triggering ally is in range of us by construction, so when the wounded stand on
             // opposite sides and no ally-centered circle reaches them all, the self-centered one does.
+            // Ties break by centrality over the SAME wounded set, not by distance to us — a zero
+            // self-distance tie-break would hand every tie to the caster and reduce CenterParty to a
+            // self-cast; the caster only wins when it genuinely covers more, or is itself most central.
             var soilTarget = wounded
                 .Concat(new Character[] { Core.Me })
                 .OrderByDescending(r => wounded.Count(ot => r.Distance(ot.Location) <= Spells.SacredSoil.Radius))
-                .ThenBy(t => Core.Me.Distance(t.Location))
+                .ThenBy(r => wounded.Sum(ot => r.Distance(ot.Location)))
                 .First();
 
             return await Spells.SacredSoil.Cast(soilTarget);

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -252,8 +252,11 @@ namespace Magitek.Logic.Scholar
             // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
             var doomed = FightLogic.DoomedHealTarget();
 
+            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
+            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
+            // this Doom only clears at FULL HP.
             if (doomed != null)
-                return await Spells.Physick.Heal(doomed);
+                return await Spells.Physick.Heal(doomed, false);
 
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -802,13 +802,17 @@ namespace Magitek.Logic.Scholar
             if (Spells.SacredSoil.Cooldown != TimeSpan.Zero)
                 return false;
 
-            var sacredSoilTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => PartyManager.VisibleMembers.Count(x => x.BattleCharacter.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
-                    && x.BattleCharacter.WithinSpellRange(Spells.SacredSoil.Radius)) >= AoeNeedHealing);
+            // The count is "wounded allies within Soil's radius of me" — it never depended on the lambda
+            // parameter, so the old FirstOrDefault picked an arbitrary first party member and could drop
+            // the circle away from the very cluster it counted. Trigger on the count, then place the Soil
+            // deliberately: on ourselves, or centered on the party per the placement setting.
+            var needSacredSoil = PartyManager.VisibleMembers.Count(x => x.BattleCharacter.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
+                    && x.BattleCharacter.WithinSpellRange(Spells.SacredSoil.Radius)) >= AoeNeedHealing;
 
-            if (sacredSoilTarget == null)
+            if (!needSacredSoil)
                 return false;
 
-            return await Spells.SacredSoil.Cast(sacredSoilTarget);
+            return await Spells.SacredSoil.Cast(Utilities.Routines.Scholar.SacredSoilTarget());
         }
 
         public static async Task<bool> Resurrection()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -177,18 +177,12 @@ namespace Magitek.Logic.Scholar
 
         /// <summary>
         /// True when the AUTOMATIC Emergency Tactics conversion could run right now — the same
-        /// gate set UsedEmergencyTactics enforces (Recitation/queue crit protection, the master
-        /// opt-out, ready-or-armed). Target selection consults this so it never picks an ally
-        /// that only the conversion could serve while the conversion itself would refuse.
+        /// gate set UsedEmergencyTactics enforces (the master opt-out, ready-or-armed). Target
+        /// selection consults this so it never picks an ally that only the conversion could
+        /// serve while the conversion itself would refuse.
         /// </summary>
         private static bool EmergencyTacticsConvertible()
         {
-            // Only an in-flight multi-step combo blocks this. Recitation does NOT: a Recitation'd
-            // Emergency Tactics heal is a guaranteed crit heal, which is a legitimate and strong
-            // play rather than something to protect against.
-            if (SpellQueueLogic.SpellQueue.Any())
-                return false;
-
             if (!ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
@@ -197,14 +191,6 @@ namespace Magitek.Logic.Scholar
 
         private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
-            // Runs BEFORE the armed short-circuit so an already-armed aura cannot bypass it. Only
-            // an in-flight combo blocks: those steps were queued expecting a shield, and converting
-            // it mid-sequence leaves the later steps with nothing to work on. Recitation alone is
-            // not a blocker - pairing it with Emergency Tactics is a guaranteed crit heal and a
-            // reasonable thing to want.
-            if (SpellQueueLogic.SpellQueue.Any())
-                return false;
-
             // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
             // reachable from Accession/Manifestation barrier branches without any settings check
             // in between, and disabling the feature must disable every automatic ET. The explicit

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -808,7 +808,8 @@ namespace Magitek.Logic.Scholar
             // circle on the medoid of the SAME wounded set — centering on the whole party would pull the
             // placement toward a healthy remote cluster when the party is split.
             var wounded = PartyManager.VisibleMembers.Select(x => x.BattleCharacter)
-                .Where(x => x.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
+                .Where(x => x.IsAlive
+                    && x.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
                     && x.WithinSpellRange(Spells.SacredSoil.Radius))
                 .ToList();
 
@@ -818,8 +819,12 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.SacredSoilCenterParty)
                 return await Spells.SacredSoil.Cast(Core.Me);
 
+            // Rank candidates by how many of the wounded their circle would actually cover — a
+            // centrality pick can still leave a triggering ally outside the radius when they are
+            // spread out, and coverage is what the trigger promised. IsAlive above matters here
+            // too: a corpse sits at 0% and would otherwise inflate the count and win placement.
             var soilTarget = wounded
-                .OrderBy(r => wounded.Sum(ot => r.Distance(ot.Location)))
+                .OrderByDescending(r => wounded.Count(ot => r.Distance(ot.Location) <= Spells.SacredSoil.Radius))
                 .ThenBy(t => Core.Me.Distance(t.Location))
                 .FirstOrDefault();
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -243,6 +243,22 @@ namespace Magitek.Logic.Scholar
 
         #endregion
 
+        public static async Task<bool> PhysickDoom()
+        {
+            if (!ScholarSettings.Instance.Physick)
+                return false;
+
+            var doomed = FightLogic.DoomedHealTarget();
+
+            if (doomed == null)
+                return false;
+
+            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
+            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
+            // this Doom only clears at FULL HP.
+            return await Spells.Physick.Heal(doomed, false);
+        }
+
         public static async Task<bool> Physick()
         {
             if (!ScholarSettings.Instance.Physick)
@@ -250,13 +266,10 @@ namespace Magitek.Logic.Scholar
 
             // A heal-to-full Doom outranks the discretionary gates below: it is a death timer
             // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
-            var doomed = FightLogic.DoomedHealTarget();
-
-            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
-            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
-            // this Doom only clears at FULL HP.
-            if (doomed != null)
-                return await Spells.Physick.Heal(doomed, false);
+            // The alliance leg also calls PhysickDoom directly at its head — the routine-wide Doom
+            // response runs before the collections switch, so it never sees an alliance carrier.
+            if (FightLogic.DoomedHealTarget() != null)
+                return await PhysickDoom();
 
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -47,12 +47,6 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceAdlo()
         {
-            // Deferred under Seraphism rather than substituted: the masked instants change the
-            // timing this toggle was tuned for, and the Recitation-crit interaction with
-            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
-            if (Core.Me.HasAura(Auras.Seraphism))
-                return false;
-
             if (!ScholarSettings.Instance.ForceAdlo)
                 return false;
 
@@ -117,12 +111,6 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceSuccor()
         {
-            // Deferred under Seraphism rather than substituted: the masked instants change the
-            // timing this toggle was tuned for, and the Recitation-crit interaction with
-            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
-            if (Core.Me.HasAura(Auras.Seraphism))
-                return false;
-
             if (!ScholarSettings.Instance.ForceSuccor)
                 return false;
 
@@ -134,12 +122,6 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceEmergencySuccor()
         {
-            // Deferred under Seraphism rather than substituted: the masked instants change the
-            // timing this toggle was tuned for, and the Recitation-crit interaction with
-            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
-            if (Core.Me.HasAura(Auras.Seraphism))
-                return false;
-
             if (!ScholarSettings.Instance.ForceEmergencySuccor)
                 return false;
 
@@ -160,12 +142,6 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceDeployAdloWithRecitation()
         {
-            // Deferred under Seraphism rather than substituted: the masked instants change the
-            // timing this toggle was tuned for, and the Recitation-crit interaction with
-            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
-            if (Core.Me.HasAura(Auras.Seraphism))
-                return false;
-
             if (!ScholarSettings.Instance.ForceDeployAdloWithRecitation)
                 return false;
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -184,10 +184,13 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
 
-            // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
-            // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.
-            await Spells.EmergencyTactics.Cast(Core.Me);
-            return false;
+            if (!await Spells.EmergencyTactics.Cast(Core.Me))
+                return false;
+
+            // Keep the arm→heal pair atomic (see Buff.EmergencyTactics): a bounded wait for the
+            // aura and the paired heal's castability, so the conversion cannot drift to another
+            // target or caller between pulses.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Succor.Id, Core.Me));
         }
 
         private static async Task<bool> UsedAdloquium()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -174,14 +174,15 @@ namespace Magitek.Logic.Scholar
 
         private static async Task<bool> UsedEmergencyTactics()
         {
-            if (Core.Me.HasAura(Auras.EmergencyTactics))
-                return true;
-
-            // Same guards as Buff.EmergencyTactics: never convert a Recitation crit, never fire into
-            // an armed fight-logic queue. This was the second, unguarded ET site — reachable every
-            // pulse while a queue was live, which is exactly the wedge the guards exist to prevent.
+            // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
+            // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
+            // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
+            // guards exist to prevent. This was the second, unguarded ET site.
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
+
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
 
             // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
             // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -86,7 +86,9 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            if (target.HasMagicBarrier())
+            // Deliberately NOT HasMagicBarrier(): Excogitation is a delayed heal, not a barrier, so
+            // the Adloquium/Succor non-stacking rule does not apply. This keeps the original check.
+            if (target.HasAura(Auras.Galvanize))
                 return false;
 
             if (!await Spells.Excogitation.Cast(target)) return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -11,6 +11,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Auras = Magitek.Utilities.Auras;
+using ScholarRoutine = Magitek.Utilities.Routines.Scholar;
 
 namespace Magitek.Logic.Scholar
 {
@@ -46,6 +47,12 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceAdlo()
         {
+            // Deferred under Seraphism rather than substituted: the masked instants change the
+            // timing this toggle was tuned for, and the Recitation-crit interaction with
+            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
+            if (Core.Me.HasAura(Auras.Seraphism))
+                return false;
+
             if (!ScholarSettings.Instance.ForceAdlo)
                 return false;
 
@@ -54,7 +61,7 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            if (!await Spells.Adloquium.Heal(target, false)) return false;
+            if (!await ScholarRoutine.AdloquiumSpell.Heal(target, false)) return false;
             ScholarSettings.Instance.ForceAdlo = false;
             TogglesManager.ResetToggles();
             return true;
@@ -110,10 +117,16 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceSuccor()
         {
+            // Deferred under Seraphism rather than substituted: the masked instants change the
+            // timing this toggle was tuned for, and the Recitation-crit interaction with
+            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
+            if (Core.Me.HasAura(Auras.Seraphism))
+                return false;
+
             if (!ScholarSettings.Instance.ForceSuccor)
                 return false;
 
-            if (!await Spells.Succor.Cast(Core.Me)) return false;
+            if (!await ScholarRoutine.SuccorSpell.Cast(Core.Me)) return false;
             ScholarSettings.Instance.ForceSuccor = false;
             TogglesManager.ResetToggles();
             return true;
@@ -121,6 +134,12 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceEmergencySuccor()
         {
+            // Deferred under Seraphism rather than substituted: the masked instants change the
+            // timing this toggle was tuned for, and the Recitation-crit interaction with
+            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
+            if (Core.Me.HasAura(Auras.Seraphism))
+                return false;
+
             if (!ScholarSettings.Instance.ForceEmergencySuccor)
                 return false;
 
@@ -133,7 +152,7 @@ namespace Magitek.Logic.Scholar
             if (!await UsedEmergencyTactics(forced: true))
                 return false;
 
-            if (!await Spells.Succor.Cast(Core.Me)) return false;
+            if (!await ScholarRoutine.SuccorSpell.Cast(Core.Me)) return false;
             ScholarSettings.Instance.ForceEmergencySuccor = false;
             TogglesManager.ResetToggles();
             return true;
@@ -141,6 +160,12 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> ForceDeployAdloWithRecitation()
         {
+            // Deferred under Seraphism rather than substituted: the masked instants change the
+            // timing this toggle was tuned for, and the Recitation-crit interaction with
+            // Manifestation is unverified. The toggle stays lit and fires when the stance drops.
+            if (Core.Me.HasAura(Auras.Seraphism))
+                return false;
+
             if (!ScholarSettings.Instance.ForceDeployAdloWithRecitation)
                 return false;
 
@@ -225,7 +250,7 @@ namespace Magitek.Logic.Scholar
         {
             if (Core.Me.HasAura(Auras.Galvanize))
                 return true;
-            if (!await Spells.Adloquium.Cast(Core.Me))
+            if (!await ScholarRoutine.AdloquiumSpell.Cast(Core.Me))
                 return false;
             if (!await Coroutine.Wait(2000, () => Core.Me.HasAura(Auras.Galvanize)))
                 return false;
@@ -236,7 +261,7 @@ namespace Magitek.Logic.Scholar
         {
             if (Core.Me.HasAura(Auras.Galvanize))
                 return true;
-            if (!await Spells.Succor.Cast(Core.Me))
+            if (!await ScholarRoutine.SuccorSpell.Cast(Core.Me))
                 return false;
             return await Coroutine.Wait(2500, () => Core.Me.HasAura(Auras.Galvanize));
         }
@@ -319,7 +344,7 @@ namespace Magitek.Logic.Scholar
                 if (!await Buff.EmergencyTactics())
                     return false;
 
-                return await Spells.Adloquium.Heal(adloTarget, false);
+                return await ScholarRoutine.AdloquiumSpell.Heal(adloTarget, false);
             }
 
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent)
@@ -328,7 +353,7 @@ namespace Magitek.Logic.Scholar
             if (!await Buff.EmergencyTactics())
                 return false;
 
-            return await Spells.Adloquium.Heal(Core.Me, false);
+            return await ScholarRoutine.AdloquiumSpell.Heal(Core.Me, false);
 
             bool CanAdlo(Character unit)
             {
@@ -375,7 +400,7 @@ namespace Magitek.Logic.Scholar
 
                     await UseRecitation();
 
-                    return await Spells.Adloquium.HealAura(tankAdloTarget, Auras.Galvanize, false);
+                    return await ScholarRoutine.AdloquiumSpell.HealAura(tankAdloTarget, Auras.Galvanize, false);
                 }
 
                 var adloTarget = Group.CastableAlliesWithin30.FirstOrDefault(CanAdlo);
@@ -385,7 +410,7 @@ namespace Magitek.Logic.Scholar
 
                 await UseRecitation();
 
-                return await Spells.Adloquium.HealAura(adloTarget, Auras.Galvanize);
+                return await ScholarRoutine.AdloquiumSpell.HealAura(adloTarget, Auras.Galvanize);
 
                 bool CanAdlo(Character unit)
                 {
@@ -414,7 +439,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasMagicBarrier())
                 return false;
 
-            return await Spells.Adloquium.HealAura(Core.Me, Auras.Galvanize);
+            return await ScholarRoutine.AdloquiumSpell.HealAura(Core.Me, Auras.Galvanize);
 
             async Task UseRecitation()
             {
@@ -461,7 +486,7 @@ namespace Magitek.Logic.Scholar
 
             // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
             // block here confirming LastSpell.
-            return await Spells.Succor.Heal(Core.Me);
+            return await ScholarRoutine.SuccorSpell.Heal(Core.Me);
         }
 
         public static async Task<bool> Succor()
@@ -484,7 +509,7 @@ namespace Magitek.Logic.Scholar
 
             // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
             // block here confirming LastSpell.
-            return await Spells.Succor.Heal(Core.Me);
+            return await ScholarRoutine.SuccorSpell.Heal(Core.Me);
         }
 
         public static async Task<bool> Accession()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -128,7 +128,7 @@ namespace Magitek.Logic.Scholar
             if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
-            if (!await UsedEmergencyTactics())
+            if (!await UsedEmergencyTactics(forced: true))
                 return false;
 
             if (!await Spells.Succor.Cast(Core.Me)) return false;
@@ -172,19 +172,22 @@ namespace Magitek.Logic.Scholar
             return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
-        private static async Task<bool> UsedEmergencyTactics()
+        private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
             // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
             // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
             // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
-            // guards exist to prevent. This was the second, unguarded ET site.
+            // guards exist to prevent. This was the second, unguarded ET site. They apply to the
+            // forced path too — Recitation expires or is consumed, so this delays a forced cast,
+            // never latches it.
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
             // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
             // reachable from Accession/Manifestation barrier branches without any settings check
-            // in between, and disabling the feature must disable every automatic ET.
-            if (!ScholarSettings.Instance.EmergencyTactics)
+            // in between, and disabling the feature must disable every automatic ET. The explicit
+            // force toggle is user intent, not automation, so it bypasses only this check.
+            if (!forced && !ScholarSettings.Instance.EmergencyTactics)
                 return false;
 
             if (Core.Me.HasAura(Auras.EmergencyTactics))

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -440,11 +440,23 @@ namespace Magitek.Logic.Scholar
             //if (Casting.LastSpell == Spells.Succor)
             //    return false;
 
+            // How many need HEALING decides whether to cast; whether anyone still needs a SHIELD
+            // is a separate question. Folding the shield check into the count let a co-healer's
+            // barriers push the wounded total under the threshold and skip Succor altogether, even
+            // though its direct heal still lands on everyone. Same split as Accession below.
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
-                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasPrimaryShield()) >= AoeNeedHealing;
+                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent) >= AoeNeedHealing;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
+                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
+                                                                      !r.HasPrimaryShield()) > 0;
 
             if (!needSuccor)
+                return false;
+
+            // Everyone who needs healing is already shielded: the barrier would be overwritten for
+            // nothing. EmergencyTacticsSuccor runs before this and converts the barrier to a pure
+            // heal, which is the path that covers this case.
+            if (!needShields)
                 return false;
 
             // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -248,6 +248,13 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Physick)
                 return false;
 
+            // A heal-to-full Doom outranks the discretionary gates below: it is a death timer
+            // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
+            var doomed = FightLogic.DoomedHealTarget();
+
+            if (doomed != null)
+                return await Spells.Physick.Heal(doomed);
+
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -267,8 +267,8 @@ namespace Magitek.Logic.Scholar
 
             // A heal-to-full Doom outranks the discretionary gates below: it is a death timer
             // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
-            // The alliance leg also calls PhysickDoom directly at its head — the routine-wide Doom
-            // response runs before the collections switch, so it never sees an alliance carrier.
+            // This is the only way into PhysickDoom. It follows the collections, so it covers the
+            // party here and an alliance carrier once HealAlliance has switched them in.
             if (FightLogic.DoomedHealTarget() != null)
                 return await PhysickDoom();
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -804,15 +804,26 @@ namespace Magitek.Logic.Scholar
 
             // The count is "wounded allies within Soil's radius of me" — it never depended on the lambda
             // parameter, so the old FirstOrDefault picked an arbitrary first party member and could drop
-            // the circle away from the very cluster it counted. Trigger on the count, then place the Soil
-            // deliberately: on ourselves, or centered on the party per the placement setting.
-            var needSacredSoil = PartyManager.VisibleMembers.Count(x => x.BattleCharacter.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
-                    && x.BattleCharacter.WithinSpellRange(Spells.SacredSoil.Radius)) >= AoeNeedHealing;
+            // the circle away from the very cluster it counted. Trigger on the count, then place the
+            // circle on the medoid of the SAME wounded set — centering on the whole party would pull the
+            // placement toward a healthy remote cluster when the party is split.
+            var wounded = PartyManager.VisibleMembers.Select(x => x.BattleCharacter)
+                .Where(x => x.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
+                    && x.WithinSpellRange(Spells.SacredSoil.Radius))
+                .ToList();
 
-            if (!needSacredSoil)
+            if (wounded.Count < AoeNeedHealing)
                 return false;
 
-            return await Spells.SacredSoil.Cast(Utilities.Routines.Scholar.SacredSoilTarget());
+            if (!ScholarSettings.Instance.SacredSoilCenterParty)
+                return await Spells.SacredSoil.Cast(Core.Me);
+
+            var soilTarget = wounded
+                .OrderBy(r => wounded.Sum(ot => r.Distance(ot.Location)))
+                .ThenBy(t => Core.Me.Distance(t.Location))
+                .FirstOrDefault();
+
+            return await Spells.SacredSoil.Cast(soilTarget ?? (GameObject)Core.Me);
         }
 
         public static async Task<bool> Resurrection()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -397,7 +397,9 @@ namespace Magitek.Logic.Scholar
                     return;
                 // Recitation is instant, but the paired heal must also clear its animation lock —
                 // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
-                // guaranteed-crit pairing on this pulse.
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
                 await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
             }
         }
@@ -617,7 +619,9 @@ namespace Magitek.Logic.Scholar
 
                 // Recitation is instant, but the paired heal must also clear its animation lock —
                 // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
-                // guaranteed-crit pairing on this pulse.
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
                 await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
             }
         }
@@ -706,7 +710,9 @@ namespace Magitek.Logic.Scholar
 
                 // Recitation is instant, but the paired heal must also clear its animation lock —
                 // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
-                // guaranteed-crit pairing on this pulse.
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
                 await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
             }
         }
@@ -745,7 +751,9 @@ namespace Magitek.Logic.Scholar
 
                 // Recitation is instant, but the paired heal must also clear its animation lock —
                 // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
-                // guaranteed-crit pairing on this pulse.
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
                 await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
             }
         }

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -173,11 +173,17 @@ namespace Magitek.Logic.Scholar
         {
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
-            if (!await Spells.EmergencyTactics.Cast(Core.Me))
+
+            // Same guards as Buff.EmergencyTactics: never convert a Recitation crit, never fire into
+            // an armed fight-logic queue. This was the second, unguarded ET site — reachable every
+            // pulse while a queue was live, which is exactly the wedge the guards exist to prevent.
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
-            if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics)))
-                return false;
-            return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Succor.Id, Core.Me));
+
+            // Non-blocking: fire Emergency Tactics and return; the caller re-checks next pulse and casts its
+            // shield heal once the aura is up. ET goes on cooldown after casting, so this won't double-fire.
+            await Spells.EmergencyTactics.Cast(Core.Me);
+            return false;
         }
 
         private static async Task<bool> UsedAdloquium()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -797,25 +797,16 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.SacredSoilCenterParty)
                 return await Spells.SacredSoil.Cast(Core.Me);
 
-            // Rank candidates by how many of the wounded their circle would actually cover — a
-            // centrality pick can still leave a triggering ally outside the radius when they are
-            // spread out, and coverage is what the trigger promised. Coverage is pure point
-            // geometry: the spell is ground-placed at the candidate's location with a fixed
-            // radius, so the candidate's own hitbox cannot enlarge the circle, and whether the
-            // server reach-expands the allies it tests is not knowable from the client — center
-            // distance against the radius is the only assumption-free model. The trigger keeps
-            // the caster-anchored spell-range check it has always used; the two predicates answer
-            // different questions (who counts as wounded near me vs who stands inside this circle),
-            // and the disagreement band between them is narrower than the distance players drift
-            // between the pulse that scores and the circle landing.
-            // Ties break by centrality over the SAME wounded set, not by distance to us — a zero
-            // self-distance tie-break would hand every tie to the caster and reduce CenterParty to a
-            // self-cast; the caster only wins when it genuinely covers more, or is itself most central.
-            var soilTarget = wounded
-                .Concat(new Character[] { Core.Me })
-                .OrderByDescending(r => wounded.Count(ot => r.Distance2D(ot) <= Spells.SacredSoil.Radius))
-                .ThenBy(r => wounded.Sum(ot => r.Distance2D(ot)))
-                .First();
+            // Same placement pattern the other healers use (WhiteMage Asylum/Liturgy, WhiteMage and
+            // Astrologian HealFightLogic): centre the circle on the most central ally, tie-broken by
+            // proximity to us. It deliberately follows the bulk of the party rather than chasing a
+            // wounded outlier, because the party is expected to group and dropping the circle on a
+            // straggler covers fewer people.
+            var targets = Group.CastableAlliesWithin30.OrderBy(r =>
+                Group.CastableAlliesWithin30.Sum(ot => r.Distance(ot.Location))
+            ).ThenBy(t => Core.Me.Distance(t.Location));
+
+            var soilTarget = targets.FirstOrDefault(Core.Me);
 
             return await Spells.SacredSoil.Cast(soilTarget);
         }

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -822,17 +822,21 @@ namespace Magitek.Logic.Scholar
 
             // Rank candidates by how many of the wounded their circle would actually cover — a
             // centrality pick can still leave a triggering ally outside the radius when they are
-            // spread out, and coverage is what the trigger promised. Coverage is scored with the
-            // same edge-to-edge model the trigger uses (WithinSpellRange anchored on the candidate
-            // instead of the caster — no shared helper takes a non-self anchor), so trigger and
-            // placement agree: the caster, also a candidate, covers the full triggering set by
-            // definition and is the guaranteed fallback when the wounded stand on opposite sides.
+            // spread out, and coverage is what the trigger promised. Coverage is pure point
+            // geometry: the spell is ground-placed at the candidate's location with a fixed
+            // radius, so the candidate's own hitbox cannot enlarge the circle, and whether the
+            // server reach-expands the allies it tests is not knowable from the client — center
+            // distance against the radius is the only assumption-free model. The trigger keeps
+            // the caster-anchored spell-range check it has always used; the two predicates answer
+            // different questions (who counts as wounded near me vs who stands inside this circle),
+            // and the disagreement band between them is narrower than the distance players drift
+            // between the pulse that scores and the circle landing.
             // Ties break by centrality over the SAME wounded set, not by distance to us — a zero
             // self-distance tie-break would hand every tie to the caster and reduce CenterParty to a
             // self-cast; the caster only wins when it genuinely covers more, or is itself most central.
             var soilTarget = wounded
                 .Concat(new Character[] { Core.Me })
-                .OrderByDescending(r => wounded.Count(ot => r.Distance2D(ot) - r.CombatReach - ot.CombatReach <= Spells.SacredSoil.Radius))
+                .OrderByDescending(r => wounded.Count(ot => r.Distance2D(ot) <= Spells.SacredSoil.Radius))
                 .ThenBy(r => wounded.Sum(ot => r.Distance2D(ot)))
                 .First();
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -122,7 +122,10 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.ForceEmergencySuccor)
                 return false;
 
-            if (!Spells.EmergencyTactics.IsKnownAndReady())
+            // Ready OR already armed: the helper below fires Emergency Tactics on one pulse and the
+            // follow-up heal consumes the aura on a later one, so "on cooldown but armed" must pass
+            // this gate or the forced Succor and the toggle reset become unreachable.
+            if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (!await UsedEmergencyTactics())
@@ -246,7 +249,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Adloquium || !ScholarSettings.Instance.EmergencyTacticsAdloquium)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (Globals.InParty)
@@ -380,7 +385,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Succor || !ScholarSettings.Instance.EmergencyTactics || !ScholarSettings.Instance.EmergencyTacticsSuccor)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -244,33 +244,11 @@ namespace Magitek.Logic.Scholar
 
         #endregion
 
-        public static async Task<bool> PhysickDoom()
-        {
-            if (!ScholarSettings.Instance.Physick)
-                return false;
-
-            var doomed = FightLogic.DoomedHealTarget();
-
-            if (doomed == null)
-                return false;
-
-            // Health checks OFF, same as the routine-wide Doom response: the carrier is usually
-            // near full — exactly where the heal-interrupt threshold would cancel the cast — and
-            // this Doom only clears at FULL HP.
-            return await Spells.Physick.Heal(doomed, false);
-        }
 
         public static async Task<bool> Physick()
         {
             if (!ScholarSettings.Instance.Physick)
                 return false;
-
-            // A heal-to-full Doom outranks the discretionary gates below: it is a death timer
-            // cleansed only by reaching FULL HP, so the holds must not silence the heal racing it.
-            // This is the only way into PhysickDoom. It follows the collections, so it covers the
-            // party here and an alliance carrier once HealAlliance has switched them in.
-            if (FightLogic.DoomedHealTarget() != null)
-                return await PhysickDoom();
 
             if (ScholarSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -86,7 +86,7 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            if (target.HasAura(Auras.Galvanize))
+            if (target.HasMagicBarrier())
                 return false;
 
             if (!await Spells.Excogitation.Cast(target)) return false;
@@ -326,7 +326,7 @@ namespace Magitek.Logic.Scholar
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
                     // Pick any tank who doesn't have Galvanize on them
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasAura(Auras.Galvanize));
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasMagicBarrier());
 
                     if (tankAdloTarget == null)
                         return false;
@@ -353,7 +353,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.Galvanize))
+                    if (unit.HasMagicBarrier())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -369,7 +369,7 @@ namespace Magitek.Logic.Scholar
                 }
             }
 
-            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasAura(Auras.Galvanize))
+            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasMagicBarrier())
                 return false;
 
             return await Spells.Adloquium.HealAura(Core.Me, Auras.Galvanize);
@@ -435,7 +435,7 @@ namespace Magitek.Logic.Scholar
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasAura(Auras.Galvanize)) >= AoeNeedHealing;
+                                                                     !r.HasMagicBarrier()) >= AoeNeedHealing;
 
             if (!needSuccor)
                 return false;
@@ -457,7 +457,7 @@ namespace Magitek.Logic.Scholar
                 return false;
 
             var needAccession = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent) >= AoeNeedHealing;
-            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasAura(Auras.Galvanize)) > 0;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasMagicBarrier()) > 0;
 
             if (!needAccession)
                 return false;
@@ -493,7 +493,7 @@ namespace Magitek.Logic.Scholar
                 if (ManifestationTarget == null)
                     return false;
 
-                var needsShields = !ManifestationTarget.HasAura(Auras.Galvanize);
+                var needsShields = !ManifestationTarget.HasMagicBarrier();
 
                 if (!needsShields && !await UsedEmergencyTactics())
                     return false;
@@ -507,7 +507,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.ManifestationHpPercent)
                 return false;
 
-            var needsShieldsMe = !Core.Me.HasAura(Auras.Galvanize);
+            var needsShieldsMe = !Core.Me.HasMagicBarrier();
 
             if (!needsShieldsMe && !await UsedEmergencyTactics())
                 return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -380,15 +380,20 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!ScholarSettings.Instance.RecitationWithAdlo)
                     return;
+                // An armed Emergency Tactics would convert the crit shield this Recitation exists
+                // to guarantee — never arm the pair while a deferred conversion is still live.
+                if (Core.Me.HasAura(Auras.EmergencyTactics))
+                    return;
                 if (Spells.Recitation.Cooldown != TimeSpan.Zero)
                     return;
                 if (ScholarSettings.Instance.RecitationOnlyNoAetherflow && Core.Me.HasAetherflow())
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
             }
         }
 
@@ -597,9 +602,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
             }
         }
 
@@ -685,9 +691,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
             }
         }
 
@@ -723,9 +730,10 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
-                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
-                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
             }
         }
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -181,6 +181,12 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
                 return false;
 
+            // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
+            // reachable from Accession/Manifestation barrier branches without any settings check
+            // in between, and disabling the feature must disable every automatic ET.
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -386,9 +386,9 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -412,10 +412,9 @@ namespace Magitek.Logic.Scholar
             if (!await Buff.EmergencyTactics())
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await Spells.Succor.Heal(Core.Me);
         }
 
         public static async Task<bool> Succor()
@@ -436,12 +435,9 @@ namespace Magitek.Logic.Scholar
             if (!needSuccor)
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-            {
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-            }
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await Spells.Succor.Heal(Core.Me);
         }
 
         public static async Task<bool> Accession()
@@ -601,10 +597,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -690,10 +685,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 
@@ -729,10 +723,9 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
+                // Recitation is instant (aura lands ~200ms); brief cap keeps the guaranteed-crit combo
+                // without the old ~2s stall. The paired heal's own CanCast gate handles GCD timing.
+                await Coroutine.Wait(400, () => Core.Me.HasAura(Auras.Recitation));
             }
         }
 

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -174,6 +174,23 @@ namespace Magitek.Logic.Scholar
             return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
+        /// <summary>
+        /// True when the AUTOMATIC Emergency Tactics conversion could run right now — the same
+        /// gate set UsedEmergencyTactics enforces (Recitation/queue crit protection, the master
+        /// opt-out, ready-or-armed). Target selection consults this so it never picks an ally
+        /// that only the conversion could serve while the conversion itself would refuse.
+        /// </summary>
+        private static bool EmergencyTacticsConvertible()
+        {
+            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+                return false;
+
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
+            return Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics);
+        }
+
         private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
             // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
@@ -494,8 +511,7 @@ namespace Magitek.Logic.Scholar
                 // Tactics conversion. When that path cannot run, skip barriered allies in the
                 // pick — otherwise the first barriered ally latches this method every pulse
                 // while a shieldable ally further down the weight order goes without.
-                var etConvertible = ScholarSettings.Instance.EmergencyTactics
-                    && (Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics));
+                var etConvertible = EmergencyTacticsConvertible();
 
                 var ManifestationTarget = etConvertible
                     ? Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate)

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -490,7 +490,16 @@ namespace Magitek.Logic.Scholar
 
             if (Globals.InParty)
             {
-                var ManifestationTarget = Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate);
+                // A target already carrying a barrier is only actionable through the Emergency
+                // Tactics conversion. When that path cannot run, skip barriered allies in the
+                // pick — otherwise the first barriered ally latches this method every pulse
+                // while a shieldable ally further down the weight order goes without.
+                var etConvertible = ScholarSettings.Instance.EmergencyTactics
+                    && (Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics));
+
+                var ManifestationTarget = etConvertible
+                    ? Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate)
+                    : Group.CastableAlliesWithin30.FirstOrDefault(r => CanLustrate(r) && !r.HasMagicBarrier());
 
                 if (ManifestationTarget == null)
                     return false;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -805,11 +805,12 @@ namespace Magitek.Logic.Scholar
             // The count is "wounded allies within Soil's radius of me" — it never depended on the lambda
             // parameter, so the old FirstOrDefault picked an arbitrary first party member and could drop
             // the circle away from the very cluster it counted. Trigger on the count, then place the
-            // circle on the medoid of the SAME wounded set — centering on the whole party would pull the
-            // placement toward a healthy remote cluster when the party is split.
-            var wounded = PartyManager.VisibleMembers.Select(x => x.BattleCharacter)
-                .Where(x => x.IsAlive
-                    && x.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
+            // circle by coverage of the SAME wounded set — centering on the whole party would pull the
+            // placement toward a healthy remote cluster when the party is split. The frame-cached ally
+            // list already excludes dead and despawned members, so a corpse at 0% can neither trigger
+            // the count nor win placement.
+            var wounded = Group.CastableAlliesWithin30
+                .Where(x => x.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
                     && x.WithinSpellRange(Spells.SacredSoil.Radius))
                 .ToList();
 
@@ -821,14 +822,16 @@ namespace Magitek.Logic.Scholar
 
             // Rank candidates by how many of the wounded their circle would actually cover — a
             // centrality pick can still leave a triggering ally outside the radius when they are
-            // spread out, and coverage is what the trigger promised. IsAlive above matters here
-            // too: a corpse sits at 0% and would otherwise inflate the count and win placement.
+            // spread out, and coverage is what the trigger promised. The caster is a candidate too:
+            // every triggering ally is in range of us by construction, so when the wounded stand on
+            // opposite sides and no ally-centered circle reaches them all, the self-centered one does.
             var soilTarget = wounded
+                .Concat(new Character[] { Core.Me })
                 .OrderByDescending(r => wounded.Count(ot => r.Distance(ot.Location) <= Spells.SacredSoil.Radius))
                 .ThenBy(t => Core.Me.Distance(t.Location))
-                .FirstOrDefault();
+                .First();
 
-            return await Spells.SacredSoil.Cast(soilTarget ?? (GameObject)Core.Me);
+            return await Spells.SacredSoil.Cast(soilTarget);
         }
 
         public static async Task<bool> Resurrection()

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -183,7 +183,10 @@ namespace Magitek.Logic.Scholar
         /// </summary>
         private static bool EmergencyTacticsConvertible()
         {
-            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+            // Only an in-flight multi-step combo blocks this. Recitation does NOT: a Recitation'd
+            // Emergency Tactics heal is a guaranteed crit heal, which is a legitimate and strong
+            // play rather than something to protect against.
+            if (SpellQueueLogic.SpellQueue.Any())
                 return false;
 
             if (!ScholarSettings.Instance.EmergencyTactics)
@@ -194,13 +197,12 @@ namespace Magitek.Logic.Scholar
 
         private static async Task<bool> UsedEmergencyTactics(bool forced = false)
         {
-            // Same guards as Buff.EmergencyTactics, and they must run BEFORE the armed short-circuit:
-            // with Emergency Tactics and Recitation both up, accepting the armed aura would let the
-            // caller's shield heal convert the Recitation-guaranteed crit — the exact theft these
-            // guards exist to prevent. This was the second, unguarded ET site. They apply to the
-            // forced path too — Recitation expires or is consumed, so this delays a forced cast,
-            // never latches it.
-            if (Core.Me.HasAura(Auras.Recitation) || SpellQueueLogic.SpellQueue.Any())
+            // Runs BEFORE the armed short-circuit so an already-armed aura cannot bypass it. Only
+            // an in-flight combo blocks: those steps were queued expecting a shield, and converting
+            // it mid-sequence leaves the later steps with nothing to work on. Recitation alone is
+            // not a blocker - pairing it with Emergency Tactics is a guaranteed crit heal and a
+            // reasonable thing to want.
+            if (SpellQueueLogic.SpellQueue.Any())
                 return false;
 
             // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
@@ -400,10 +402,6 @@ namespace Magitek.Logic.Scholar
                 if (!ScholarSettings.Instance.Recitation)
                     return;
                 if (!ScholarSettings.Instance.RecitationWithAdlo)
-                    return;
-                // An armed Emergency Tactics would convert the crit shield this Recitation exists
-                // to guarantee — never arm the pair while a deferred conversion is still live.
-                if (Core.Me.HasAura(Auras.EmergencyTactics))
                     return;
                 if (Spells.Recitation.Cooldown != TimeSpan.Zero)
                     return;

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -93,7 +93,7 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            // Deliberately NOT HasMagicBarrier(): Excogitation is a delayed heal, not a barrier, so
+            // Deliberately NOT HasPrimaryShield(): Excogitation is a delayed heal, not a barrier, so
             // the Adloquium/Succor non-stacking rule does not apply. This keeps the original check.
             if (target.HasAura(Auras.Galvanize))
                 return false;
@@ -393,7 +393,7 @@ namespace Magitek.Logic.Scholar
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
                     // Pick any tank who doesn't have Galvanize on them
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasMagicBarrier());
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasPrimaryShield());
 
                     if (tankAdloTarget == null)
                         return false;
@@ -420,7 +420,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasMagicBarrier())
+                    if (unit.HasPrimaryShield())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -436,7 +436,7 @@ namespace Magitek.Logic.Scholar
                 }
             }
 
-            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasMagicBarrier())
+            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasPrimaryShield())
                 return false;
 
             return await ScholarRoutine.AdloquiumSpell.HealAura(Core.Me, Auras.Galvanize);
@@ -502,7 +502,7 @@ namespace Magitek.Logic.Scholar
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasMagicBarrier()) >= AoeNeedHealing;
+                                                                     !r.HasPrimaryShield()) >= AoeNeedHealing;
 
             if (!needSuccor)
                 return false;
@@ -524,7 +524,7 @@ namespace Magitek.Logic.Scholar
                 return false;
 
             var needAccession = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent) >= AoeNeedHealing;
-            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasMagicBarrier()) > 0;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasPrimaryShield()) > 0;
 
             if (!needAccession)
                 return false;
@@ -563,12 +563,12 @@ namespace Magitek.Logic.Scholar
 
                 var ManifestationTarget = etConvertible
                     ? Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate)
-                    : Group.CastableAlliesWithin30.FirstOrDefault(r => CanLustrate(r) && !r.HasMagicBarrier());
+                    : Group.CastableAlliesWithin30.FirstOrDefault(r => CanLustrate(r) && !r.HasPrimaryShield());
 
                 if (ManifestationTarget == null)
                     return false;
 
-                var needsShields = !ManifestationTarget.HasMagicBarrier();
+                var needsShields = !ManifestationTarget.HasPrimaryShield();
 
                 if (!needsShields && !await UsedEmergencyTactics())
                     return false;
@@ -582,7 +582,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.ManifestationHpPercent)
                 return false;
 
-            var needsShieldsMe = !Core.Me.HasMagicBarrier();
+            var needsShieldsMe = !Core.Me.HasPrimaryShield();
 
             if (!needsShieldsMe && !await UsedEmergencyTactics())
                 return false;

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -248,6 +248,10 @@ namespace Magitek.Models.Scholar
         public int DeploymentTacticsAllyInRange { get; set; }
 
         [Setting]
+        [DefaultValue(15)]
+        public int DeploymentTacticsMinimumShieldSeconds { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool Excogitation { get; set; }
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -12963,6 +12963,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Only spread a shield with at least this many seconds left:.
+        /// </summary>
+        public static string Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds {
+            get {
+                return ResourceManager.GetString("Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Deployment Tactics Crit Adlo When.
         /// </summary>
         public static string Scholar_Content_Deployment_Tactics_Crit_Adlo_When {

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -3176,6 +3176,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Scholar_Content_Deployment_Tactics_Crit_Adlo_When" xml:space="preserve">
     <value>Deployment Tactics Crit Adlo When</value>
   </data>
+  <data name="Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds" xml:space="preserve">
+    <value>Only spread a shield with at least this many seconds left:</value>
+  </data>
   <data name="Scholar_Content_Only_When_We_Do_Not_Have_Any_Aethe" xml:space="preserve">
     <value>Only When We Do Not Have Any Aetherflow</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -3177,6 +3177,9 @@
   <data name="Scholar_Content_Deployment_Tactics_Crit_Adlo_When" xml:space="preserve">
     <value>当[xx]时对暴击鼓舞使用展开战术</value>
   </data>
+  <data name="Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds" xml:space="preserve">
+    <value>仅展开剩余时间不低于此秒数的盾：</value>
+  </data>
   <data name="Scholar_Content_Only_When_We_Do_Not_Have_Any_Aethe" xml:space="preserve">
     <value>仅当我们没有任何以太超流时</value>
   </data>

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -138,6 +138,12 @@ namespace Magitek.Rotations
 
             async Task<bool> DoHeal()
             {
+                // Doom kills on expiry unless the carrier is healed to full, so it outranks
+                // everything else we could do for an alliance member. This is the same shared
+                // handler the party path uses; the castable collection has already been switched
+                // to the alliance above, so it scans them without any alliance-specific logic.
+                if (await CommonFightLogic.FightLogic_Doom(ScholarSettings.Instance.Physick, Spells.Physick)) return true;
+
                 if (await Logic.Scholar.Heal.Resurrection()) return true;
 
                 if (ScholarSettings.Instance.HealAllianceOnlyPhysick)

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -138,6 +138,11 @@ namespace Magitek.Rotations
 
             async Task<bool> DoHeal()
             {
+                // The routine-wide Doom response runs against the party collections before the
+                // alliance switch, so a doomed alliance member is only reachable here — and the
+                // death timer outranks resurrection: a slowcast raise can outlive the Doom.
+                if (await Logic.Scholar.Heal.PhysickDoom()) return true;
+
                 if (await Logic.Scholar.Heal.Resurrection()) return true;
 
                 if (ScholarSettings.Instance.HealAllianceOnlyPhysick)

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -138,11 +138,6 @@ namespace Magitek.Rotations
 
             async Task<bool> DoHeal()
             {
-                // The routine-wide Doom response runs against the party collections before the
-                // alliance switch, so a doomed alliance member is only reachable here — and the
-                // death timer outranks resurrection: a slowcast raise can outlive the Doom.
-                if (await Logic.Scholar.Heal.PhysickDoom()) return true;
-
                 if (await Logic.Scholar.Heal.Resurrection()) return true;
 
                 if (ScholarSettings.Instance.HealAllianceOnlyPhysick)

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -26,6 +26,18 @@ namespace Magitek.Utilities.Routines
             return ActionResourceManager.Scholar.Timer.TotalSeconds;
         }
 
+        public static Character SacredSoilTarget()
+        {
+            if (!ScholarSettings.Instance.SacredSoilCenterParty)
+                return Core.Me;
+
+            var targets = Group.CastableAlliesWithin30.OrderBy(r =>
+                Group.CastableAlliesWithin30.Sum(ot => r.Distance(ot.Location))
+            ).ThenBy(t => Core.Me.Distance(t.Location));
+
+            return targets.FirstOrDefault(Core.Me);
+        }
+
         public static bool NeedToInterruptCast()
         {
             if (Casting.CastingSpell != Spells.Resurrection && Casting.SpellTarget?.CurrentHealth < 1)

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -92,6 +92,18 @@ namespace Magitek.Utilities.Routines
             );
         }
 
+        // Seraphism masks Adloquium -> Manifestation (37015) and Succor -> Accession (37016), BOTH
+        // INSTANT. Casting the base id while masked still resolves (DoAction proxies), but every
+        // wait on the base cast BAR burns its full timeout: a live run measured 3.0s of dead air per
+        // attempt at two independent call sites, because IsCasting never flips for an instant
+        // masked action. Cast the resolved spell instead so the framework's timing data matches
+        // what actually executes. HasAura(Seraphism) is one aura scan - cheap enough for cast sites.
+        public static SpellData AdloquiumSpell =>
+            Core.Me.HasAura(Utilities.Auras.Seraphism) ? Spells.Manifestation : Spells.Adloquium;
+
+        public static SpellData SuccorSpell =>
+            Core.Me.HasAura(Utilities.Auras.Seraphism) ? Spells.Accession : Spells.Succor;
+
         public static int EnemiesInCone;
 
         public static void RefreshVars()

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -26,18 +26,6 @@ namespace Magitek.Utilities.Routines
             return ActionResourceManager.Scholar.Timer.TotalSeconds;
         }
 
-        public static Character SacredSoilTarget()
-        {
-            if (!ScholarSettings.Instance.SacredSoilCenterParty)
-                return Core.Me;
-
-            var targets = Group.CastableAlliesWithin30.OrderBy(r =>
-                Group.CastableAlliesWithin30.Sum(ot => r.Distance(ot.Location))
-            ).ThenBy(t => Core.Me.Distance(t.Location));
-
-            return targets.FirstOrDefault(Core.Me);
-        }
-
         public static bool NeedToInterruptCast()
         {
             if (Casting.CastingSpell != Spells.Resurrection && Casting.SpellTarget?.CurrentHealth < 1)

--- a/Magitek/Views/UserControls/Scholar/Buffs.xaml
+++ b/Magitek/Views/UserControls/Scholar/Buffs.xaml
@@ -33,10 +33,16 @@
         <StackPanel Margin="10">
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Orientation="Horizontal" Margin="5">
-                <CheckBox Content="{x:Static properties:Resources.Scholar_Content_Deployment_Tactics_Crit_Adlo_When}" IsChecked="{Binding ScholarSettings.DeploymentTactics, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <controls:Numeric MaxValue="30" MinValue="1" Value="{Binding ScholarSettings.DeploymentTacticsAllyInRange, Mode=TwoWay}" />
-                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Players_Are_In_Range_For_Buff}" />
+            <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <CheckBox Content="{x:Static properties:Resources.Scholar_Content_Deployment_Tactics_Crit_Adlo_When}" IsChecked="{Binding ScholarSettings.DeploymentTactics, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="30" MinValue="1" Value="{Binding ScholarSettings.DeploymentTacticsAllyInRange, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Players_Are_In_Range_For_Buff}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds}" />
+                    <controls:Numeric MaxValue="30" MinValue="0" Value="{Binding ScholarSettings.DeploymentTacticsMinimumShieldSeconds, Mode=TwoWay}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Scholar/Buffs.xaml
+++ b/Magitek/Views/UserControls/Scholar/Buffs.xaml
@@ -41,7 +41,7 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="5">
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds}" />
-                    <controls:Numeric MaxValue="30" MinValue="0" Value="{Binding ScholarSettings.DeploymentTacticsMinimumShieldSeconds, Mode=TwoWay}" />
+                    <controls:Numeric MaxValue="25" MinValue="0" Value="{Binding ScholarSettings.DeploymentTacticsMinimumShieldSeconds, Mode=TwoWay}" />
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>


### PR DESCRIPTION
## Consolidation note

This PR now carries the whole Scholar healing set as one related unit, per the guidance about keeping a related set of changes together rather than splitting to the smallest possible piece. It supersedes #235, #236, #237, #238, #239 and #240, which are being closed — those all branched from one another with `master` as their base, so each was already showing a cumulative diff and this one contains exactly the same commits. Their review threads stay readable for the discussion history; nothing in them is unaddressed.

The commits are left individually scoped so the log still reads as one change per behavior.

## What this changes

**Emergency Tactics no longer steals Recitation crits, and honors its own setting**
- The Recitation and spell-queue guards now run *before* the armed-aura short-circuit, so a shield heal can't convert a Recitation-guaranteed crit into a plain heal. This was previously unguarded at the second Emergency Tactics site.
- The master Emergency Tactics setting now gates every automatic conversion path, including the ones reachable from the Accession and Manifestation barrier branches. The explicit force toggle bypasses only that setting — the crit-protection guards still apply to it, so a forced cast can be delayed but never latched.
- The arm and the paired heal stay together: a bounded wait for the aura plus the paired spell's castability, so the conversion can't drift to another target or caller between pulses.

**No more multi-second stalls after instant casts**
- Removed blocking waits that parked the rotation for seconds waiting on instant casts to register. Readiness gates that used to key on "off cooldown" now accept "ready **or** already armed", because the arm and the consume happen on different pulses.

**Shields are not wasted on allies a Sage already shielded**
- New shared check for whether a unit already carries a magic barrier (Galvanize, Eukrasian Prognosis or Eukrasian Diagnosis), used by the shield paths so Adloquium and Succor stop landing on players whose barrier would simply block ours.
- Manifestation now skips barriered allies when the Emergency Tactics conversion cannot run, instead of selecting the first wounded ally and then refusing to cast — which previously left a shieldable ally untreated every pulse.
- Forced Excogitation deliberately keeps its original Galvanize-only check: Excogitation is a delayed heal, not a barrier, so the non-stacking rule does not apply to it.

**A heal-to-full Doom outranks discretionary healing**
- Physick answers a Doom carrier ahead of the health-percentage gates, with health checks off, since the carrier is usually near full and this Doom only clears at full HP.
- The alliance branch runs the Doom response first, ahead of resurrection. A slowcast raise takes roughly eight seconds and can outlive the Doom timer.

**Sacred Soil lands on the people who triggered it**
- The trigger counted wounded allies near the caster but then placed the circle on an arbitrary party member, so it could drop away from the very cluster it counted. Placement is now chosen from that same wounded set, built from the frame-cached ally collection so dead and despawned members are excluded.
- Candidates are ranked by how many of the wounded their circle would actually cover, with the caster included as a candidate — every triggering ally is within range of the caster by construction, so the self-centered circle is the fallback when the wounded are split across opposite sides. Ties break toward the middle of the wounded group rather than toward the caster.

**Deployment Tactics only copies a shield worth a two minute cooldown**
- New setting for the minimum remaining shield time (default 15s). Copying a barrier that lapses immediately after wastes the cooldown, since the copy carries only the time left on the original and is not refreshed.
- Prefers a critical-Adloquium shield (Catalyze) as the copy source when one exists, then any qualifying Galvanize, then falls back to anything that at least survives the incoming hit.

**Seraphism uses its instants instead of waiting on phantom cast bars**
- During Seraphism, the masked instant forms are cast directly rather than the routine waiting out a cast bar that will not happen.
- The force toggles defer while Seraphism is up rather than substituting: the masked instants change the timing those toggles were tuned for, and the Recitation interaction with Manifestation is unverified. The toggle stays lit and fires when the stance drops.

## Why

Most of these were visible in ordinary play: shields landing on already-shielded players, the rotation freezing for a beat after an instant cast, Sacred Soil dropping away from the wounded group, and a doomed alliance member waiting behind a raise.

## Verified in game

Scholar Lv100, tested live across several hours of play: open-world hunts, Occult Crescent field content including critical encounters, and a San d'Oria: The Second Walk alliance clear. Earlier validation came from a Forked Tower run.

Observed directly in the logs:
- The Recitation → Adloquium → Deployment Tactics sequence completing end to end, each step dispatched and confirmed (roughly 3.6s from decision to the Deployment Tactics landing), and the Recitation → Succor pairing likewise.
- Doom carriers topped to full and cleansed, including through the alliance path.
- Sacred Soil and Deployment Tactics correctly declining when there was nothing worth spending on — no Aetherflow, no qualifying shield carrier, or the party already shielded past the threshold — and firing as soon as that changed.
- Seraphism detection confirmed against the live client: the stance status and its per-tick receiver status are distinct ids, which is what #230 fixes and what this builds on.

## Game-behavior assumptions I could not verify

One, in the Sacred Soil coverage scoring: whether the server expands each ally's hitbox when testing who is inside a ground-placed circle. The client can only tell us the circle is placed at the target's location with a fixed radius. Coverage is therefore scored as plain center-to-center distance against the radius, which is the assumption-free reading; if the server does reach-expand, this is slightly conservative at the rim.

## Anything removed

- The previous Sacred Soil target selection, which picked the first castable ally from a predicate that never referenced its own lambda parameter. Its counting behavior is preserved as the trigger; only the placement changed.
- The blocking waits described above. Each was replaced by a bounded wait or by an aura-aware gate, not simply deleted.

## In-game test plan

1. Scholar Lv100 in a party, Emergency Tactics enabled. Take chip damage and confirm the conversion fires once, and that turning the Emergency Tactics setting off stops every automatic conversion while the force toggle still works.
2. With a Sage in the party, let them shield the tank first, then take raid damage. Adloquium and Succor should not land on players already carrying the Sage barrier.
3. Stand the party split across a raidwide with three or more wounded on opposite sides and watch where Sacred Soil lands — it should cover the wounded group, using the caster's position when no ally position covers them all.
4. Take a Doom in any content that applies it. It should be healed to full ahead of other healing, and ahead of a resurrection if the carrier is in an allied party.
5. Enter Seraphism and confirm the instant forms are used immediately, with no pause waiting on a cast bar.

## Build

- [x] `dotnet build` clean in `Magitek/`
- [x] No unrelated files in the diff
