### PR TITLE
BLM - Fix state handling, Flare Star deadlocks, and AoE logic

### DIFF
--- a/Magitek/Logic/BlackMage/Aoe.cs
+++ b/Magitek/Logic/BlackMage/Aoe.cs
@@ -1,4 +1,4 @@
-﻿using Buddy.Coroutines;
+using Buddy.Coroutines;
 using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
@@ -10,98 +10,156 @@ using System.Threading.Tasks;
 using static ff14bot.Managers.ActionResourceManager.BlackMage;
 using BlackMageRoutine = Magitek.Utilities.Routines.BlackMage;
 
-
 namespace Magitek.Logic.BlackMage
 {
     internal static class Aoe
     {
         public static async Task<bool> Foul()
         {
+            // Do not cast if AoE is disabled globally
             if (!AoeControl.Enabled)
                 return false;
 
-            //requires Polyglot
+            // Do not cast if we do not have a Polyglot stack available
             if (!PolyglotStatus)
                 return false;
 
-            //Can't use whatcha don't have
+            // Do not cast if Foul is not unlocked yet
             if (!Spells.Foul.IsKnown())
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Do not waste a GCD on Foul if Flare Star is fully stacked and ready to fire
             if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
                 return false;
 
-            // If we're moving in combat
+            // Movement logic: Handle casting while on the run
             if (MovementManager.IsMoving)
             {
-                // HARDCODED: Level 80 is when Foul becomes instant cast via trait
                 // This is a trait check, not a spell availability check
                 // If we have instant cast Foul (level 80+) and have Swiftcast/Triplecast,
                 // don't cast Foul - use procs on other spells instead
                 if (Core.Me.ClassLevel >= 80 && (Core.Me.HasAura(Auras.Swiftcast) || Core.Me.HasAura(Auras.Triplecast)))
                     return false;
 
-                // HARDCODED: Level 80 is when Foul becomes instant cast via trait
-                // This is a trait check, not a spell availability check
-                // If below level 80 (Foul has cast time) and we don't have Swiftcast/Triplecast,
-                // skip Foul - can't cast it while moving
+                // If under level 80 (Foul has a cast time) and we lack instant-cast buffs, we cannot cast while moving
                 if (Core.Me.ClassLevel < 80 && !Core.Me.HasAura(Auras.Swiftcast) && !Core.Me.HasAura(Auras.Triplecast))
                     return false;
+
+                return await Spells.Foul.Cast(Core.Me.CurrentTarget);
             }
 
-            // Always cast if we're about to overcap Polyglot (prevent waste)
+            // Always prevent overcapping Polyglot stacks regardless of user settings
             if (BlackMageRoutine.WillOvercapPolyglot())
                 return await Spells.Foul.Cast(Core.Me.CurrentTarget);
 
-            // In AoE, don't save charges - use them for more damage
-            return await Spells.Foul.Cast(Core.Me.CurrentTarget);
+            // Respect the user's saved charges setting before using Foul as a stationary filler
+            if (PolyglotCount <= BlackMageSettings.Instance.SaveXenoglossyCharges)
+                return false;
+
+            // Standard use: Use Foul as instant filler in Umbral Ice to safely weave Transpose (only when above saved charge threshold)
+            if (UmbralStacks > 0 && UmbralHearts == 3)
+                return await Spells.Foul.Cast(Core.Me.CurrentTarget);
+
+            return false;
+        }
+
+        public static async Task<bool> AoeTranspose()
+        {
+            // Transpose must be unlocked
+            if (!Spells.Transpose.IsKnown())
+                return false;
+
+            // Dawntrail AoE Loop: In Umbral Ice, once we secure 3 Umbral Hearts, Transpose back to Astral Fire
+            if (UmbralStacks > 0 && UmbralHearts == 3)
+            {
+                return await Spells.Transpose.Cast(Core.Me);
+            }
+
+            // Finisher Transition: In Astral Fire, if MP is depleted (<800), Transpose to Umbral Ice
+            if (AstralStacks > 0 && Core.Me.CurrentMana < 800)
+            {
+                // Safety check: Do not Transpose yet if we still need to execute our Flare Star finisher
+                if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
+                    return false;
+
+                return await Spells.Transpose.Cast(Core.Me);
+            }
+
+            return false;
+        }
+        
+        public static async Task<bool> UseAoeEther()
+        {
+            // Verify user has opted into using Ethers for AoE
+            if (!BlackMageSettings.Instance.UseEtherInAoe)
+                return false;
+
+            // Only use ethers to extend the Astral Fire phase
+            if (AstralStacks == 0)
+                return false;
+
+            // Do not pop an ether if we already have enough MP to cast Flare
+            if (Core.Me.CurrentMana >= 800)
+                return false;
+
+            // Hold ether until after Flare Star is consumed
+            if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
+                return false;
+
+            // Respect settings: Only block Ether if Manafont is actually permitted to be used
+            if (BlackMageSettings.Instance.ManaFont && Spells.ManaFont.IsKnownAndReady())
+                return false;
+
+            // Try each ether from best to worst; any granting 800+ MP enables an extra Flare
+            foreach (var etherId in BlackMageRoutine.AoeEthers)
+            {
+                if (await Ether.UseEther((int)etherId))
+                    return true;
+            }
+
+            return false;
         }
 
         public static async Task<bool> Flare()
         {
+            // Do not cast if AoE is disabled globally
             if (!AoeControl.Enabled)
                 return false;
 
-            //Can't use in Umbral Ice anymore
+            // Flare is strictly an Astral Fire ability
             if (UmbralStacks > 0)
                 return false;
 
-            //If flarestar is ready, cast it
-            if (AstralSoulStacks == 6)
+            // Priority: Execute Flare Star if fully stacked before casting another Flare
+            if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
                 return false;
 
+            // Spell must be unlocked
             if (!Spells.Flare.IsKnown())
                 return false;
 
-            // if (Core.Me.CurrentMana < 800)
-            //     return false;
+            // Must have Astral Fire active or enough MP to initiate it (800 MP is Flare's base cost)
+            if (AstralStacks == 0 && Core.Me.CurrentMana < 800)
+                return false;
 
-            // HARDCODED: Level 100 has special Flare behavior (likely trait-based)
-            // This is a trait check, not a spell availability check
-            if (Core.Me.ClassLevel == 100)
-            {
-                if (AstralStacks > 0)
-                    return await Spells.Flare.Cast(Core.Me.CurrentTarget);
-            }
-
-            //No longer worth casting two HighFire2
-
-            //Force flare after manafont
-            if (Casting.LastSpellWas(Spells.ManaFont))
-                return await Spells.Flare.Cast(Core.Me.CurrentTarget);
+            // If we are below the base MP cost (800) and lack Umbral Hearts to reduce the AF penalty, we cannot cast Flare
+            if (Core.Me.CurrentMana < 800 && UmbralHearts == 0)
+                return false;
 
             return await Spells.Flare.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> FlareStar()
         {
+            // Spell must be unlocked
             if (!Spells.FlareStar.IsKnown())
                 return false;
 
+            // Target must be valid and ability ready
             if (!Spells.FlareStar.IsKnownAndReadyAndCastableAtTarget())
                 return false;
 
+            // Prevent casting Flare Star immediately after a transition spell to avoid breaking sequences
             if (Casting.LastSpellWas(Spells.Fire3) || Casting.LastSpellWas(Spells.Blizzard3))
                 return false;
 
@@ -110,25 +168,28 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Freeze()
         {
+            // Do not cast if AoE is disabled globally
             if (!AoeControl.Enabled)
                 return false;
 
-            //If we don't have Freeze, how can we cast it?
+            // Spell must be unlocked
             if (!Spells.Freeze.IsKnown())
                 return false;
 
+            // Prevent double-casting Freeze
             if (Casting.LastSpellWas(Spells.Freeze))
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Never execute Freeze if we are holding a Flare Star proc
             if (AstralSoulStacks == 6)
                 return false;
 
-            //Can only use in Umbral Ice
-            if (UmbralStacks != 3)
+            // Freeze is strictly an Umbral Ice ability
+            if (UmbralStacks == 0)
                 return false;
 
-            if (Core.Me.CurrentMana == 10000)
+            // Do not cast Freeze if we already have max Umbral Hearts
+            if (UmbralHearts == 3)
                 return false;
 
             return await Spells.Freeze.Cast(Core.Me.CurrentTarget);
@@ -136,34 +197,37 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Thunder4()
         {
+            // Do not cast if AoE is disabled globally
             if (!AoeControl.Enabled)
                 return false;
 
+            // Base Thunder II must be unlocked
             if (!Spells.Thunder2.IsKnown())
                 return false;
 
+            // Respect user settings for AoE Thunder
             if (!BlackMageSettings.Instance.ThunderAoe)
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Do not waste a GCD on Thunder if Flare Star is ready
             if (AstralSoulStacks == 6)
                 return false;
 
-            // If the last spell we cast is triple cast, stop
-            if (Casting.LastSpellWas(Spells.Triplecast))
-                return false;
+            // Consume Thunderhead proc immediately in rotation weave slots without waiting for DoT expiration
+            bool hasThunderhead = Core.Me.HasAura(Auras.Thunderhead);
 
-            // If we have the triplecast aura, stop
-            if (Core.Me.HasAura(Auras.Triplecast))
-                return false;
+            if (!hasThunderhead)
+            {
+                // Do not clip Thunder if the target already has the DoT with plenty of time remaining
+                if (Core.Me.CurrentTarget.HasAnyAura(ThunderAuras, true, BlackMageSettings.Instance.ThunderRefreshSecondsLeft * 1000 + 500))
+                    return false;
+            }
 
-            //If we don't need to refresh Thunder, skip
-            if (Core.Me.CurrentTarget.HasAnyAura(ThunderAuras, true, BlackMageSettings.Instance.ThunderRefreshSecondsLeft * 1000 + 500))
-                return false;
-
+            // Time To Die (TTD) check: Don't cast DoTs on trash mobs that are about to die anyway
             if (BlackMageSettings.Instance.UseTTDForThunderAoe && Combat.CurrentTargetCombatTimeLeft <= BlackMageSettings.Instance.ThunderAoeTTDSeconds && !Core.Me.CurrentTarget.IsBoss())
                 return false;
 
+            // Spell Upgrade Fallbacks
             if (!Spells.Thunder4.IsKnown())
                 return await Spells.Thunder2.Cast(Core.Me.CurrentTarget);
 
@@ -175,79 +239,82 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Fire2()
         {
+            // Do not cast if AoE is disabled globally
             if (!AoeControl.Enabled)
                 return false;
 
+            // Spell must be unlocked
             if (!Spells.Fire2.IsKnown())
                 return false;
 
-            //No stack, open with Fire3
-            if (AstralStacks < 3 && UmbralStacks == 0)
+            // Immediate priority: If we have 3 Umbral Hearts in Umbral Ice, transition back to AF right now.
+            if (UmbralStacks > 0 && UmbralHearts == 3)
+            {
+                if (Spells.HighFireII.IsKnown()) 
+                    return await Spells.HighFireII.Cast(Core.Me.CurrentTarget);
                 return await Spells.Fire2.Cast(Core.Me.CurrentTarget);
+            }
 
-            //If flarestar is ready, cast it
+            // Neutral/Dropped Stance Recovery: Cast Fire 2 to enter Astral Fire
+            if (AstralStacks < 3 && UmbralStacks == 0)
+            {
+                if (Spells.HighFireII.IsKnown()) return await Spells.HighFireII.Cast(Core.Me.CurrentTarget);
+                return await Spells.Fire2.Cast(Core.Me.CurrentTarget);
+            }
+
+            // Priority: Stop casting fillers if Flare Star is fully stacked and ready
             if (AstralSoulStacks == 6)
                 return false;
 
+            // In Umbral Ice, do not cast Fire 2 if we still need to secure Umbral Hearts
             if (UmbralStacks == 3 && UmbralHearts != 3)
                 return false;
 
-            //Try and keep from doublecasting or using after manafont
-            // if (Casting.LastSpell == Spells.Fire2
-            //     || Casting.LastSpell == Spells.HighFireII
-            //     || Casting.LastSpell == Spells.ManaFont)
-            //     return false;
-
-            if (Core.Me.HasAura(Auras.Triplecast))
-                return false;
-
-            // HARDCODED: Level 58 is when Umbral Hearts trait unlocks (allows two Flares)
-            // This is a trait check, not a spell availability check
-            // At level 58+, Umbral Hearts allow two Flares, so Fire2 is less valuable
-            // Below level 58, we need Fire2 in Astral Fire (after Transpose from Umbral Ice)
+            // Standard Rotation Rule (Lv 58+): Only use Fire 2 during UI -> AF transitions or if we dropped AF3
             if (Core.Me.ClassLevel >= 58)
             {
                 if (AstralStacks == 3 || UmbralStacks < 3)
                     return false;
             }
-            else
-            {
-                // // Below level 58, need to be in Astral Fire to cast Fire2
-                // if (AstralStacks >= 1)
-                //     return false;
-            }
 
+            // Spell Upgrade Fallbacks
+            if (Spells.HighFireII.IsKnown()) return await Spells.HighFireII.Cast(Core.Me.CurrentTarget);
             return await Spells.Fire2.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> Blizzard2()
         {
+            // Do not cast if AoE is disabled globally
             if (!AoeControl.Enabled)
                 return false;
 
+            // Spell must be unlocked
             if (!Spells.Blizzard2.IsKnown())
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Stop casting fillers if Flare Star is fully stacked and ready
             if (AstralSoulStacks == 6)
                 return false;
 
+            // Prevent double-casting or breaking Manafont timing
             if (Casting.LastSpellWas(Spells.Blizzard2)
                 || Casting.LastSpellWas(Spells.HighBlizzardII)
                 || Casting.LastSpellWas(Spells.ManaFont))
                 return false;
 
+            // Do not cast if we are trying to build Astral Fire or if we are already in max Umbral Ice
             if (AstralStacks < 3 || UmbralStacks == 3)
                 return false;
 
+            // Skip low-level filler if we already have the MP to re-enter Astral Fire
             if (Core.Me.CurrentMana >= 1600)
                 return false;
 
-            if (Spells.ManaFont.IsKnownAndReady())
-                return false;
-
+            // Spell Upgrade Fallbacks
+            if (Spells.HighBlizzardII.IsKnown()) return await Spells.HighBlizzardII.Cast(Core.Me.CurrentTarget);
             return await Spells.Blizzard2.Cast(Core.Me.CurrentTarget);
         }
+
         private static readonly uint[] ThunderAuras =
         {
             Auras.Thunder,
@@ -258,14 +325,9 @@ namespace Magitek.Logic.BlackMage
             Auras.HighThunder2
         };
 
-        /**********************************************************************************************
-        *                              Limit Break
-        * ********************************************************************************************/
         public static bool ForceLimitBreak()
         {
             return MagicDps.ForceLimitBreak(Spells.Skyshard, Spells.Starstorm, Spells.Meteor, Spells.Blizzard);
         }
     }
 }
-
-

--- a/Magitek/Logic/BlackMage/Aoe.cs
+++ b/Magitek/Logic/BlackMage/Aoe.cs
@@ -75,8 +75,9 @@ namespace Magitek.Logic.BlackMage
                 return await Spells.Transpose.Cast(Core.Me);
             }
 
-            // Finisher Transition: In Astral Fire, if MP is depleted (<800), Transpose to Umbral Ice
-            if (AstralStacks > 0 && Core.Me.CurrentMana < 800)
+            // Finisher Transition: In Astral Fire, Transpose to Umbral Ice when out of filler MP
+            int minAoeMp = Spells.Flare.IsKnown() ? 800 : 3000;
+            if (AstralStacks > 0 && Core.Me.CurrentMana < minAoeMp)
             {
                 // Safety check: Do not Transpose yet if we still need to execute our Flare Star finisher
                 if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
@@ -87,7 +88,7 @@ namespace Magitek.Logic.BlackMage
 
             return false;
         }
-        
+
         public static async Task<bool> UseAoeEther()
         {
             // Verify user has opted into using Ethers for AoE
@@ -110,8 +111,21 @@ namespace Magitek.Logic.BlackMage
             if (BlackMageSettings.Instance.ManaFont && Spells.ManaFont.IsKnownAndReady())
                 return false;
 
+            // Define common high-tier Ether item IDs (HQ and NQ) that grant sufficient MP
+
             // Try each ether from best to worst; any granting 800+ MP enables an extra Flare
-            foreach (var etherId in BlackMageRoutine.AoeEthers)
+            foreach (var etherId in new uint[] {
+                36257,
+                36256, // Super Ether (HQ / NQ)
+                31854,
+                31853, // Max-Ether (HQ / NQ)
+                27999,
+                27998, // Mega-Ether (HQ / NQ)
+                23172,
+                23171, // X-Ether (HQ / NQ)
+                19845,
+                19844  // Hi-Ether (HQ / NQ)
+            })
             {
                 if (await Ether.UseEther((int)etherId))
                     return true;
@@ -250,7 +264,7 @@ namespace Magitek.Logic.BlackMage
             // Immediate priority: If we have 3 Umbral Hearts in Umbral Ice, transition back to AF right now.
             if (UmbralStacks > 0 && UmbralHearts == 3)
             {
-                if (Spells.HighFireII.IsKnown()) 
+                if (Spells.HighFireII.IsKnown())
                     return await Spells.HighFireII.Cast(Core.Me.CurrentTarget);
                 return await Spells.Fire2.Cast(Core.Me.CurrentTarget);
             }

--- a/Magitek/Logic/BlackMage/Buff.cs
+++ b/Magitek/Logic/BlackMage/Buff.cs
@@ -1,4 +1,4 @@
-﻿using Buddy.Coroutines;
+using Buddy.Coroutines;
 using ff14bot;
 using ff14bot.Managers;
 using Magitek.Extensions;
@@ -15,91 +15,112 @@ namespace Magitek.Logic.BlackMage
     {
         public static async Task<bool> Triplecast()
         {
+            // Spell must be unlocked and user setting enabled
             if (!Spells.Triplecast.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.TripleCast)
                 return false;
 
+            // Do not pop Triplecast if Flare Star is ready, as it is an instant cast and would waste a charge
             if (AstralSoulStacks == 6)
                 return false;
 
-            if (!Core.Me.CurrentTarget.HasAnyAura(ThunderAuras, true, BlackMageSettings.Instance.ThunderRefreshSecondsLeft * 1000 + 500))
+            // Cooldown/charge availability check
+            if (Spells.Triplecast.Cooldown != TimeSpan.Zero && Spells.Triplecast.Charges == 0)
                 return false;
 
+            // Do not pop Triplecast if we already have instant cast buffs active
+            if (Core.Me.HasAura(Auras.Triplecast) || Core.Me.HasAura(Auras.Swiftcast))
+                return false;
+
+            // Restrict Triplecast entirely to Astral Fire to maximize damage output
+            if (AstralStacks == 0)
+                return false;
+
+            // Do not pop Triplecast if we are out of MP and about to transition, unless we need it to move
+            if (Core.Me.CurrentMana < 4800 && !MovementManager.IsMoving)
+                return false;
+
+            // Emergency Movement: Pop Triplecast if moving while fully stacked in Astral Fire
             if ((MovementManager.IsMoving && AstralStacks == 3))
                 return await Spells.Triplecast.Cast(Core.Me);
 
+            // Setting check: Prevent using the last charge for stationary damage if the user saves it for moving
             if (BlackMageSettings.Instance.TripleCastWhileMoving && Spells.Triplecast.Charges <= 1)
-                return false;
-
-            // Don't dot if time in combat less than 30 seconds
-            //if (Combat.CombatTotalTimeLeft <= 30)
-            //    return false;
-
-            // Add check for charges with new update
-            if (Spells.Triplecast.Cooldown != TimeSpan.Zero
-                && Spells.Triplecast.Charges == 0)
-                return false;
-
-            // Check to see if triplecast is already up
-            if (Core.Me.HasAura(Auras.Triplecast))
-                return false;
-
-            // Dun cast truplecast when in umbral
-            if (UmbralStacks > 0)
                 return false;
 
             return await Spells.Triplecast.Cast(Core.Me);
         }
-        //Sharpcast was removed from game.
+
+        public static async Task<bool> Swiftcast()
+        {
+            // Standard API readiness check
+            if (!Spells.Swiftcast.IsKnownAndReady())
+                return false;
+
+            // Do not pop Swiftcast if we already have instant cast buffs active
+            if (Core.Me.HasAura(Auras.Triplecast) || Core.Me.HasAura(Auras.Swiftcast))
+                return false;
+
+            // Restrict Swiftcast strictly to Astral Fire to maximize damage
+            if (AstralStacks == 0)
+                return false;
+
+            // Never pop Swiftcast if out of MP; next action will be Blizzard III (Ice transition) which already casts fast
+            if (Core.Me.CurrentMana < 1600 && !MovementManager.IsMoving)
+                return false;
+
+            // Use Swiftcast strictly to maintain uptime during Movement
+            if (MovementManager.IsMoving)
+                return await Spells.Swiftcast.Cast(Core.Me);
+
+            // Use Swiftcast for high-cost, long-cast spells at the end of the Fire phase (specifically Despair)
+            if (Core.Me.CurrentMana > 800 && Core.Me.CurrentMana <= 2400)
+                return await Spells.Swiftcast.Cast(Core.Me);
+
+            return false;
+        }
 
         public static async Task<bool> LeyLines()
         {
+            // Spell must be unlocked and user setting enabled
             if (!Spells.LeyLines.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.LeyLines)
                 return false;
 
-            if (BlackMageSettings.Instance.LeyLinesBossOnly
-                && !Core.Me.CurrentTarget.IsBoss())
+            // Check if user has restricted LeyLines to boss encounters only
+            if (BlackMageSettings.Instance.LeyLinesBossOnly && !Core.Me.CurrentTarget.IsBoss())
                 return false;
 
-            // Don't use if time in combat less than 30 seconds
-            //if (Combat.CombatTotalTimeLeft <= 30)
-            //    return false;
-
-            //Don't use while moving
+            // Do not drop LeyLines while moving
             if (MovementManager.IsMoving)
                 return false;
 
+            // Prevent double-casting if LeyLines are already deployed
             if (Core.Me.HasAura(Auras.LeyLines))
                 return false;
 
+            // Do not deploy LeyLines until our DoTs are safely applied
             if (!Core.Me.CurrentTarget.HasAnyAura(ThunderAuras, true, BlackMageSettings.Instance.ThunderRefreshSecondsLeft * 1000 + 500))
                 return false;
 
-            // Do not Ley Lines if we don't have 3 astral stacks
-            if (AstralStacks != 3
-                || UmbralStacks > 0)
+            // Restrict LeyLines entirely to Astral Fire to maximize damage
+            if (AstralStacks != 3 || UmbralStacks > 0)
                 return false;
 
+            // Safety check against the Circle Of Power buff
             if (Core.Me.HasAura(Auras.CircleOfPower))
                 return false;
 
-            // Do not Ley Lines if we don't have any umbral hearts (roundabout check to see if we're at the begining of astral)
-            if (Casting.LastSpellWas(Spells.Fire3)
-                && (UmbralHearts == 3
-                || Core.Me.HasAura(Auras.Triplecast)))
-                // Fire 3 is always used at the start of Astral
+            // Weave window optimization: Cast LeyLines after transitioning into Fire 3 with Umbral Hearts or Triplecast
+            if (Casting.LastSpellWas(Spells.Fire3) && (UmbralHearts == 3 || Core.Me.HasAura(Auras.Triplecast)))
                 return await Spells.LeyLines.Cast(Core.Me);
 
-            //Use in AoE rotation as well
-            if (Casting.LastSpellWas(Spells.HighFireII)
-                && (UmbralHearts == 3
-                || Core.Me.HasAura(Auras.Triplecast)))
-                // High Fire II is always used at the start of Astral
+            // Weave window optimization (AoE): Cast LeyLines after transitioning into High Fire II
+            if (Casting.LastSpellWas(Spells.HighFireII) && (UmbralHearts == 3 || Core.Me.HasAura(Auras.Triplecast)))
                 return await Spells.LeyLines.Cast(Core.Me);
 
             return await Spells.LeyLines.Cast(Core.Me);
@@ -117,6 +138,7 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Retrace()
         {
+            // Spell must be unlocked and ready
             if (!Spells.Retrace.IsKnown())
                 return false;
 
@@ -126,22 +148,28 @@ namespace Magitek.Logic.BlackMage
             if (Spells.Retrace.Cooldown != TimeSpan.Zero)
                 return false;
 
+            // We must have LeyLines active to teleport back to them
             if (!Core.Me.HasAura(Auras.LeyLines))
                 return false;
 
+            // If we already have the CircleOfPower buff, we are standing in them; no need to teleport
             if (Core.Me.HasAura(Auras.CircleOfPower))
                 return false;
 
+            // Do not attempt to Retrace if currently moving
             if (MovementManager.IsMoving)
                 return false;
 
+            // Only use during combat encounters
             if (!Core.Me.InCombat)
                 return false;
 
             return await Spells.Retrace.Cast(Core.Me);
         }
+
         public static async Task<bool> UmbralSoul()
         {
+            // Spell must be unlocked and setting enabled
             if (!Spells.UmbralSoul.IsKnown())
                 return false;
 
@@ -151,24 +179,25 @@ namespace Magitek.Logic.BlackMage
             if (Spells.UmbralSoul.Cooldown != TimeSpan.Zero)
                 return false;
 
-            // Do not Umbral Soul unless we have 1 umbral stack
+            // Combat safety: Allow Umbral Soul in combat IF moving to recover mana/stacks on the run,
+            // otherwise block it so we don't accidentally cast it while standing in front of a target
+            if (Core.Me.InCombat && Core.Me.HasTarget && !MovementManager.IsMoving)
+                return false;
+
+            // Umbral Soul strictly requires Umbral Ice to be active
             if (UmbralStacks == 0)
                 return false;
 
-            if (Core.Me.CurrentTarget != null)
-                return false;
-
-            //Try and not get stuck at 2 stacks
-            if (UmbralStacks < 3
-                && UmbralStacks > 1)
+            // Cast if we need to secure max stacks or max hearts
+            if (UmbralStacks < 3 || UmbralHearts < 3)
                 return await Spells.UmbralSoul.Cast(Core.Me);
 
             return false;
-
         }
 
         public static async Task<bool> PreCombatUmbralSoul()
         {
+            // Spell must be unlocked and setting enabled
             if (!Spells.UmbralSoul.IsKnown())
                 return false;
 
@@ -178,90 +207,48 @@ namespace Magitek.Logic.BlackMage
             if (!Spells.UmbralSoul.IsKnownAndReady())
                 return false;
 
-            // Only use out of combat (restores 10,000 MP when used outside combat)
+            // This is strictly a pre-combat out-of-combat preparation method
             if (Core.Me.InCombat)
                 return false;
 
-            // Can only be executed while under the effect of Umbral Ice
+            // Umbral Soul strictly requires Umbral Ice to be active
             if (UmbralStacks == 0)
                 return false;
 
-            // Only use when not at max mana (to restore MP)
-            if (Core.Me.CurrentMana >= Core.Me.MaxMana)
-                return false;
+            // Maintain max stacks, hearts, and MP between pulls
+            if (UmbralStacks < 3 || UmbralHearts < 3 || Core.Me.CurrentMana < Core.Me.MaxMana)
+                return await Spells.UmbralSoul.Cast(Core.Me);
 
-            return await Spells.UmbralSoul.Cast(Core.Me);
+            return false;
         }
 
         public static async Task<bool> ManaFont()
         {
+            // Spell must be unlocked and setting enabled
             if (!Spells.ManaFont.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.ManaFont)
                 return false;
 
-            if (UmbralStacks != 0)
+            // Dawntrail check: Manafont restores MP but MUST be used while in Astral Fire
+            if (AstralStacks == 0)
                 return false;
 
-            /*
-            if (Spells.ManaFont.Cooldown != TimeSpan.Zero)
+            // Do not pop Manafont if Flare Star is fully stacked and ready to fire
+            if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
                 return false;
 
-            if (!BlackMageSettings.Instance.ConvertAfterFire3)
-                return false;
-
-            // Don't use if time in combat less than 30 seconds
-            if (Combat.CombatTotalTimeLeft <= 30)
-                return false;
-
-            if (Core.Me.CurrentMana >= 7000)
-                return false;
-
-            //Moved this up as it should go off regardless of toggle
-            //Swapped mana check to be first as this was going off before we had 0 mana
-            if (Core.Me.CurrentMana == 0
-                && (Casting.LastSpellWas(Spells.Flare)
-                || Casting.LastSpellWas(Spells.Foul)))
-            //&& Spells.Fire.Cooldown.TotalMilliseconds > Globals.AnimationLockMs                
-            {
-                Logger.WriteInfo($@"[Debug] If we get to this point we should have cast flare and have 0 mana - actual last spell is {Casting.LastSpell} and we have {Core.Me.CurrentMana} mana.");
-
-                return await Spells.ManaFont.Cast(Core.Me);
-
-            }
-
-
-            Logger.WriteInfo($@"[Debug] If we get to this point we should have less than 7000 mana - actual current mana is {Core.Me.CurrentMana}.");
-
-            if (Core.Me.CurrentMana == 0
-                && (Casting.LastSpellWas(Spells.Despair)
-                || Casting.LastSpellWas(Spells.Xenoglossy)))
-            {
-                Logger.WriteInfo($@"[Debug] If we get to this point we should have cast xeno or despair - actual last spell is {Casting.LastSpell}.");
-
-                return await Spells.ManaFont.Cast(Core.Me);
-            }
-            if (Casting.LastSpellWas(Spells.Fire3)
-                //&& Spells.Fire.Cooldown.TotalMilliseconds > Globals.AnimationLockMs
-                && BlackMageSettings.Instance.ConvertAfterFire3
-                && Core.Me.CurrentMana < 7000)
-            {
-                Logger.WriteInfo($@"[Debug] If we get to this point we should have cast fire III - actual last spell is {Casting.LastSpell}.");
-
-                return await Spells.ManaFont.Cast(Core.Me);
-
-            }
-            */
-
-            //Still got enough mana to make one more fire cast
-            if (Core.Me.CurrentMana >= 1600)
+            // Only pop Manafont when completely out of MP at the end of the AF phase
+            if (Core.Me.CurrentMana >= 800)
                 return false;
 
             return await Spells.ManaFont.Cast(Core.Me);
         }
+
         public static async Task<bool> Transpose()
         {
+            // Basic API unlock check
             if (!Spells.Transpose.IsKnown())
                 return false;
 
@@ -270,43 +257,49 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> PreCombatTranspose()
         {
+            // Spell must be unlocked and ready
             if (!Spells.Transpose.IsKnown())
                 return false;
 
             if (!Spells.Transpose.IsKnownAndReady())
                 return false;
 
-            // Only transpose out of combat
+            // This is strictly a pre-combat out-of-combat preparation method
             if (Core.Me.InCombat)
                 return false;
 
-            // Only transpose when we have astral fire
+            // If we dropped stance entirely, do not Transpose
             if (AstralStacks == 0)
                 return false;
 
-            // Only transpose when not at max mana
+            // Do not transpose if our MP is already full
             if (Core.Me.CurrentMana >= Core.Me.MaxMana)
                 return false;
 
             return await Spells.Transpose.Cast(Core.Me);
         }
+
         public static async Task<bool> Amplifier()
         {
+            // Spell must be unlocked and setting enabled
             if (!Spells.Amplifier.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.Amplifier)
                 return false;
 
-            if (ActionResourceManager.BlackMage.PolyglotCount > 2)
+            // Strictly restrict to active combat
+            if (!Core.Me.InCombat)
                 return false;
 
-            if (!Core.Me.InCombat)
+            // Verify our max polyglot stack count based on current character level
+            int maxPolyglot = Core.Me.ClassLevel >= 98 ? 3 : (Core.Me.ClassLevel >= 80 ? 2 : 1);
+            
+            // Do not cast if we are already at the maximum capacity for Polyglot stacks
+            if (ActionResourceManager.BlackMage.PolyglotCount >= maxPolyglot)
                 return false;
 
             return await Spells.Amplifier.Cast(Core.Me);
         }
-
     }
-
 }

--- a/Magitek/Logic/BlackMage/SingleTarget.cs
+++ b/Magitek/Logic/BlackMage/SingleTarget.cs
@@ -16,39 +16,42 @@ namespace Magitek.Logic.BlackMage
     {
         public static async Task<bool> Xenoglossy()
         {
-            // If Xenoglossy isn't unlocked, use Foul instead
+            // 2-Target optimization: Foul is a mathematical DPS gain over Xenoglossy on 2+ targets
+            if (Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= 2 && Spells.Foul.IsKnown() && PolyglotStatus)
+                return await Aoe.Foul();
+
+            // Fallback: If Xenoglossy isn't unlocked yet, default to Foul if we have Polyglot
             if (!Spells.Xenoglossy.IsKnown())
             {
-                // Check if we can use Foul
                 if (Spells.Foul.IsKnown() && PolyglotStatus)
                     return await Aoe.Foul();
                 return false;
             }
 
+            // Respect user setting
             if (!BlackMageSettings.Instance.Xenoglossy)
                 return false;
 
+            // Do not use in neutral stance
             if (AstralStacks == 0 && UmbralStacks == 0)
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Do not waste a GCD on Xenoglossy if Flare Star is fully stacked and ready to fire
             if (AstralSoulStacks == 6)
                 return false;
 
-            // If we're moving in combat
+            // Movement logic: Dump Xenoglossy to maintain uptime while running if we lack instant-cast buffs
             if (MovementManager.IsMoving)
             {
-                // If we don't have any procs (while in movement), cast
-                if (!Core.Me.HasAura(Auras.Swiftcast)
-                    && !Core.Me.HasAura(Auras.Triplecast))
+                if (!Core.Me.HasAura(Auras.Swiftcast) && !Core.Me.HasAura(Auras.Triplecast))
                     return await Spells.Xenoglossy.Cast(Core.Me.CurrentTarget);
             }
 
-            // Cast if we're about to overcap Polyglot (prevent waste)
+            // Always prevent overcapping Polyglot stacks regardless of user settings
             if (BlackMageRoutine.WillOvercapPolyglot())
                 return await Spells.Xenoglossy.Cast(Core.Me.CurrentTarget);
 
-            //If at save threshold, don't cast
+            // Respect the user's saved charges setting before using Xenoglossy as a stationary filler
             if (PolyglotCount <= BlackMageSettings.Instance.SaveXenoglossyCharges)
                 return false;
 
@@ -57,30 +60,43 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Despair()
         {
+            // Spell must be unlocked and user setting enabled
             if (!Spells.Despair.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.Despair)
                 return false;
 
+            // Skip single-target Despair finisher during AoE encounters
+            if (AoeControl.Enabled 
+                && BlackMageSettings.Instance.UseAoe 
+                && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
+                return false;
+
+            // Prevent double-casting
             if (Casting.LastSpellWas(Spells.Despair))
                 return false;
 
-            //If flarestar is ready, cast it
-            if (AstralSoulStacks == 6)
+            // Allow 0 MP drop if Flare Star is queued right after
+            // Wait to cast Despair until Flare Star is available (if known) to ensure proper sequence
+            if (AstralSoulStacks == 6 && !Spells.FlareStar.IsKnown())
                 return false;
 
+            // Despair is strictly an Astral Fire ability
             if (UmbralStacks > 0)
                 return false;
 
+            // Standard API readiness check
             if (!Spells.Despair.IsKnownAndReadyAndCastable())
                 return false;
 
-            if (Spells.ManaFont.IsKnownAndReadyAndCastable())
+            // Minimum MP requirement: Despair requires at least 800 MP to cast, despite draining all MP
+            if (Core.Me.CurrentMana < 800)
                 return false;
 
-            // If our mana is more then 1600
-            if (Core.Me.CurrentMana >= 1600 || Core.Me.CurrentMana == 0)
+            // Do not cast Despair if we still have enough MP to fit another Fire 4
+            int fire4Cost = UmbralHearts > 0 ? 800 : 1600;
+            if (Core.Me.CurrentMana >= fire4Cost + 800)
                 return false;
 
             return await Spells.Despair.Cast(Core.Me.CurrentTarget);
@@ -88,41 +104,46 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Fire()
         {
-
+            // Spell must be unlocked
             if (!Spells.Fire.IsKnown())
                 return false;
 
-            if (Spells.Fire4.IsKnown())
+            // When Paradox is known (Lv 90+), Paradox entirely replaces Fire 1 for Astral Fire timer refreshes
+            if (Spells.Paradox.IsKnown())
                 return false;
-
-            //If flarestar is ready, cast it
+                
+            // Priority: Do not cast filler if Flare Star is ready
             if (AstralSoulStacks == 6)
                 return false;
 
-            //only use in astral fire
+            // Fire is an Astral Fire / Neutral ability
             if (UmbralStacks > 0)
                 return false;
 
-            // FFXIV MP costs (patch 7.x): Fire base cost 800 MP, doubled to 1600 in Astral Fire.
-            // Spells.Fire.Cost is NOT reliably dynamic for AF stance; hardcode known game values.
-            // If SQEX changes Fire's MP cost in a future patch, update these constants.
+            // Do not cast if we don't have the MP to support it in Astral Fire (costs double MP = 1600)
             if (AstralStacks > 0 && Core.Me.CurrentMana < 1600)
                 return false;
 
+            // Do not cast if we don't have the base MP to cast it in Neutral stance
             if (AstralStacks == 0 && Core.Me.CurrentMana < 800)
                 return false;
 
             return await Spells.Fire.Cast(Core.Me.CurrentTarget);
-
         }
 
         public static async Task<bool> Fire4()
         {
+            // Spell must be unlocked
             if (!Spells.Fire4.IsKnown())
                 return false;
 
-            //only use in astral fire
+            // Fire IV requires full Astral Fire III
             if (AstralStacks != 3)
+                return false;
+
+            // Calculate cost (800 with hearts, 1600 without) and verify MP is sufficient
+            int cost = UmbralHearts > 0 ? 800 : 1600;
+            if (Core.Me.CurrentMana < cost)
                 return false;
 
             return await Spells.Fire4.Cast(Core.Me.CurrentTarget);
@@ -130,77 +151,76 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Fire3()
         {
-
+            // Spell must be unlocked
             if (!Spells.Fire3.IsKnown())
                 return false;
 
-            //No stack, open with Fire3
+            // Transition: If we lost our stance, cast Fire 3 to instantly jump back to Astral Fire III
             if (AstralStacks < 3 && UmbralStacks == 0)
                 return await Spells.Fire3.Cast(Core.Me.CurrentTarget);
 
-            // if (BlackMageSettings.Instance.UseAoe
-            //     && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
-            //     return false;
-
+            // Prevent double-casting
             if (Casting.LastSpellWas(Spells.Fire3))
                 return false;
 
-            //Don't waste firestarter if we are about to enter UI
-            if (Core.Me.CurrentMana < 2000
-                && Core.Me.HasAura(Auras.FireStarter))
+            // Consume Firestarter proc if we are low on MP
+            if (Core.Me.CurrentMana < 2000 && Core.Me.HasAura(Auras.FireStarter))
                 return false;
 
-            //Keep from using firestarter early - wait for full mana
-            if (Core.Me.HasAura(Auras.FireStarter)
-                && Core.Me.CurrentMana < 8400)
+            // Hold Firestarter proc for movement or later weaving if we have plenty of MP
+            if (Core.Me.HasAura(Auras.FireStarter) && Core.Me.CurrentMana < 8400)
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Do not waste a GCD on Fire 3 if Flare Star is ready
             if (AstralSoulStacks == 6)
                 return false;
 
-            if (Core.Me.HasAura(Auras.Triplecast))
-                return false;
-
+            // Standard rotation: Do not hardcast Fire 3 if we are already in AF3 or haven't maxed Umbral Ice yet
             if (AstralStacks == 3 || UmbralStacks < 3)
                 return false;
 
-            if (UmbralStacks > 0 && Core.Me.CurrentMana != Core.Me.MaxMana)
+            // Transition checks: Ensure we secure Umbral Hearts before leaving Umbral Ice
+            if (Spells.Blizzard4.IsKnown())
+            {
+                if (UmbralHearts < 3 && !Casting.LastSpellWas(Spells.Blizzard4))
+                    return false;
+            }
+            // Low level: Wait for MP to tick up before transitioning back to Astral Fire
+            else if (Core.Me.CurrentMana < 7200)
+            {
                 return false;
+            }
 
             return await Spells.Fire3.Cast(Core.Me.CurrentTarget);
         }
 
         public static async Task<bool> Thunder3()
         {
-
+            // Base spell must be unlocked and user setting enabled
             if (!Spells.Thunder.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.ThunderSingle)
                 return false;
 
-            // Skip if we're in an AoE situation (use Thunder4 instead)
+            // Require Thunderhead proc to instantly cast and refresh DoT
+            if (!Core.Me.HasAura(Auras.Thunderhead))
+                return false;
+
+            // Do not use Single-Target Thunder during AoE encounters
             if (AoeControl.Enabled
                 && BlackMageSettings.Instance.UseAoe
                 && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
                 return false;
 
-            // If the last spell we cast is triple cast, stop
+            // Do not consume a Thunderhead proc if we just popped Triplecast (use the buff for heavy nukes instead)
             if (Casting.LastSpellWas(Spells.Triplecast))
                 return false;
 
-            // If we have the triplecast aura, stop
             if (Core.Me.HasAura(Auras.Triplecast))
                 return false;
 
-            //Moved this up to see if it stops the doublecast
-            if (Casting.LastSpellWas(Spells.Thunder)
-                || Casting.LastSpellWas(Spells.Thunder3)
-                || Casting.LastSpellWas(Spells.HighThunder))
-                return false;
-
-            // Try to keep from double-casting thunder
+            // Prevent double-casting or refreshing immediately
             if (Casting.LastSpellWas(Spells.Thunder)
                 || Casting.LastSpellWas(Spells.Thunder2)
                 || Casting.LastSpellWas(Spells.Thunder3)
@@ -209,12 +229,15 @@ namespace Magitek.Logic.BlackMage
                 || Casting.LastSpellWas(Spells.HighThunderII))
                 return false;
 
+            // Do not clip Thunder if the target already has the DoT with plenty of time remaining
             if (Core.Me.CurrentTarget.HasAnyAura(ThunderAuras, true, BlackMageSettings.Instance.ThunderRefreshSecondsLeft * 1000 + 500))
                 return false;
 
+            // Time To Die (TTD) check: Don't cast DoTs on trash mobs that are about to die anyway
             if (BlackMageSettings.Instance.UseTTDForThunderSingle && Combat.CurrentTargetCombatTimeLeft <= BlackMageSettings.Instance.ThunderSingleTTDSeconds && !Core.Me.CurrentTarget.IsBoss())
                 return false;
 
+            // Spell Upgrade Fallbacks
             if (!Spells.Thunder3.IsKnown())
                 return await Spells.Thunder.Cast(Core.Me.CurrentTarget);
 
@@ -222,11 +245,10 @@ namespace Magitek.Logic.BlackMage
                 return await Spells.Thunder3.Cast(Core.Me.CurrentTarget);
 
             return await Spells.HighThunder.Cast(Core.Me.CurrentTarget);
-
         }
 
         private static readonly uint[] ThunderAuras =
-       {
+        {
             Auras.Thunder,
             Auras.Thunder2,
             Auras.Thunder3,
@@ -237,16 +259,19 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Blizzard4()
         {
-
+            // Spell must be unlocked
             if (!Spells.Blizzard4.IsKnown())
                 return false;
 
+            // Blizzard 4 requires max Umbral Ice III to cast
             if (UmbralStacks != 3)
                 return false;
 
-            if (Core.Me.CurrentMana == Core.Me.MaxMana)
+            // Do not cast if we already have max Umbral Hearts secured
+            if (UmbralHearts == 3)
                 return false;
 
+            // Prevent double-casting or sequence breaking
             if (Casting.LastSpellWas(Spells.Blizzard4))
                 return false;
 
@@ -258,92 +283,107 @@ namespace Magitek.Logic.BlackMage
 
         public static async Task<bool> Blizzard3()
         {
-
+            // Spell must be unlocked
             if (!Spells.Blizzard3.IsKnown())
                 return false;
 
-            if (Casting.LastSpellWas(Spells.Blizzard3)
-                || Casting.LastSpellWas(Spells.ManaFont))
+            // Prevent double-casting or breaking Manafont timing
+            if (Casting.LastSpellWas(Spells.Blizzard3) || Casting.LastSpellWas(Spells.ManaFont))
                 return false;
 
-            //If flarestar is ready, cast it
+            // Priority: Execute Flare Star before transitioning to Umbral Ice
             if (AstralSoulStacks == 6)
                 return false;
 
+            // Do not cast if we are trying to build Astral Fire or if we are already in max Umbral Ice
             if (AstralStacks < 3 || UmbralStacks == 3)
                 return false;
 
+            // Do not use single-target Blizzard 3 in AoE encounters (use Freeze/Blizzard 2 instead)
             if (AoeControl.Enabled
                 && BlackMageSettings.Instance.UseAoe
                 && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
                 return false;
 
+            // Allow Blizzard 3 immediately if our mana drops below 1600 (catching low MP states cleanly for fast cast transition)
             if (Core.Me.CurrentMana >= 1600)
-                return false;
-
-            if (Spells.ManaFont.IsKnownAndReady())
                 return false;
 
             return await Spells.Blizzard3.Cast(Core.Me.CurrentTarget);
         }
+
         public static async Task<bool> Blizzard()
         {
-            // Low level logic - when Blizzard3 isn't available, Blizzard handles AF/UI transitions
+            // Do not use base Blizzard if Blizzard 4 is available for Heart generation
+            if (Spells.Blizzard4.IsKnown())
+                return false;
+
+            // Early game fallback logic when Blizzard 3 is not yet unlocked
             if (!Spells.Blizzard3.IsKnown())
             {
-                // Don't cast right after Transpose if still in Astral Fire (edge case)
                 if (Casting.LastSpellWas(Spells.Transpose) && AstralStacks > 0)
                     return false;
 
-                // FFXIV MP costs (patch 7.x): Fire base cost 800, doubled to 1600 in Astral Fire.
-                // Spells.Fire.Cost is NOT reliably dynamic for AF stance; hardcode known game values.
-                // If SQEX changes Fire's MP cost in a future patch, update these constants.
-
-                // In Astral Fire: switch to Umbral Ice when MP too low for Fire (1600 in AF)
                 if (AstralStacks > 0 && Core.Me.CurrentMana < 1600)
                     return await Spells.Blizzard.Cast(Core.Me.CurrentTarget);
 
-                // In Umbral Ice: keep casting Blizzard while MP regens (maintains UI stacks)
                 if (UmbralStacks > 0 && Core.Me.CurrentMana < Core.Me.MaxMana)
                     return await Spells.Blizzard.Cast(Core.Me.CurrentTarget);
 
-                // Neutral with low MP: enter Umbral Ice to start MP recovery
                 if (AstralStacks == 0 && UmbralStacks == 0 && Core.Me.CurrentMana < 1600)
                     return await Spells.Blizzard.Cast(Core.Me.CurrentTarget);
 
                 return false;
             }
 
+            // Prevent double-casting or sequencing errors
             if (Casting.LastSpellWas(Spells.Blizzard4))
                 return false;
 
             return await Spells.Blizzard.Cast(Core.Me.CurrentTarget);
         }
+
         public static async Task<bool> Paradox()
         {
+            // Spell must be unlocked and setting enabled
             if (!Spells.Paradox.IsKnown())
                 return false;
 
             if (!BlackMageSettings.Instance.Paradox)
                 return false;
 
+            // FFXIV MP costs (patch 7.x): Fire base cost 800 MP, doubled to 1600 in Astral Fire.
+            // Spells.Fire.Cost is NOT reliably dynamic for AF stance; hardcode known game values.
+            // If SQEX changes Fire's MP cost in a future patch, update these constants.
+            if (AstralStacks > 0 && Core.Me.CurrentMana < 1600)
+                return false;
+
+            // Skip single-target Paradox during AoE encounters
+            if (AoeControl.Enabled
+                && BlackMageSettings.Instance.UseAoe
+                && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
+                return false;
+
+            // Prevent sequence breaking immediately after transitions
             if (Casting.LastSpellWas(Spells.Fire3))
                 return false;
 
             if (Casting.LastSpellWas(Spells.Blizzard3))
                 return false;
-
+                
+            // Dawntrail check: Paradox is strictly available in Astral Fire III and Umbral Ice III
             if (AstralStacks != 3 && UmbralStacks != 3)
                 return false;
 
-            if (Spells.ManaFont.IsKnownAndReady())
-                return false;
+            // If we are moving, prioritize dropping Paradox as an instant cast
+            if (MovementManager.IsMoving)
+                return await Spells.Paradox.Cast(Core.Me.CurrentTarget);
 
-            if (Spells.Fire4.IsKnownAndReadyAndCastableAtTarget() && Spells.ManaFont.Cooldown.TotalMilliseconds >= 70000)
+            // Maintain Astral Fire sequence: Wait until we have cast 3 Fire IVs (3 Astral Soul stacks) before weaving Paradox
+            if (AstralSoulStacks < 3 && Spells.Fire4.IsKnown())
                 return false;
 
             return await Spells.Paradox.Cast(Core.Me.CurrentTarget);
         }
-
     }
 }

--- a/Magitek/Models/BlackMage/BlackMageSettings.cs
+++ b/Magitek/Models/BlackMage/BlackMageSettings.cs
@@ -127,6 +127,10 @@ namespace Magitek.Models.BlackMage
         public bool ThunderAoe { get; set; }
         #endregion
 
+        [Setting]
+        [DefaultValue(false)]
+        public bool UseEtherInAoe { get; set; }
+
         #region PVP
         [Setting]
         [DefaultValue(true)]

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -2053,7 +2053,14 @@ namespace Magitek.Properties {
                 return ResourceManager.GetString("BlackMage_Text_Use_Soul_Resonance_when_target_HP_below", resourceCulture);
             }
         }
-        
+        /// <summary>
+        ///   Looks up a localized string similar to Use Ethers in AoE.
+        /// </summary>
+        public static string BlackMage_Content_Use_Ethers_In_AOE {
+            get {
+                return ResourceManager.GetString("BlackMage_Content_Use_Ethers_In_AOE", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Add Interrupt/Stun.
         /// </summary>

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -59,18 +59,18 @@ namespace Magitek.Rotations
             // 1. Universal / Survival: Evaluated every tick regardless of stance
             // Execute Limit Break if forced by user settings
             if (Aoe.ForceLimitBreak()) return true;
-            
+
             // Automatically pop defensive cooldowns (Manaward, Addle, Surecast) based on incoming boss mechanics
             if (await CommonFightLogic.FightLogic_SelfShield(BlackMageSettings.Instance.FightLogicManaward, Spells.Manaward, castTimeRemainingMs: 19000)) return true;
             if (await MagicDps.FightLogic_Addle(BlackMageSettings.Instance)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(BlackMageSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 
             // 2. Dynamic Target & Stance Evaluation: Determine AoE vs Single-Target and current elemental stance
-            bool isAoe = BlackMageSettings.Instance.UseAoe && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies;
+            bool isAoe = AoeControl.Enabled && BlackMageSettings.Instance.UseAoe && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies;
             bool inAstralFire = AstralStacks > 0;
             bool inUmbralIce = UmbralStacks > 0;
             bool isNeutral = !inAstralFire && !inUmbralIce;
-            
+
             // 3. Movement Safety: Check if we have instant cast buffs active to allow casting on the run
             bool hasInstantCastBuff = Core.Me.HasAura(Auras.Triplecast) || Core.Me.HasAura(Auras.Swiftcast);
 
@@ -89,23 +89,24 @@ namespace Magitek.Rotations
                     if (await SingleTarget.Xenoglossy()) return true;
                     if (await SingleTarget.Paradox()) return true;
                     if (await SingleTarget.Thunder3()) return true;
-                    
+
                     // Consume Firestarter proc if we have one
                     if (Core.Me.HasAura(Auras.FireStarter) && await SingleTarget.Fire3()) return true;
                 }
 
                 // If no instant spells are available, try to pop a movement buff
-                if (Spells.Triplecast.IsKnownAndReady()) return await Spells.Triplecast.Cast(Core.Me);
+                // If no instant spells are available, try to pop a movement buff
+                if (BlackMageSettings.Instance.TripleCast && Spells.Triplecast.IsKnownAndReady()) return await Spells.Triplecast.Cast(Core.Me);
                 if (Spells.Swiftcast.IsKnownAndReady()) return await Spells.Swiftcast.Cast(Core.Me);
-                
+
                 // Safely yield the tick so the bot's navigation system can move the character
-                return false; 
+                return false;
             }
 
             // 4. Off-Global Cooldowns: Use buffs and oGCDs independently of our current elemental stance
             if (await Buff.Amplifier()) return true;
             if (await Buff.Triplecast()) return true;
-            if (await Buff.Swiftcast()) return true; 
+            if (await Buff.Swiftcast()) return true;
             if (await Buff.LeyLines()) return true;
             if (await Buff.Retrace()) return true;
             if (await Buff.ManaFont()) return true;
@@ -132,17 +133,17 @@ namespace Magitek.Rotations
                     {
                         // Use Flare if known and we meet the MP/Heart requirements
                         if (await Aoe.Flare()) return true;
-                        if (Spells.Flare.IsKnownAndReady() && (Core.Me.CurrentMana >= 800 || UmbralHearts > 0)) 
+                        if (Spells.Flare.IsKnownAndReady() && (Core.Me.CurrentMana >= 800 || UmbralHearts > 0))
                             return await Spells.Flare.Cast(Core.Me.CurrentTarget);
 
                         // Fallback to Fire 2 / High Fire 2 if Flare isn't known
                         if (await Aoe.Fire2()) return true;
                         if (Spells.Fire2.IsKnownAndReady()) return await Spells.Fire2.Cast(Core.Me.CurrentTarget);
-                        
-                        return false; 
+
+                        return false;
                     }
                     // AoE Finisher Phase: MP is depleted. Execute finishers, weave, and swap to ice.
-                    else 
+                    else
                     {
                         // 1. Flare Star: Dump 6 Astral Soul stacks if we have them
                         if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
@@ -192,23 +193,22 @@ namespace Magitek.Rotations
                         if (Spells.Fire4.IsKnownAndReady()) return await Spells.Fire4.Cast(Core.Me.CurrentTarget);
 
                         // Consume Firestarter procs if generated
-                        if (await SingleTarget.Fire3()) return true; 
+                        if (await SingleTarget.Fire3()) return true;
 
                         // Fallback to basic Fire if Fire IV isn't known yet
                         if (await SingleTarget.Fire()) return true;
                         if (Spells.Fire.IsKnownAndReady()) return await Spells.Fire.Cast(Core.Me.CurrentTarget);
-                        
-                        return false; 
+
+                        return false;
                     }
                     // Single-Target Finisher Phase: MP is too low for Fire IV. Dump remaining MP and transition.
-                    else 
+                    else
                     {
                         // 1. Despair: Consumes all remaining MP (Minimum 800 MP required)
-                        if (Spells.Despair.IsKnown() && Core.Me.CurrentMana >= 800)
+                        if (BlackMageSettings.Instance.Despair && Spells.Despair.IsKnown() && Core.Me.CurrentMana >= 800)
                         {
                             if (await SingleTarget.Despair()) return true;
                             if (Spells.Despair.IsKnownAndReady()) return await Spells.Despair.Cast(Core.Me.CurrentTarget);
-                            return true; // HOLD TICK FOR DESPAIR
                         }
 
                         // 2. Flare Star: Cast for 0 MP, Consumes 6 Astral Soul Stacks
@@ -222,9 +222,9 @@ namespace Magitek.Rotations
                         // 3. Blizzard III Transition: Costs 0 MP under Astral Fire III to swap to Umbral Ice
                         if (await SingleTarget.Blizzard3()) return true;
                         if (Spells.Blizzard3.IsKnownAndReady()) return await Spells.Blizzard3.Cast(Core.Me.CurrentTarget);
-                        
+
                         // Low-level fallback if Blizzard III isn't known
-                        if (!Spells.Blizzard3.IsKnown() && Spells.Transpose.IsKnownAndReady()) 
+                        if (!Spells.Blizzard3.IsKnown() && Spells.Transpose.IsKnownAndReady())
                             return await Spells.Transpose.Cast(Core.Me);
 
                         return true; // HOLD TICK FOR TRANSITION
@@ -266,7 +266,7 @@ namespace Magitek.Rotations
                         if (await Aoe.Blizzard2()) return true;
                         if (Spells.Blizzard2.IsKnownAndReady()) return await Spells.Blizzard2.Cast(Core.Me.CurrentTarget);
                     }
-                    
+
                     return true; // Hold tick to prevent dropping combat
                 }
                 else
@@ -286,7 +286,7 @@ namespace Magitek.Rotations
                         if (Spells.Blizzard4.IsKnownAndReady()) return await Spells.Blizzard4.Cast(Core.Me.CurrentTarget);
                         return true; // HOLD TICK: Wait for B4 travel time! Never fall through.
                     }
-                    
+
                     // Main Ice Spells & Procs: Refresh Thunder DoT, dump Xenoglossy, and cast Paradox
                     if (await SingleTarget.Thunder3()) return true;
                     if (await SingleTarget.Xenoglossy()) return true;
@@ -306,7 +306,7 @@ namespace Magitek.Rotations
                         if (await SingleTarget.Blizzard()) return true;
                         if (Spells.Blizzard.IsKnownAndReady()) return await Spells.Blizzard.Cast(Core.Me.CurrentTarget);
                     }
-                    
+
                     return true; // Hold tick to prevent dropping combat
                 }
             }
@@ -317,6 +317,16 @@ namespace Magitek.Rotations
             {
                 if (isAoe)
                 {
+                    // Start with Blizzard II / High Blizzard II if we have zero stacks
+                    if (AstralStacks == 0 && UmbralStacks == 0)
+                    {
+                        if (await Aoe.Blizzard2()) return true;
+                        if (Spells.Blizzard2.IsKnownAndReady()) return await Spells.Blizzard2.Cast(Core.Me.CurrentTarget);
+                    }
+
+                    if (Spells.Transpose.IsKnownAndReady() && await Spells.Transpose.Cast(Core.Me)) return true;
+                    if (await Aoe.Freeze()) return true;
+                    if (Spells.Freeze.IsKnownAndReady()) return await Spells.Freeze.Cast(Core.Me.CurrentTarget);
                     // AoE Neutral Recovery: Apply Thunder and cast Freeze to enter Umbral Ice
                     if (await Aoe.Thunder4()) return true;
                     if (Spells.Transpose.IsKnownAndReady() && await Spells.Transpose.Cast(Core.Me)) return true;
@@ -328,7 +338,7 @@ namespace Magitek.Rotations
                     // Single-Target Neutral Recovery: Cast Blizzard 3 or Fire 3 to immediately enter a stance
                     if (await SingleTarget.Blizzard3()) return true;
                     if (Spells.Blizzard3.IsKnownAndReady()) return await Spells.Blizzard3.Cast(Core.Me.CurrentTarget);
-                    
+
                     if (await SingleTarget.Fire3()) return true;
                     if (await SingleTarget.Blizzard()) return true;
                     if (await SingleTarget.Fire()) return true;

--- a/Magitek/Rotations/BlackMage.cs
+++ b/Magitek/Rotations/BlackMage.cs
@@ -1,4 +1,5 @@
 using ff14bot;
+using ff14bot.Managers;
 using Magitek.Extensions;
 using Magitek.Logic.BlackMage;
 using Magitek.Logic.Roles;
@@ -21,7 +22,6 @@ namespace Magitek.Rotations
 
         public static async Task<bool> PreCombatBuff()
         {
-            //Try to keep stacks outside combat
             if (!BlackMageSettings.Instance.UsePreCombatTranspose)
                 return false;
 
@@ -40,76 +40,301 @@ namespace Magitek.Rotations
         {
             return false;
         }
-        public static Task<bool> CombatBuff()
+
+        public static async Task<bool> CombatBuff()
         {
-            return Task.FromResult(false);
+            if (global::Magitek.Utilities.Combat.IsBoss() && await MagicDps.UsePotion(BlackMageSettings.Instance)) return true;
+            return false;
         }
+
+        // =========================================================================================
+        // COMBAT METHOD - Unified On-The-Fly Dynamic Routine
+        // =========================================================================================
         public static async Task<bool> Combat()
         {
+            // Ensure we have a valid, attackable target before attempting any combat logic
             if (!Core.Me.HasTarget || !Core.Me.CurrentTarget.ThoroughCanAttack())
                 return false;
 
-            //LimitBreak
+            // 1. Universal / Survival: Evaluated every tick regardless of stance
+            // Execute Limit Break if forced by user settings
             if (Aoe.ForceLimitBreak()) return true;
-
+            
+            // Automatically pop defensive cooldowns (Manaward, Addle, Surecast) based on incoming boss mechanics
             if (await CommonFightLogic.FightLogic_SelfShield(BlackMageSettings.Instance.FightLogicManaward, Spells.Manaward, castTimeRemainingMs: 19000)) return true;
             if (await MagicDps.FightLogic_Addle(BlackMageSettings.Instance)) return true;
             if (await CommonFightLogic.FightLogic_Knockback(BlackMageSettings.Instance.FightLogicKnockback, Spells.Surecast, true, aura: Auras.Surecast)) return true;
 
-            if (await Aoe.FlareStar()) return true;
+            // 2. Dynamic Target & Stance Evaluation: Determine AoE vs Single-Target and current elemental stance
+            bool isAoe = BlackMageSettings.Instance.UseAoe && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies;
+            bool inAstralFire = AstralStacks > 0;
+            bool inUmbralIce = UmbralStacks > 0;
+            bool isNeutral = !inAstralFire && !inUmbralIce;
+            
+            // 3. Movement Safety: Check if we have instant cast buffs active to allow casting on the run
+            bool hasInstantCastBuff = Core.Me.HasAura(Auras.Triplecast) || Core.Me.HasAura(Auras.Swiftcast);
 
+            // If moving without instant-cast buffs, use natural instant spells to maintain uptime
+            if (MovementManager.IsMoving && !hasInstantCastBuff)
+            {
+                if (isAoe)
+                {
+                    // Instant AoE fillers
+                    if (await Aoe.Thunder4()) return true;
+                    if (await Aoe.Foul()) return true;
+                }
+                else
+                {
+                    // Instant Single-Target fillers
+                    if (await SingleTarget.Xenoglossy()) return true;
+                    if (await SingleTarget.Paradox()) return true;
+                    if (await SingleTarget.Thunder3()) return true;
+                    
+                    // Consume Firestarter proc if we have one
+                    if (Core.Me.HasAura(Auras.FireStarter) && await SingleTarget.Fire3()) return true;
+                }
+
+                // If no instant spells are available, try to pop a movement buff
+                if (Spells.Triplecast.IsKnownAndReady()) return await Spells.Triplecast.Cast(Core.Me);
+                if (Spells.Swiftcast.IsKnownAndReady()) return await Spells.Swiftcast.Cast(Core.Me);
+                
+                // Safely yield the tick so the bot's navigation system can move the character
+                return false; 
+            }
+
+            // 4. Off-Global Cooldowns: Use buffs and oGCDs independently of our current elemental stance
             if (await Buff.Amplifier()) return true;
             if (await Buff.Triplecast()) return true;
+            if (await Buff.Swiftcast()) return true; 
             if (await Buff.LeyLines()) return true;
             if (await Buff.Retrace()) return true;
             if (await Buff.ManaFont()) return true;
-            if (await Buff.UmbralSoul()) return true;
 
-            if (await SingleTarget.Thunder3()) return true;
-            if (await SingleTarget.Paradox()) return true;
-            if (await SingleTarget.Despair()) return true;
-
-            //AoE Section
-            if (BlackMageSettings.Instance.UseAoe && Core.Me.CurrentTarget.EnemiesNearby(10).Count() >= BlackMageSettings.Instance.AoeEnemies)
+            // =========================================================
+            // 5. ASTRAL FIRE PHASE: The primary damage phase. Burns MP to deal heavy damage.
+            // =========================================================
+            if (inAstralFire)
             {
-                //Either
-                if (await Aoe.Thunder4()) return true;
-                if (await Aoe.Foul()) return true;
+                if (isAoe)
+                {
+                    // AoE Recovery: Force Flare to reach Astral Fire III if we somehow dropped stacks or transposed
+                    if (AstralStacks < 3 && Core.Me.CurrentMana >= 800)
+                    {
+                        if (await Aoe.Flare()) return true;
+                        if (Spells.Flare.IsKnownAndReady()) return await Spells.Flare.Cast(Core.Me.CurrentTarget);
+                    }
 
-                if (await Aoe.Blizzard2()) return true;
-                if (await Aoe.Fire2()) return true;
+                    // Determine the minimum MP required to continue the AoE Main Phase (Flare takes 800, Fire II takes 3000)
+                    int minAoeMp = Spells.Flare.IsKnown() ? 800 : 3000;
 
-                if (await Aoe.Flare()) return true;
-                if (await Aoe.Freeze()) return true;
+                    // AoE Main Phase: Spam Flare or Fire II as long as we have the MP to support it
+                    if (Core.Me.CurrentMana >= minAoeMp)
+                    {
+                        // Use Flare if known and we meet the MP/Heart requirements
+                        if (await Aoe.Flare()) return true;
+                        if (Spells.Flare.IsKnownAndReady() && (Core.Me.CurrentMana >= 800 || UmbralHearts > 0)) 
+                            return await Spells.Flare.Cast(Core.Me.CurrentTarget);
+
+                        // Fallback to Fire 2 / High Fire 2 if Flare isn't known
+                        if (await Aoe.Fire2()) return true;
+                        if (Spells.Fire2.IsKnownAndReady()) return await Spells.Fire2.Cast(Core.Me.CurrentTarget);
+                        
+                        return false; 
+                    }
+                    // AoE Finisher Phase: MP is depleted. Execute finishers, weave, and swap to ice.
+                    else 
+                    {
+                        // 1. Flare Star: Dump 6 Astral Soul stacks if we have them
+                        if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
+                        {
+                            if (await Aoe.FlareStar()) return true;
+                            if (Spells.FlareStar.IsKnownAndReady()) return await Spells.FlareStar.Cast(Core.Me.CurrentTarget);
+                            return true; // HOLD TICK
+                        }
+
+                        // FIXED: Now properly calling Ether helper so the setting actually works!
+                        if (await Aoe.UseAoeEther()) return true;
+
+                        // 2. Weaves: Maintain Thunder DoT and use Foul during the instant cast window
+                        if (await Aoe.Thunder4()) return true;
+                        if (await Aoe.Foul()) return true;
+
+                        // FIXED: Now properly calling Transpose helper to swap to Umbral Ice!
+                        if (await Aoe.AoeTranspose()) return true;
+                        return true; // HOLD TICK
+                    }
+                }
+                else
+                {
+                    // Single-Target Recovery: Cast Fire I or Fire III to reach Astral Fire III if we dropped Enochian or Transposed
+                    if (AstralStacks < 3)
+                    {
+                        if (await SingleTarget.Fire3()) return true;
+                        if (Spells.Fire3.IsKnownAndReady()) return await Spells.Fire3.Cast(Core.Me.CurrentTarget);
+                        if (Spells.Fire.IsKnownAndReady()) return await Spells.Fire.Cast(Core.Me.CurrentTarget);
+                    }
+
+                    // Cast Paradox whenever available to refresh the Astral Fire timer
+                    if (await SingleTarget.Paradox()) return true;
+
+                    // Calculate MP threshold: 2400 to fit Despair + Fire IV, or 1600 for just Fire IV if Despair isn't known
+                    int minStMp = Spells.Despair.IsKnown() ? 2400 : 1600;
+
+                    // Single-Target Main Phase: Maintain DoTs and spam Fire IV while MP allows
+                    if (Core.Me.CurrentMana >= minStMp)
+                    {
+                        // Maintain Thunder and prevent Polyglot overcap during Main Phase
+                        if (await SingleTarget.Thunder3()) return true;
+                        if (await SingleTarget.Xenoglossy()) return true;
+
+                        // Primary nuke
+                        if (await SingleTarget.Fire4()) return true;
+                        if (Spells.Fire4.IsKnownAndReady()) return await Spells.Fire4.Cast(Core.Me.CurrentTarget);
+
+                        // Consume Firestarter procs if generated
+                        if (await SingleTarget.Fire3()) return true; 
+
+                        // Fallback to basic Fire if Fire IV isn't known yet
+                        if (await SingleTarget.Fire()) return true;
+                        if (Spells.Fire.IsKnownAndReady()) return await Spells.Fire.Cast(Core.Me.CurrentTarget);
+                        
+                        return false; 
+                    }
+                    // Single-Target Finisher Phase: MP is too low for Fire IV. Dump remaining MP and transition.
+                    else 
+                    {
+                        // 1. Despair: Consumes all remaining MP (Minimum 800 MP required)
+                        if (Spells.Despair.IsKnown() && Core.Me.CurrentMana >= 800)
+                        {
+                            if (await SingleTarget.Despair()) return true;
+                            if (Spells.Despair.IsKnownAndReady()) return await Spells.Despair.Cast(Core.Me.CurrentTarget);
+                            return true; // HOLD TICK FOR DESPAIR
+                        }
+
+                        // 2. Flare Star: Cast for 0 MP, Consumes 6 Astral Soul Stacks
+                        if (AstralSoulStacks == 6 && Spells.FlareStar.IsKnown())
+                        {
+                            if (await Aoe.FlareStar()) return true;
+                            if (Spells.FlareStar.IsKnownAndReady()) return await Spells.FlareStar.Cast(Core.Me.CurrentTarget);
+                            return true; // HOLD TICK FOR FLARE STAR
+                        }
+
+                        // 3. Blizzard III Transition: Costs 0 MP under Astral Fire III to swap to Umbral Ice
+                        if (await SingleTarget.Blizzard3()) return true;
+                        if (Spells.Blizzard3.IsKnownAndReady()) return await Spells.Blizzard3.Cast(Core.Me.CurrentTarget);
+                        
+                        // Low-level fallback if Blizzard III isn't known
+                        if (!Spells.Blizzard3.IsKnown() && Spells.Transpose.IsKnownAndReady()) 
+                            return await Spells.Transpose.Cast(Core.Me);
+
+                        return true; // HOLD TICK FOR TRANSITION
+                    }
+                }
             }
-
-            if (await SingleTarget.Xenoglossy()) return true;
-            if (await SingleTarget.Blizzard4()) return true;
-            if (await SingleTarget.Fire4()) return true;
-
-            if (await SingleTarget.Blizzard3()) return true;
-            if (await SingleTarget.Fire3()) return true;
-
-            // Low-level mana management: Transpose between Astral Fire and Umbral Ice
-            if (!Spells.Blizzard3.IsKnown() || !Spells.Fire3.IsKnown())
+            // =========================================================
+            // 6. UMBRAL ICE PHASE: The recovery phase. Restores MP and secures Umbral Hearts.
+            // =========================================================
+            else if (inUmbralIce)
             {
-                // FFXIV MP costs (patch 7.x): Fire base cost 800, doubled to 1600 in Astral Fire.
-                // Spells.Fire.Cost is NOT reliably dynamic for AF stance; hardcode known game values.
-                // If SQEX changes Fire's MP cost in a future patch, update these constants.
-                // AF→UI: Transpose when MP too low for Fire (1600 in AF)
-                if (AstralStacks > 0 && Core.Me.CurrentMana < 1600 && Spells.Transpose.IsKnownAndReady())
+                if (isAoe)
                 {
-                    if (await Buff.Transpose()) return true;
+                    // Secure Umbral Hearts using Freeze (grants 3 hearts). Hold the tick to account for travel time.
+                    if (Spells.Freeze.IsKnown() && UmbralHearts < 3 && (!MovementManager.IsMoving || hasInstantCastBuff))
+                    {
+                        if (Core.Me.CurrentTarget != null)
+                        {
+                            if (await Aoe.Freeze()) return true;
+                            if (Spells.Freeze.IsKnownAndReady()) return await Spells.Freeze.Cast(Core.Me.CurrentTarget);
+                        }
+                        return true; // HOLD TICK: Wait for Freeze travel time! Never fall through.
+                    }
+
+                    // Once Hearts are secured (or MP is full at low levels), weave instant spells and Transpose back to Fire
+                    if (UmbralHearts == 3 || Core.Me.CurrentMana >= 10000 || Core.Me.CurrentMana == Core.Me.MaxMana)
+                    {
+                        if (await Aoe.Thunder4()) return true;
+                        if (await Aoe.Foul()) return true;
+
+                        if (Spells.Transpose.IsKnownAndReady()) return await Spells.Transpose.Cast(Core.Me);
+                        return true; // HOLD TICK FOR TRANSITION
+                    }
+
+                    // Low-Level AoE Filler: Use Umbral Soul or Blizzard II until MP is full (< Lv 58)
+                    if (!Spells.Freeze.IsKnown())
+                    {
+                        if (await Buff.UmbralSoul()) return true;
+                        if (await Aoe.Blizzard2()) return true;
+                        if (Spells.Blizzard2.IsKnownAndReady()) return await Spells.Blizzard2.Cast(Core.Me.CurrentTarget);
+                    }
+                    
+                    return true; // Hold tick to prevent dropping combat
                 }
-                // UI→AF: Transpose when MP is full to start Fire phase
-                if (UmbralStacks > 0 && Core.Me.CurrentMana == Core.Me.MaxMana && Spells.Transpose.IsKnownAndReady())
+                else
                 {
-                    if (await Buff.Transpose()) return true;
+                    // Single-Target Recovery: Ensure we reach Umbral Ice III for maximum MP regen speed
+                    if (UmbralStacks < 3)
+                    {
+                        if (await SingleTarget.Blizzard3()) return true;
+                        if (Spells.Blizzard3.IsKnownAndReady()) return await Spells.Blizzard3.Cast(Core.Me.CurrentTarget);
+                        return true; // HOLD TICK FOR B3
+                    }
+
+                    // Secure Umbral Hearts using Blizzard 4 (grants 3 hearts and instantly restores 10k MP on hit)
+                    if (Spells.Blizzard4.IsKnown() && UmbralHearts < 3 && (!MovementManager.IsMoving || hasInstantCastBuff))
+                    {
+                        if (await SingleTarget.Blizzard4()) return true;
+                        if (Spells.Blizzard4.IsKnownAndReady()) return await Spells.Blizzard4.Cast(Core.Me.CurrentTarget);
+                        return true; // HOLD TICK: Wait for B4 travel time! Never fall through.
+                    }
+                    
+                    // Main Ice Spells & Procs: Refresh Thunder DoT, dump Xenoglossy, and cast Paradox
+                    if (await SingleTarget.Thunder3()) return true;
+                    if (await SingleTarget.Xenoglossy()) return true;
+                    if (await SingleTarget.Paradox()) return true;
+
+                    // Transition to Fire: Dawntrail removed passive MP ticks. Use full Hearts or full MP as the trigger.
+                    if (UmbralHearts == 3 || Core.Me.CurrentMana >= 10000 || Core.Me.CurrentMana == Core.Me.MaxMana)
+                    {
+                        if (await SingleTarget.Fire3()) return true;
+                        if (Spells.Fire3.IsKnownAndReady()) return await Spells.Fire3.Cast(Core.Me.CurrentTarget);
+                        return true; // HOLD TICK FOR TRANSITION
+                    }
+
+                    // Low-Level Filler: Spam Blizzard I until MP passively ticks back to full (< Lv 58)
+                    if (!Spells.Blizzard4.IsKnown())
+                    {
+                        if (await SingleTarget.Blizzard()) return true;
+                        if (Spells.Blizzard.IsKnownAndReady()) return await Spells.Blizzard.Cast(Core.Me.CurrentTarget);
+                    }
+                    
+                    return true; // Hold tick to prevent dropping combat
                 }
             }
-
-            if (await SingleTarget.Fire()) return true;
-            if (await SingleTarget.Blizzard()) return true;
+            // =========================================================
+            // 7. NEUTRAL PHASE: Opening of combat or recovering from dropping Enochian entirely
+            // =========================================================
+            else if (isNeutral)
+            {
+                if (isAoe)
+                {
+                    // AoE Neutral Recovery: Apply Thunder and cast Freeze to enter Umbral Ice
+                    if (await Aoe.Thunder4()) return true;
+                    if (Spells.Transpose.IsKnownAndReady() && await Spells.Transpose.Cast(Core.Me)) return true;
+                    if (await Aoe.Freeze()) return true;
+                    if (Spells.Freeze.IsKnownAndReady()) return await Spells.Freeze.Cast(Core.Me.CurrentTarget);
+                }
+                else
+                {
+                    // Single-Target Neutral Recovery: Cast Blizzard 3 or Fire 3 to immediately enter a stance
+                    if (await SingleTarget.Blizzard3()) return true;
+                    if (Spells.Blizzard3.IsKnownAndReady()) return await Spells.Blizzard3.Cast(Core.Me.CurrentTarget);
+                    
+                    if (await SingleTarget.Fire3()) return true;
+                    if (await SingleTarget.Blizzard()) return true;
+                    if (await SingleTarget.Fire()) return true;
+                }
+                return false;
+            }
 
             return false;
         }

--- a/Magitek/Views/UserControls/BlackMage/Aoe.xaml
+++ b/Magitek/Views/UserControls/BlackMage/Aoe.xaml
@@ -41,6 +41,14 @@
             </StackPanel>
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,3,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <CheckBox Content="{x:Static properties:Resources.BlackMage_Content_Use_Ethers_In_AOE}" IsChecked="{Binding BlackMageSettings.UseEtherInAoe, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Summary of Changes
* **State Handling:** Fixed transition logic between Astral Fire and Umbral Ice states.
* **Flare Star Deadlocks:** Resolved issues where the routine could lock up when queuing Flare Star.
* **AoE Optimization:** Refined multi-target rotation sequences for cleaner dungeon clear pacing.