### PR TITLE
FightLogic - Mitigate all four Headsmen in the Meso Terminal, not just one

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -6521,6 +6521,59 @@ namespace Magitek.Utilities
                         SharedTankBusters = null,
                         BigAoes = null
                     },
+                    new Enemy {
+                        Id = 14049,
+                        Name = "Pale Headsman",
+                        TankBusters = new List<uint> {
+                            43589, // Relentless Torment - the tank's duel mechanic. Follows Will
+                                   // Breaker (44856), which is the interruptible half. Four hits in
+                                   // 1.8s totalling 55.9% of a health bar.
+                        },
+                        Aoes = new List<uint> {
+                            43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14048,
+                        Name = "Ravenous Headsman",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14050,
+                        Name = "Pestilent Headsman",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14239,
+                        Name = "Hooded Headsman",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            43579, // Head-splitting Roar - this one casts the sibling id, and it is
+                                   // the half that lands the damage: 25.3% on all four.
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
                 }
             },
             new Encounter {


### PR DESCRIPTION
**Tested:** SCH Lv100, full Meso Terminal clear 2026-08-19. The entries themselves are **not tested in game** — derived from that run's ACT log afterwards, so every id is measured but none has been seen to fire.

**What prompted it:** the Headsmen encounter has five enemies and only one was catalogued. The tank ate a 55.9% buster with no reaction available, because the enemy casting it has no entry.

### The gap

`Head-splitting Roar` is cast by **four** of the variants, but was only listed under Bloody Headsman — so the other three cast the same id and nothing answered. Adds `43578` to Pale, Ravenous and Pestilent, and `43579` to Hooded, which casts the sibling id and is the half that lands the damage (25.3% on all four).

### Pale Headsman `14049` — the tank buster

`43589` **Relentless Torment**, the tank's duel mechanic. Measured 2026-08-19 16:02:38:

```
16:02:38.117  CAST 43589 -> tank      (5.0s cast)
16:02:43.113  hit  43589   17.0%
16:02:43.515  hit  43590   13.3%
16:02:44.228  hit  43590   12.8%
16:02:44.938  hit  43590   12.8%
```

Four hits in 1.8s, **55.9% of a health bar**. Reacting to the cast gives the full 5s. `43590` is the follow-up damage id and is deliberately not listed — it resolves inside the same window, so the cast id covers it.

### Deliberately excluded

Most of the shared Headsman kit is dodgeable, and the hits-per-cast ratio says so plainly:

- `43587` Dismemberment — 32 casts, **0** damaging hits
- `43592` Flaying Flail — 30 casts, **1** hit
- `43593` Peal of Judgment — 10 casts, 1 hit
- `43577` Lawless Pursuit, `43595` Chopping Block, `43596` Execution Wheel, `43597` Serial Torture — all zero

`43588` **Death Penalty** is also left out. It is the healer's role mechanic and its payload is a cleansable Doom (status `5185`), which the existing Esuna path already handles via `HasAnyDispellableAura()` — it needs a cleanse, not mitigation, and filing it as a TankBuster would point tank cooldowns at the wrong player.

`44856` **Will Breaker** is the interruptible cast preceding Relentless Torment. Not listed because the corpus has no interrupt category — flagging it as a possible feature rather than forcing it into an existing one.

### Checked and deliberately unchanged

**Immortal Remains and Chirurgeon General are already correct.** Memory of the Pyre `43824` measured 139.7% of a health bar and Memory of the Storm `43822` measured 69.7%, but both cast in the **same millisecond** as their already-catalogued cast ids (`43823`, `43821`), so reacting to those gives the full 5s of lead and adding the damage ids would only double-detect. The 139.7% was a Pictomancer taking a tankbuster after the tank fell off the arena edge, not a missed reaction.

`43797` Sensory Deprivation is party-wide per the duty guide but only 3.8% — not worth a GCD.

**Sources:** ACT network log `Network_30208_20260819.log`, run window 15:51–16:11 local. NpcIds from AddCombatant field [9]; cast bars from type 20; damage and victim counts from types 21/22 filtered to damage-flagged lines landing on players. Mechanic roles cross-checked against the duty guide.
