### PR TITLE
FightLogic - Mitigate the stacks and marked AoEs in Anamnesis Anyder

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -2483,7 +2483,9 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19306 //Inscrutability
+                            19306, //Inscrutability
+                            19322 //Ectoplasmic Ray - stack. Damage lands as 19320 on all four
+                                  //players 5.25s after this cast, up to 30.4% of a health bar.
                         },
                         BigAoes = null
                     },
@@ -2496,7 +2498,9 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19306 //Inscrutability
+                            19306, //Inscrutability
+                            19322 //Ectoplasmic Ray - stack. Damage lands as 19320 on all four
+                                  //players 5.25s after this cast, up to 30.4% of a health bar.
                         },
                         BigAoes = null
                     },
@@ -2506,7 +2510,13 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19288 //The Final Verse
+                            19288, //The Final Verse
+                            19296 //Open Hearth - 4 hits from one cast, all four players, 33.1%
+                        },
+                        AoeLockOns = new List<uint>() {
+                            96 //Wanderer's Pyre marks three players in the same millisecond as
+                               //its cast. On the global common-marker set, which is inert unless
+                               //the enemy declares it.
                         },
                         BigAoes = null
                     },
@@ -2517,7 +2527,14 @@ namespace Magitek.Utilities
                             19340 //Bonebreaker
                         },
                         SharedTankBusters = null,
-                        Aoes = null,
+                        Aoes = new List<uint>() {
+                            19325, //Falling Water - hits TWO players at once (damage id 19326),
+                                   //and not the tanks, so the party answer is the right one.
+                            19327 //Flying Fount - stack (damage id 19328), up to 52.1%
+                        },
+                        AoeLockOns = new List<uint>() {
+                            62 //Flying Fount's stack marker
+                        },
                         BigAoes = null
                     }
                 }

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -2529,16 +2529,40 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19323, //Seabed Ceremony - hits the whole party, and it is the most
-                                   //frequent damage in the fight: 7 casts in one clear, up to
-                                   //41.7%. Damage id is 19324.
-                            19325, //Falling Water - marks TWO players at once (damage id 19326),
-                                   //and not the tanks, so the party answer is the right one.
-                            19327 //Flying Fount - stack (damage id 19328), up to 52.1%
+                            //Each of these fires as a PAIR sharing one cast time: a self-targeted
+                            //id with EffectRange 0, and the id that carries the geometry and the
+                            //damage. Both show a cast bar, so both are listed - which one the
+                            //client reports as the enemy's current cast is not something we can
+                            //tell from a log, and an id that never matches is simply inert.
+                            //Measured 2026-08-20: the r0 half dealt zero damage every time.
+                            19323, //Seabed Ceremony - the most frequent damage in the fight,
+                                   //7 casts in one clear, up to 41.7%. This half is single r0.
+                            19324, //Seabed Ceremony - circle r60, carries the damage (7/7 hits)
+                            19325, //Falling Water - marks TWO players at once, and not the tanks,
+                                   //so the party answer is the right one. This half is single r0.
+                            19326, //Falling Water - circle r8, carries the damage
+                            19327, //Flying Fount - stack, up to 52.1%. This half is single r0.
+                            19328 //Flying Fount - circle r6, carries the damage
                         },
                         AoeLockOns = new List<uint>() {
                             62 //Flying Fount's stack marker
                         },
+                        BigAoes = null
+                    },
+                    //Trash, not a boss - the only such entry here. Included on a player ruling:
+                    //Barreling Smash is a lock-on charge along a line at whoever it picks, and it
+                    //is worth a single-target barrier on that player. Filed under TankBusters
+                    //because that is the path that shields the named target; the victim is not
+                    //necessarily a tank. No head marker precedes it (checked type-27 lines in the
+                    //8s before each cast), so the 5.0s cast bar is the only signal we get.
+                    new Enemy {
+                        Id = 9280,
+                        Name = "Io Ousia",
+                        TankBusters = new List<uint>() {
+                            20004 //Barreling Smash - line charge, 30.5% on its single victim
+                        },
+                        SharedTankBusters = null,
+                        Aoes = null,
                         BigAoes = null
                     }
                 }

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -2514,9 +2514,10 @@ namespace Magitek.Utilities
                             19296 //Open Hearth - 4 hits from one cast, all four players, 33.1%
                         },
                         AoeLockOns = new List<uint>() {
+                            62, //Open Hearth's stack marker
                             96 //Wanderer's Pyre marks three players in the same millisecond as
-                               //its cast. On the global common-marker set, which is inert unless
-                               //the enemy declares it.
+                               //its cast. Both of these are on the global common-marker set,
+                               //which is inert unless the enemy declares it.
                         },
                         BigAoes = null
                     },
