### PR TITLE
AST & SGE - Stop reporting an interrupted heal as a failed resurrection

### DIFF
--- a/Magitek/Utilities/Routines/Astrologian.cs
+++ b/Magitek/Utilities/Routines/Astrologian.cs
@@ -34,7 +34,7 @@ namespace Magitek.Utilities.Routines
 
             if (Casting.CastingSpell != Spells.Ascend && Casting.SpellTarget?.CurrentHealth < 1)
             {
-                Logger.Error($@"Stopped Resurrection: Unit Died");
+                Logger.Error($@"Stopped Cast: Unit Died");
                 return true;
             }
 

--- a/Magitek/Utilities/Routines/Sage.cs
+++ b/Magitek/Utilities/Routines/Sage.cs
@@ -59,7 +59,7 @@ namespace Magitek.Utilities.Routines
 
             if (Casting.CastingSpell != Spells.Egeiro && Casting.SpellTarget?.CurrentHealth < 1)
             {
-                Logger.Error($@"Stopped cast: Unit Died");
+                Logger.Error($@"Stopped Cast: Unit Died");
                 return true;
             }
 


### PR DESCRIPTION
Log text only — no behaviour change.

**Tested:** AST Lv100, Occult Crescent North Horn critical encounters, 2026-08-19. Observed the incorrect line live, then confirmed the guard's condition in source.

**What was wrong:** Astrologian's died-mid-cast guard is `Casting.CastingSpell != Spells.Ascend`, so it only runs when we are *not* resurrecting — but it logged `Stopped Resurrection: Unit Died`. Healing a target who dies mid-cast therefore reported a resurrection failure. Scholar and White Mage already log `Stopped Cast: Unit Died` from the identical guard.

It matters more than a typo normally would, because it misreports on the one job where you would least want to misdiagnose raise behaviour: chasing "why did my Ascend get cancelled" leads to a guard that never touches Ascend.

Sage's copy said `Stopped cast:` with a lowercase c; included so all four healers emit the same string and the line is greppable.

| job | before | after |
|---|---|---|
| Astrologian | `Stopped Resurrection: Unit Died` | `Stopped Cast: Unit Died` |
| Sage | `Stopped cast: Unit Died` | `Stopped Cast: Unit Died` |
| Scholar | `Stopped Cast: Unit Died` | unchanged |
| White Mage | `Stopped Cast: Unit Died` | unchanged |

**Sources:** none needed — no claim about game behaviour. The guards' own conditions are the evidence.

**Removals:** none. No condition, guard, or control flow touched; both hunks change a string literal.
