### PR TITLE
FightLogic - Mitigate the marked AoEs and the stack in AAC Heavyweight (M4)

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7675,12 +7675,9 @@ namespace Magitek.Utilities
                             47552, // Splattershed
                             48096, // Splattershed
                             46208, // Venomous Scourge — marked AoE on every player. Measured 22 hits
-                                   // across all eight at up to 62.2% of a health bar.
-                            46209, // Grotesquerie — inflicts Burning Grotesquerie on all players,
-                                   // which resolves as a marked AoE when it expires. The damage lands
-                                   // ~18s later under a different name (Dramatic Lysis, measured 73.6%
-                                   // on all eight) and has no cast line of its own, so this cast is the
-                                   // only thing that can be reacted to.
+                                   // across all eight at up to 62.2% of a health bar, and its damage
+                                   // lands 5.0s after the cast, so mitigation applied on the cast is
+                                   // still up when the hit arrives.
                         },
                         AoeLockOns = new List<uint> {
                             93,    // Stack marker -> Fourth-wall Fusion, which measured 317.9% of a

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7674,8 +7674,23 @@ namespace Magitek.Utilities
                             46228, // The Fixer
                             47552, // Splattershed
                             48096, // Splattershed
+                            46208, // Venomous Scourge — marked AoE on every player. Measured 22 hits
+                                   // across all eight at up to 62.2% of a health bar.
+                            46209, // Grotesquerie — inflicts Burning Grotesquerie on all players,
+                                   // which resolves as a marked AoE when it expires. The damage lands
+                                   // ~18s later under a different name (Dramatic Lysis, measured 73.6%
+                                   // on all eight) and has no cast line of its own, so this cast is the
+                                   // only thing that can be reacted to.
                         },
-                        AoeLockOns = null,
+                        AoeLockOns = new List<uint> {
+                            93,    // Stack marker -> Fourth-wall Fusion, which measured 317.9% of a
+                                   // health bar across six players. Catalogued by marker because the
+                                   // mechanic has NO cast line at all; its only antecedent is Ravenous
+                                   // Reach 11-12s earlier, which is a positional cleave and would
+                                   // mis-time. Marker 93 is the stack marker: it precedes Fourth-wall
+                                   // Fusion here, and lands in the same millisecond as Mog Stone IV in
+                                   // Thornmarch, single-target both times.
+                        },
                         Knockbacks = null,
                         SharedTankBusters = null,
                         BigAoes = null


### PR DESCRIPTION
Lindwurm had its tank buster, The Fixer and Splattershed catalogued, but the marker mechanics were missing. All figures below are measured from a live pull as a share of each victim's max HP.

**Venomous Scourge (46208)** — marked AoE on every player. 22 hits across all eight, up to 62.2%, which is comparable to the Splattershed already listed, so it sits in the same chain.

**Grotesquerie (46209)** — inflicts Burning Grotesquerie on all players, resolving as a marked AoE when it expires. Worth being explicit about why this id: the damage lands roughly 18 seconds later under a *different* name, Dramatic Lysis, measured at 73.6% across all eight, and Dramatic Lysis has no cast line of its own. The Grotesquerie cast is the only thing fight logic can react to.

**Fourth-wall Fusion — catalogued by head marker (93), not cast id.** This is the fight's most dangerous mechanic: 317.9% of a health bar across six players, lethal if the stack is missed. It has no type-20 cast line whatsoever, so cast-id detection cannot see it at all. Its only antecedent cast is Ravenous Reach 11 to 12 seconds earlier, which is itself a positional cleave and would fire mitigation at the wrong moment.

Marker 93 is the stack marker. That is not inferred from this fight alone: it precedes all three Fourth-wall Fusion bursts here on a single target, and it also lands in the same millisecond as Mog Stone IV in Thornmarch, which is likewise a stack. Two unrelated bosses, single target both times.

I deliberately did not add marker 311 alongside it. That one landed on all eight with Mograin of Death and is the spread-on-everyone marker; the spreads in this fight are already covered by cast id above, so listing it would double-detect.

One calibration note for the reviewer: I did not promote anything to `BigAoes` here. The Fixer already sits in `Aoes` at a measured 87.5%, and in a raid tier near-lethal damage is the design rather than a signal — a threshold that makes sense for dungeon content would put almost everything in this fight in the heavy chain.

**Tested:** Not tested in game. Ids, damage and the marker correlation all come from a live M4 pull, but the fight has not been re-run since the change, so no detection has been observed firing. A wrong id is silent rather than loud here.

**Sources:** Cast ids, head markers, and per-ability damage as a share of target max HP from the combat log of an M4 pull, with the marker-to-mechanic correlation cross-checked against a second fight (Thornmarch) in the same session. Mechanic descriptions cross-checked against the Icy Veins guide, which independently describes Venomous Scourge and Dramatic Lysis as marked AoEs on all players and Fourth-wall Fusion as a stack marker on a healer.

**Removals:** None.
