### PR TITLE
FightLogic - Mitigate the party-wide marked AoEs in the Grand Cosmos

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -2788,7 +2788,13 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            18851 //Immortal Anathema
+                            18851, //Immortal Anathema
+                            18285, // Dark Well — AoE marker on every player, immediately after Dark
+                                   // Pulse. Measured 12 casts hitting all four for up to 48% of a
+                                   // health bar each; it was the hardest hit in the fight and drew
+                                   // no response at all.
+                            18282, // Dark Pulse — stack marker; the party groups to split it, so
+                                   // everyone takes a share. Measured 8 hits across all four.
                         },
                         BigAoes = null
                     },
@@ -2800,7 +2806,10 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            18204 //Ode to Lost Love
+                            18204, //Ode to Lost Love
+                            18210, // Ode to Far Winds — AoE marker on every player alongside ground
+                                   // circles. Damage not measured this run, so catalogued on the
+                                   // mechanic description rather than a magnitude.
                         },
                         BigAoes = null
                     },
@@ -2812,7 +2821,9 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            18277 //Culling Blade
+                            18277, //Culling Blade
+                            18267, // Otherworldly Heat — red marker on every player, each becoming a
+                            18268, // cross that explodes. Two cast ids (4.7s and 2.2s).
                         },
                         BigAoes = null
                     }


### PR DESCRIPTION
Each Grand Cosmos boss had exactly one tank buster and one raidwide catalogued. Everything marker-based was missing, so several mechanics that hit the entire party drew no response.

**Seeker of Solitude — Dark Well (18285)** is the significant one. It puts an AoE marker on every player immediately after Dark Pulse. Measured across a full clear: 12 casts, all four party members every time, up to 48% of a health bar each. It was the hardest-hitting ability in the fight and fight logic could not see it.

**Seeker of Solitude — Dark Pulse (18282)** is the stack marker that precedes it. The party groups up to split the damage, so everyone takes a share; measured 8 hits across all four.

**Leannan Sith — Ode to Far Winds (18210)** puts an AoE marker on every player alongside ground circles. Its damage was not measured in this run, so it is catalogued on the mechanic description rather than a magnitude, and sits in the light chain accordingly.

**Lugus — Otherworldly Heat (18267, 18268)** puts a red marker on every player that becomes an exploding cross. Two cast ids for the one mechanic.

Deliberately excluded, because mitigation is the wrong answer: Dark Shock (a single-player circle you dodge — high damage but one victim), Tribulation and Far Wind (broom and seed positioning), Direct Seeding and Gardener's Hymn (add summons), Ode to Fallen Petals (the safe spot is next to the boss, so the answer is to move in), and the Scorching Left/Right and Fire's Ire positionals. Scorching Right in particular measured 95% of a health bar, and a barrier does not save that — it is a side-dodge.

Also left out: Fire's Domain, which measured 11 hits across all four players at 28.7% and is arguably party-wide, but the guide frames it as sequential tethers resolved by positioning. That wants a judgement call rather than being folded in silently here.

**Tested:** Not tested in game. Ids were read from a live Grand Cosmos clear and the damage figures above come from that same run, but the dungeon has not been re-run since the change, so I have not seen the detections fire. A wrong id here is silent — the mechanic just draws no response, as before.

**Sources:** Cast ids, caster identity and per-ability damage as a share of target max HP, all from the combat log of a Grand Cosmos clear. Mechanic descriptions cross-checked against the Icy Veins dungeon guide, which independently describes Dark Well, Ode to Far Winds and Otherworldly Heat as markers on all players, and Dark Pulse as a stack.

**Removals:** None.
