### PR TITLE
FightLogic - Mitigate Barnabas and more of Anima's kit in the Tower of Babil

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -4534,11 +4534,34 @@ namespace Magitek.Utilities
                     }
                 }
             },
+            // Anima's Oblivion (cast id 25359) is left out on purpose. Measured 2026-08-19:
+            // the cast bar runs ~6.0s, then 23697 ticks 15 times across all four players at
+            // ~10.6% of a health bar each over the next 4.3s, and only then does 23872 land for
+            // 49.1% - 13.1s after the cast starts. Reacting on the cast puts a barrier up in time
+            // for the chip damage, which consumes it, so it is gone before the hit that matters;
+            // Sacred Soil's 15s survives but with under 2s to spare.
+            //
+            // What would make it catalogueable is a per-mechanic reaction delay. HodlCastTimeRemaining
+            // already resolves (encounter, enemyLogic, enemy) and every job reaches it - the four
+            // healer HealFightLogic files and CommonFightLogic alike - so a hold keyed on
+            // enemy.CastingSpellId would let this one entry react at cast-end instead of cast-start
+            // without touching any other reaction. Flagging rather than building it: the shape of
+            // that (data on the mechanic vs a lookup in FightLogic) is your call.
             new Encounter {
                 ZoneId = ZoneId.TheTowerOfBabil,
                 Name = "Dungeon: The Tower of Babil",
                 Expansion = FfxivExpansion.Endwalker,
                 Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 10279,
+                        Name = "Barnabas",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = new List<uint> {
+                            25324 //Shocking Force
+                        },
+                        BigAoes = null
+                    },
                     new Enemy {
                         Id = 10281,
                         Name = "Lugae",
@@ -4565,8 +4588,15 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
-                            25344 //Mega Graviton
+                            25344, //Mega Graviton
+                            25352, //Erupting Pain
+                            25351, //Erupting Pain (second cast id)
+                            25347  //Boundless Pain - casts as 25347, lands as 25348
                         },
+                        AoeLockOns = new List<uint> {
+                            139 //Erupting Pain marks every player ~5s before the hit
+                        },
+                        // 25359, //Oblivion - deliberately NOT catalogued; see the note above this encounter
                         BigAoes = null
                     },
                     new Enemy {
@@ -4575,8 +4605,15 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
-                            25344 //Mega Graviton
+                            25344, //Mega Graviton
+                            25352, //Erupting Pain
+                            25351, //Erupting Pain (second cast id)
+                            25347  //Boundless Pain - casts as 25347, lands as 25348
                         },
+                        AoeLockOns = new List<uint> {
+                            139 //Erupting Pain marks every player ~5s before the hit
+                        },
+                        // 25359, //Oblivion - deliberately NOT catalogued; see the note above this encounter
                         BigAoes = null
                     }
                 }

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -4560,6 +4560,9 @@ namespace Magitek.Utilities
                         Aoes = new List<uint> {
                             25324 //Shocking Force
                         },
+                        AoeLockOns = new List<uint> {
+                            62 //Shocking Force stacks the party on one marked player ~5s ahead
+                        },
                         BigAoes = null
                     },
                     new Enemy {


### PR DESCRIPTION
**Tested:** SCH Lv100, full Tower of Babil clear 2026-08-19 — but **the entries themselves are not tested in game.** They were derived from that run's ACT log after the fact, so every id below is measured, and none has been seen to *fire* yet. A wrong id fails silently, so absence of a detection line on the next run means the id is wrong rather than the mechanic not happening.

**What prompted it:** Barnabas took the party for 29.4% of a health bar twice with no response. He has no entry at all — the zone lists only Lugae and Anima, one AoE each.

**Detection itself is fine.** Positive control from the same run: both existing ids (`25338` Thermal Suppression, `25344` Mega Graviton) were detected and drew responses. The gaps are catalogue-only.

### Barnabas (10279) — new

- `25324` **Shocking Force** — two casts, each hit all four party members, max 29.4% of a health bar, has its own cast bar.

### Anima (10285 / 10288) — additions

- `25352` + `25351` **Erupting Pain** — 41.1%, all four players, 5.0s from cast to damage.
- `25347` **Boundless Pain** — casts as `25347`, lands as `25348` for 30.0% on all four about 9.2s later, then a long `25349` tail at 5.5%.
- `AoeLockOns = { 139 }` — **this is the part that actually fixes Erupting Pain.** It marks every player 5.0s ahead of the hit. 139 is already on the global `CommonAoeLockOns` set, but `PresentLockOnCounts` only unions that set in when `FightLogicIncludeCommonAoeLockOnsTest` is enabled, so by default relevance comes solely from each enemy's own `AoeLockOns` — and Anima declared none. The marker was seen and discarded.

### Deliberately left out

- **Oblivion `25359` — commented, with a note in the file.** Cast bar ~6.0s, then `23697` ticks 15× across all four at ~10.6% each over 4.3s, and only then `23872` for 49.1% — 13.1s after the cast starts. Reacting on the cast puts a barrier up in time for the chip damage, which eats it before the hit that matters. It needs a per-mechanic reaction delay to be worth cataloguing; the note sketches where that would go (`HodlCastTimeRemaining` already resolves the enemy and every job reaches it) but I have not built it — the shape is your call.
- **Ground and Pound `25322`** (Barnabas, 28.2%, single target, 4 casts) and **Surface Missile `25335`** (Lugae, 20.2%, single target, 8 casts). Both look like tank busters, but three of Ground and Pound's four resolutions carry an empty target field, so I would rather see one clean pull than guess a category.
- Everything under ~2% of a health bar, and the `23697`/`25348`/`25349` damage halves, which have no cast line of their own.

**Sources:** ACT network log 2026-08-19, `Network_30208_20260819.log`, run window 12:51–13:08 local. NpcIds read from AddCombatant; cast bars from type 20; victim counts and damage from types 21/22; the head marker from type 27 field [6] (`008B` = 139).