@@ -2528,7 +2529,10 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19325, //Falling Water - hits TWO players at once (damage id 19326),
+                            19323, //Seabed Ceremony - hits the whole party, and it is the most
+                                   //frequent damage in the fight: 7 casts in one clear, up to
+                                   //41.7%. Damage id is 19324.
+                            19325, //Falling Water - marks TWO players at once (damage id 19326),
                                    //and not the tanks, so the party answer is the right one.
                             19327 //Flying Fount - stack (damage id 19328), up to 52.1%
                         },


### PR DESCRIPTION
**Tested:** SCH Lv100, full Anamnesis Anyder clear 2026-08-19. The entries themselves are **not tested in game** — measured from that run's ACT log afterwards, so every id is real but none has been seen to fire yet.

**Why:** the zone had one AoE for Kyklops and nothing but a tank buster for Rukshs Dheem. Seven casts of a party-wide hit went unanswered in a single clear.

### Unknown `9260` / `9261`

- `19322` **Ectoplasmic Ray** — a stack. Damage lands as `19320` on all four players 5.25s after the cast, up to 30.4%.

### Kyklops `9263`

- `19296` **Open Hearth** — stack marker on one player, 4 hits from one cast on all four, up to 33.1%.
- `AoeLockOns = { 62, 96 }` — Open Hearth's stack marker, and Wanderer's Pyre's spread marker (`96`, placed on three players in the same millisecond as its cast). Both are on the global `CommonAoeLockOns` set, which is inert unless the enemy declares it, so neither did anything before.

### Rukshs Dheem `9264`

- `19323` **Seabed Ceremony** — the big one. **Seven casts in one clear**, every one hitting all four players, up to 41.7%. Damage id `19324`; `19323` is the self-targeted telegraph, cast in the same millisecond, ~4.0s lead.
- `19325` **Falling Water** — marks two random players at once (damage `19326`), and not the tanks. Filed under `Aoes` rather than `SharedTankBusters` deliberately: the targets are random, so the party answer is the right one.
- `19327` **Flying Fount** — a stack (damage `19328`), up to 52.1%.
- `AoeLockOns = { 62 }` — Flying Fount's stack marker.

### Deliberately excluded

Nearly everything else in this dungeon is a dodge, and the hits-per-cast ratio separates them cleanly:

| | hits/cast |
|---|---|
| Open Hearth, the Final Verse | 4.0, 3.7 |
| 2,000-mina swing, 2,000-mina swipe | 1.5, 1.0 |
| Raging Glower, Eye of the Cyclone, Terrible Hammer, Terrible Blade | 0.0 |

Swing reads 72.9% and swipe 36.9%, which is why damage magnitude is the wrong sort key — both are avoidable, and the duty guide agrees ("watch the boss's cast bar to avoid"). Also excluded: Scrutiny, Luminous Ray, Clearout, Setback, Command Current, Rising Tide and both Depth Grip variants, all positional.

**Note on markers:** Ectoplasmic Ray is a stack but ACT logged **no** head marker for it — three type-27 lines exist in the whole Unknown fight and all three are the Fetid Fang telegraph. Open Hearth and Flying Fount do log marker 62. The channel is inconsistent, so every entry here reacts to the cast id, with `AoeLockOns` as a bonus where a marker was actually observed.

**Sources:** ACT network log `Network_30208_20260819.log`, run window 16:34–16:56 local. NpcIds from AddCombatant field [9]; cast bars from type 20; damage and victim counts from types 21/22 filtered to damage-flagged lines landing on players; markers from type 27 field [6]. Classifications cross-checked against the duty guide and confirmed by the player mid-run.
