### PR TITLE
FightLogic - Mitigate the party-wide marked AoEs in the Clyteum

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -6448,7 +6448,10 @@ namespace Magitek.Utilities
                         },
                         Aoes = new List<uint> {
                             48920, // Rubbish Disposal
+                            48928, // Wrathful Wire — marked AoE on every party member, the same shape as
+                                   // Chort's Evil Emission below. Was missing entirely.
                             48929, // Gluttonous Wire
+                            48930, // Gluttonous Wire — second cast id (4.7s; 48929 is the 3.7s variant)
                         },
                         AoeLockOns = null,
                         Knockbacks = null,
@@ -6474,6 +6477,9 @@ namespace Magitek.Utilities
                         Aoes = new List<uint> {
                             48884, // Ripples of Gloom
                             48879, // Bodyweight Exorcism
+                            48885, // Evil Emission — second cast id (4.7s; 50417 is the 4.2s variant).
+                                   // Both occur in a single run, so listing only one left half the
+                                   // occurrences unanswered.
                             50417, // Evil Emission
                             48886, // Profane Pressure
                         },


### PR DESCRIPTION
Three cast ids were missing from the Clyteum, so mechanics that hit the whole party drew no response at all.

**Malphas — Wrathful Wire (48928)** was absent entirely. It puts a head marker on every party member, the same shape as Chort's Evil Emission which is already catalogued below it. Observed in game with all four members marked and the routine continuing its damage rotation through it.

**Chort — Evil Emission (48885)** is a second cast id for the ability already listed as 50417. Both fired in a single run (4.7s and 4.2s casts), so cataloguing one left roughly half the occurrences unanswered.

**Malphas — Gluttonous Wire (48930)** is likewise a second cast id for the already-listed 48929.

That two-cast-ids-per-ability pattern accounts for two of the three additions here, and it is silent when you get it wrong: the mechanic is answered sometimes and not others, which reads as bad luck rather than a gap.

Everything else observed in the dungeon is deliberately left out because mitigation is not the answer for it — Void Dark, Petrifying Beam, Anti-personnel Missile, Tribulation, the Bodyweight Exorcism variants, and Motion Scanner and String Up, which punish acting or standing still rather than dealing party-wide damage.

**Tested:** Not tested in game. The ids were read from a live Clyteum run (ACT network log, cross-checked against the ability names the client reports), but no run has happened since the change, so I have not seen the detection fire. Worth knowing that a wrong id here fails silently rather than loudly — the mechanic simply draws no response, exactly as it did before.

**Sources:** Cast ids and caster identity from the combat log of a Clyteum clear. Mechanic descriptions cross-checked against the Icy Veins dungeon guide, which independently describes Wrathful Wire and Evil Emission as marked AoEs on all players.

**Removals:** None.
