### PR TITLE
FightLogic - Add mitigation for Thornmarch (Hard)

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -66,6 +66,20 @@ namespace Magitek.Utilities
                         },
                         BigAoes = null
                     },
+                    // Order matters. GetEnemyLogicAndEnemy takes the FIRST entry with a live actor
+                    // and only that entry's casts are examined, so when two catalogued moogles are up
+                    // together the later one is unreachable. Pukna Pako and Pukla Puki spawn as a
+                    // pair, so the tank buster goes first as the more urgent of the two.
+                    new Enemy {
+                        Id = 724,
+                        Name = "Pukna Pako the Tailturner",
+                        TankBusters = new List<uint> {
+                            29214, // Moogle Thrust
+                        },
+                        SharedTankBusters = null,
+                        Aoes = null,
+                        BigAoes = null
+                    },
                     new Enemy {
                         Id = 722,
                         Name = "Pukla Puki the Pomburner",
@@ -85,16 +99,6 @@ namespace Magitek.Utilities
                         Aoes = new List<uint> {
                             29211, // Pom Holy
                         },
-                        BigAoes = null
-                    },
-                    new Enemy {
-                        Id = 724,
-                        Name = "Pukna Pako the Tailturner",
-                        TankBusters = new List<uint> {
-                            29214, // Moogle Thrust
-                        },
-                        SharedTankBusters = null,
-                        Aoes = null,
                         BigAoes = null
                     },
                 }

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -29,6 +29,79 @@ namespace Magitek.Utilities
 
             #endregion
 
+            #region A Realm Reborn: Trials
+
+            new Encounter {
+                ZoneId = ZoneId.ThornmarchHard,
+                Name = "Trial: Thornmarch (Hard) - Good King Moggle Mog XII",
+                Expansion = FfxivExpansion.ARealmReborn,
+                Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 725,
+                        Name = "Good King Moggle Mog XII",
+                        TankBusters = null,
+                        SharedTankBusters = new List<uint> {
+                            29205, // Twin Pom Meteor — tank stack marker, both tanks share it.
+                            29206, // Second cast id for the same mechanic.
+                        },
+                        Aoes = new List<uint> {
+                            29217, // Memento Moogle — the unavoidable phase-transition raidwide.
+                                   // Measured 38.2% of a health bar on all eight.
+                            29203, // Mog Stone IV — stack marker; measured 38.8% on seven, because
+                                   // the party is stacked and takes it together.
+                            29210, // Pom Holy — measured 21.1% across all eight.
+                            29192, // Mograin of Death — marker on every player. The King casts the
+                                   // same id the Mooglesguard use.
+                        },
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 721,
+                        Name = "Woolywart Kupqu Kogi",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = new List<uint> {
+                            29191, // Mograin of Death — 2.7s variant.
+                            29192, // Mograin of Death — 5.7s variant. Both occur.
+                        },
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 722,
+                        Name = "Pukla Puki the Pomburner",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = new List<uint> {
+                            29204, // Mog Stone IV — her cast id for the stack the King also throws.
+                            29192, // Mograin of Death
+                        },
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 720,
+                        Name = "Furryfoot Kupli Kipp",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = new List<uint> {
+                            29211, // Pom Holy
+                        },
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 724,
+                        Name = "Pukna Pako the Tailturner",
+                        TankBusters = new List<uint> {
+                            29214, // Moogle Thrust
+                        },
+                        SharedTankBusters = null,
+                        Aoes = null,
+                        BigAoes = null
+                    },
+                }
+            },
+
+            #endregion
+
             #region Heavensward: Alliance Raids
 
             new Encounter {

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -32,7 +32,7 @@ namespace Magitek.Utilities
             #region A Realm Reborn: Trials
 
             new Encounter {
-                ZoneId = ZoneId.ThornmarchHard,
+                ZoneId = 1067,
                 Name = "Trial: Thornmarch (Hard) - Good King Moggle Mog XII",
                 Expansion = FfxivExpansion.ARealmReborn,
                 Enemies = new List<Enemy> {


### PR DESCRIPTION
Thornmarch (Hard) had no encounter entry at all — only the zone id existed — so nothing in the trial drew a mitigation response. This adds one, along with an `A Realm Reborn: Trials` region, since the file had no home for ARR trials.

Every id here was read from a single clear, and the damage figures are measured from that same run as a share of each victim's max HP.

**Good King Moggle Mog XII (725)**
- Memento Moogle (29217) — the unavoidable phase-transition raidwide, 38.2% on all eight.
- Mog Stone IV (29203) — stack marker, 38.8% across seven, since the party takes it together.
- Pom Holy (29210) — 21.1% across all eight.
- Mograin of Death (29192) — marker on every player; the King throws the same id the Mooglesguard use.
- Twin Pom Meteor (29205, 29206) — the tank stack, so `SharedTankBusters` rather than a plain buster.

**Mooglesguard** — Kupqu Kogi (721) casts Mograin of Death under two ids, 29191 and 29192; Pukla Puki (722) has her own Mog Stone IV (29204) plus Mograin; Kupli Kipp (720) casts Pom Holy (29211); Pukna Pako (724) has the Moogle Thrust tank buster (29214).

Left out because mitigation is not the answer: Spinning Mogshield, 1000-kuponze Swipe, Moggleday Night Fever and Pom Bog (all positional), Pom Meteor (a soak), Good King's Decree (a summon), and Pom Cure, which is the boss healing itself. Moogle-Go-Round measured 35.5% but is an arena sweep you walk out of, so it is excluded too.

Two things worth flagging for review:

The trial has no ilvl sync, so the King died before the Third Decree. That means 1000 Kuponze Charge, Mog Comet, Pom Stone III and Mog Creation never cast and have no ids yet — the entry is knowingly incomplete at the tail of the fight. One further cast, id 29187, hit three players for 15.6% and the client reports no name for it; I have left it out rather than catalogue something unidentified.

There is also a second zone id, `ThornmarchHard61` (207), which this entry does not cover. I do not know whether that is the same duty reached by another route; the clear this was built from was zone 1067.

**Tested:** Not tested in game. Ids and damage come from a live clear, but the trial has not been re-run since the entry was added, so no detection has been observed firing. A wrong id fails silently here — the mechanic simply draws no response, which is the current behaviour anyway.

**Sources:** Cast ids, NpcIds and per-ability damage from the combat log and the client's own object data during a Thornmarch (Hard) clear. Mechanic descriptions cross-checked against the Icy Veins trial guide, which independently identifies Memento Moogle as unavoidable, Mog Stone IV and Twin Pom Meteor as stacks, and Moogle Thrust as a tank buster.

**Removals:** None.
