### PR TITLE
SCH - Fix Aetherpact never releasing the tank once they are back to full health

### DIFF
--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -489,6 +489,15 @@ namespace Magitek.Logic.Scholar
                 if (unit.CurrentHealthPercent < ScholarSettings.Instance.BreakAetherpactHp)
                     return false;
 
+                // Both thresholds accept 1-100 independently, so a release threshold at or below the
+                // engage threshold would release a tank who immediately qualifies to be re-pacted, and
+                // the pair would alternate until the tank climbed past the engage value - burning
+                // gauge and an oGCD slot each cycle. Requiring the tank to be above the ENGAGE
+                // threshold too makes the two settings coherent whatever they are set to, without
+                // rejecting or silently rewriting the user's numbers.
+                if (unit.CurrentHealthPercent < ScholarSettings.Instance.AetherpactHealthPercent)
+                    return false;
+
                 // Fey Union applies as one of two ids (1222 / 1223), never both at once, so
                 // requiring both here could never be satisfied and this method could never return
                 // a target. Reject only a unit carrying neither. The three other Fey Union checks

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -19,6 +19,16 @@ namespace Magitek.Logic.Scholar
         // Prevents double summoning of fairy
         public static DateTime FairySummonCooldown = DateTime.Now;
 
+        // Aetherpact is a toggle, so a second cast inside the latency window after one lands can
+        // re-establish the pact that was just released. Debounced on time rather than on
+        // Casting.LastSpell: with damage disabled, or no attack target, the Scholar can go a long
+        // while casting nothing else, and LastSpell would then sit on Aetherpact indefinitely and
+        // latch both paths off — the break permanently, which is the failure this file is fixing.
+        private static DateTime AetherpactToggle = DateTime.MinValue;
+
+        private static bool AetherpactToggledRecently =>
+            (DateTime.Now - AetherpactToggle).TotalMilliseconds < 1500;
+
         public static async Task<bool> SummonPet()
         {
             if (Core.Me.Pet != null)
@@ -375,7 +385,7 @@ namespace Magitek.Logic.Scholar
             if (!Globals.PartyInCombat)
                 return false;
 
-            if (Casting.LastSpell == Spells.Aetherpact)
+            if (AetherpactToggledRecently)
                 return false;
 
             if (!ActionManager.HasSpell(Spells.Aetherpact.Id))
@@ -399,7 +409,11 @@ namespace Magitek.Logic.Scholar
             //if (Casting.LastSpell != Spells.Biolysis || Casting.LastSpell != Spells.ArtOfWar || Casting.LastSpell != Spells.Adloquium || Casting.LastSpell != Spells.Succor)
             //    if (await Spells.Ruin2.Cast(Core.Me.CurrentTarget))
             //        return true;
-            return await Spells.Aetherpact.Cast(aetherpactTarget);
+            if (!await Spells.Aetherpact.Cast(aetherpactTarget))
+                return false;
+
+            AetherpactToggle = DateTime.Now;
+            return true;
 
             bool CanAetherpact(GameObject unit)
             {
@@ -429,10 +443,9 @@ namespace Magitek.Logic.Scholar
                 return false;
 
             // Aetherpact is a toggle: cast at a unit that already has Fey Union it ends the channel,
-            // cast again it starts a new one. The aura does not clear the instant the break lands, so
-            // without this the next pulse can re-establish the pact it just released. The same guard
-            // sits on the start path; it only matters here now that this method can actually fire.
-            if (Casting.LastSpell == Spells.Aetherpact)
+            // cast again it starts a new one. The aura does not clear the instant the break lands,
+            // so without a debounce the next pulse can re-establish the pact it just released.
+            if (AetherpactToggledRecently)
                 return false;
 
             if (!Group.CastableAlliesWithin30.Any(r => r.HasAura(Auras.FeyUnion) || r.HasAura(Auras.FeyUnion2)))
@@ -443,7 +456,11 @@ namespace Magitek.Logic.Scholar
             if (aetherpactTarget == null)
                 return false;
 
-            return await Spells.Aetherpact.Cast(aetherpactTarget);
+            if (!await Spells.Aetherpact.Cast(aetherpactTarget))
+                return false;
+
+            AetherpactToggle = DateTime.Now;
+            return true;
 
             bool CanDeAetherpact(GameObject unit)
             {

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -464,6 +464,14 @@ namespace Magitek.Logic.Scholar
 
             bool CanDeAetherpact(GameObject unit)
             {
+                // The pact is only ever placed on a tank (see CanAetherpact), so the unit whose health
+                // and surroundings decide whether to release it has to be that tank. Excluding
+                // ourselves matters because the two Fey Union ids may not both sit on the recipient:
+                // if one of them lands on the Scholar, we would otherwise weigh OUR health and OUR
+                // nearby enemies and release a pact on a tank who is still hurt.
+                if (unit == null || unit == Core.Me || !unit.IsTank())
+                    return false;
+
                 if (unit.EnemiesNearby(6).Count() > ScholarSettings.Instance.AetherpactEnemies)
                     return false;
 

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -428,6 +428,13 @@ namespace Magitek.Logic.Scholar
             if (!ActionManager.HasSpell(Spells.Aetherpact.Id))
                 return false;
 
+            // Aetherpact is a toggle: cast at a unit that already has Fey Union it ends the channel,
+            // cast again it starts a new one. The aura does not clear the instant the break lands, so
+            // without this the next pulse can re-establish the pact it just released. The same guard
+            // sits on the start path; it only matters here now that this method can actually fire.
+            if (Casting.LastSpell == Spells.Aetherpact)
+                return false;
+
             if (!Group.CastableAlliesWithin30.Any(r => r.HasAura(Auras.FeyUnion) || r.HasAura(Auras.FeyUnion2)))
                 return false;
 
@@ -443,10 +450,19 @@ namespace Magitek.Logic.Scholar
                 if (unit.EnemiesNearby(6).Count() > ScholarSettings.Instance.AetherpactEnemies)
                     return false;
 
-                if (unit.CurrentHealthPercent >= ScholarSettings.Instance.BreakAetherpactHp)
+                // Break once the tank is topped up, which is what the option says on the tin
+                // ("Break Aetherpact If Tank Is Full HP Only With N enemies") and what the 100%
+                // default describes. The comparison was the other way round, so the pact was held
+                // exactly while the tank no longer needed it and released only while they were
+                // still hurt — the opposite of the setting, and a straight waste of Fairy Gauge.
+                if (unit.CurrentHealthPercent < ScholarSettings.Instance.BreakAetherpactHp)
                     return false;
 
-                if (!unit.HasAura(Auras.FeyUnion) || !unit.HasAura(Auras.FeyUnion2))
+                // Fey Union applies as one of two ids (1222 / 1223), never both at once, so
+                // requiring both here could never be satisfied and this method could never return
+                // a target. Reject only a unit carrying neither. The three other Fey Union checks
+                // in this file already test them as alternatives.
+                if (!unit.HasAura(Auras.FeyUnion) && !unit.HasAura(Auras.FeyUnion2))
                     return false;
 
                 return true;

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -464,6 +464,12 @@ namespace Magitek.Logic.Scholar
 
             bool CanDeAetherpact(GameObject unit)
             {
+                // Releasing at all is opt-out: some Scholars run the pact as a sustained regen on the
+                // tank and would rather it never drop, which the HP threshold alone cannot express -
+                // there is no value of it that means "never".
+                if (!ScholarSettings.Instance.BreakAetherpact)
+                    return false;
+
                 // The pact is only ever placed on a tank (see CanAetherpact), so the unit whose health
                 // and surroundings decide whether to release it has to be that tank. Excluding
                 // ourselves matters because the two Fey Union ids may not both sit on the recipient:

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -525,6 +525,10 @@ namespace Magitek.Models.Scholar
         public float AetherpactHealthPercent { get; set; }
 
         [Setting]
+        [DefaultValue(true)]
+        public bool BreakAetherpact { get; set; }
+
+        [Setting]
         [DefaultValue(100.0f)]
         public float BreakAetherpactHp { get; set; }
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -13530,6 +13530,33 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Break Aetherpact.
+        /// </summary>
+        public static string Scholar_Content_Break_Aetherpact {
+            get {
+                return ResourceManager.GetString("Scholar_Content_Break_Aetherpact", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Once The Tank Reaches.
+        /// </summary>
+        public static string Scholar_Text_Once_The_Tank_Reaches {
+            get {
+                return ResourceManager.GetString("Scholar_Text_Once_The_Tank_Reaches", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to And There Are.
+        /// </summary>
+        public static string Scholar_Text_And_There_Are {
+            get {
+                return ResourceManager.GetString("Scholar_Text_And_There_Are", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to or less Enemies.
         /// </summary>
         public static string Scholar_Text_or_less_Enemies {

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -3157,6 +3157,15 @@ Does not work if Lightspeed is disabled.</value>
   </data>
   <data name="Scholar_Text_Break_Aetherpact_If_Tank_Is_Full_HP_O" xml:space="preserve">
     <value>Break Aetherpact If Tank Is Full HP Only With</value>
+  </data>
+  <data name="Scholar_Content_Break_Aetherpact" xml:space="preserve">
+    <value>Break Aetherpact</value>
+  </data>
+  <data name="Scholar_Text_Once_The_Tank_Reaches" xml:space="preserve">
+    <value>Once The Tank Reaches</value>
+  </data>
+  <data name="Scholar_Text_And_There_Are" xml:space="preserve">
+    <value>And There Are</value>
   </data>
   <data name="Scholar_Text_or_less_Enemies" xml:space="preserve">
     <value>or less Enemies</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -3158,6 +3158,15 @@
   </data>
   <data name="Scholar_Text_Break_Aetherpact_If_Tank_Is_Full_HP_O" xml:space="preserve">
     <value>如果坦克满血则中断 以太契约</value>
+  </data>
+  <data name="Scholar_Content_Break_Aetherpact" xml:space="preserve">
+    <value>中断以太契约</value>
+  </data>
+  <data name="Scholar_Text_Once_The_Tank_Reaches" xml:space="preserve">
+    <value>当坦克血量达到[xx]</value>
+  </data>
+  <data name="Scholar_Text_And_There_Are" xml:space="preserve">
+    <value>且敌人数量为</value>
   </data>
   <data name="Scholar_Text_or_less_Enemies" xml:space="preserve">
     <value>仅在有[xx]或更少敌人时</value>

--- a/Magitek/Views/UserControls/Scholar/Aetherpact.xaml
+++ b/Magitek/Views/UserControls/Scholar/Aetherpact.xaml
@@ -32,8 +32,18 @@
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
                 </StackPanel>
 
+                <StackPanel Margin="5">
+                    <CheckBox Content="{x:Static properties:Resources.Scholar_Content_Break_Aetherpact}" IsChecked="{Binding ScholarSettings.BreakAetherpact, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+
                 <StackPanel Margin="0,3" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_Break_Aetherpact_If_Tank_Is_Full_HP_O}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_Once_The_Tank_Reaches}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding ScholarSettings.BreakAetherpactHp, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+
+                <StackPanel Margin="0,3" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_And_There_Are}" />
                     <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding ScholarSettings.AetherpactEnemies, Mode=TwoWay}" />
                     <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_or_less_Enemies}" />
                 </StackPanel>


### PR DESCRIPTION
## What this changes

Aetherpact currently starts correctly and then never releases. Two conditions in `CanDeAetherpact` prevent it, and either one alone is enough to make the break unreachable.

**The Fey Union check could never be satisfied.** It read:

```csharp
if (!unit.HasAura(Auras.FeyUnion) || !unit.HasAura(Auras.FeyUnion2))
    return false;
```

which rejects the unit unless it holds **both** ids at once. Fey Union applies as one of two ids — 1222 and 1223, both named "Fey Union" in the status sheet — never both together, so this always returned false and the method could never produce a target. The three other Fey Union checks in the same file already treat them as alternatives; this is the only one that negates them. Now rejects only a unit carrying neither.

**The health comparison was inverted relative to its own setting.** It read:

```csharp
if (unit.CurrentHealthPercent >= ScholarSettings.Instance.BreakAetherpactHp)
    return false;
```

`BreakAetherpactHp` defaults to 100 and the option is presented as *"Break Aetherpact If Tank Is Full HP Only With N enemies"*. So the code declined to break precisely when the tank was full — the case the setting exists to describe — and would only have released while they were still hurt. Flipped to `<`, so a topped-up tank ends the channel.

**One guard added, because the fix makes a latent hazard reachable.** Aetherpact is a toggle: cast at someone who already has Fey Union it ends the channel, cast again it starts a new one. The aura does not clear the instant the break lands, so a second pulse could re-establish the pact it had just released. The start path already guards on `Casting.LastSpell == Spells.Aetherpact`; the break path now does too. This only matters now that the break can fire at all.

The enemy-count condition above these is unchanged and was already correct — it holds the pact while more than N enemies are on the tank.

## Why

Reported from play: the fairy takes the pact at the configured health threshold and then channels indefinitely, draining Fairy Gauge on a tank who is back at full. With both conditions as they were, that is the only possible behaviour.

## Verified against game data

- Status ids 1222 and 1223 both resolve to "Fey Union" in the client's own status sheet, confirming they are alternative applications of one effect rather than two co-applied auras.
- The option's own label and its 100% default establish the intended direction of the health comparison.

## Game-behavior assumptions I could not verify

None. Both changes are read off the aura data and the setting's stated meaning.

## Anything removed

No conditions removed. Two comparisons corrected, one guard added.

## In-game test plan

1. Scholar with a fairy out, in a party, Aetherpact enabled. Let a tank drop below the start threshold (75% by default) and confirm Fey Union begins as it does today.
2. Heal the tank to full with three or fewer enemies on them. Expect the pact to release at 100%, and Fairy Gauge to stop draining.
3. Watch the pulse after the release: the pact must not immediately restart. If it does, the toggle guard is not holding.
4. Repeat with more than N enemies still on the tank and confirm the pact is *held* rather than released, which is the existing enemy-count behaviour.

## Build

- [x] `dotnet build` clean in `Magitek/`
- [x] No unrelated files in the diff
