### PR TITLE
ALL - Stop damage over time and ranged pulls targeting enemies we cannot hurt

### DIFF
--- a/Magitek/Logic/Astrologian/SingleTarget.cs
+++ b/Magitek/Logic/Astrologian/SingleTarget.cs
@@ -61,6 +61,12 @@ namespace Magitek.Logic.Astrologian
 
             bool CanCombust(GameObject unit)
             {
+                // A target our damage cannot reach never takes the DoT, so it stays missing the aura
+                // and is re-picked on the very next pulse. This search does not pass through
+                // ThoroughCanAttack, so the damageable check has to happen here.
+                if (!unit.CanBeDamagedByMe())
+                    return false;
+
                 if (!AstrologianSettings.Instance.UseTTDForCombust)
                     return true;
 

--- a/Magitek/Logic/Bard/DamageOverTime.cs
+++ b/Magitek/Logic/Bard/DamageOverTime.cs
@@ -139,6 +139,12 @@ namespace Magitek.Logic.Bard
             if (unit == Core.Me.CurrentTarget)
                 return false;
 
+            // A target our damage cannot reach never takes the DoT, so it stays missing the aura and
+            // is re-picked on the very next pulse. The multi-DoT search does not pass through
+            // ThoroughCanAttack, so the damageable check has to happen here.
+            if (!unit.CanBeDamagedByMe())
+                return false;
+
             if (!unit.InLineOfSight())
                 return false;
 
@@ -220,6 +226,11 @@ namespace Magitek.Logic.Bard
             bool IsValidIronJawsTarget(BattleCharacter unit)
             {
                 if (unit == Core.Me.CurrentTarget)
+                    return false;
+
+                // Same reasoning as IsValidTargetToApplyDoT: an undamageable target never takes the
+                // refresh, so it would be re-picked every pulse.
+                if (!unit.CanBeDamagedByMe())
                     return false;
 
                 if (!unit.InLineOfSight())

--- a/Magitek/Logic/DarkKnight/SingleTarget.cs
+++ b/Magitek/Logic/DarkKnight/SingleTarget.cs
@@ -158,7 +158,7 @@ namespace Magitek.Logic.DarkKnight
                 : Core.Me.CombatReach + DarkKnightSettings.Instance.UnmendMinDistance;
 
             //find target already pulled on which I lose aggro
-            var unmendTarget = Combat.Enemies.FirstOrDefault(r => r.ValidAttackUnit()
+            var unmendTarget = Combat.Enemies.FirstOrDefault(r => r.ValidDamageTarget()
                                                                     && r.NotInvulnerable()
                                                                     && !r.WithinSpellRange(calculatedCombatReach)
                                                                     && r.WithinSpellRange(Spells.Unmend.Range)

--- a/Magitek/Logic/Gunbreaker/SingleTarget.cs
+++ b/Magitek/Logic/Gunbreaker/SingleTarget.cs
@@ -52,7 +52,7 @@ namespace Magitek.Logic.Gunbreaker
                 return false;
 
             //find target already pulled on which I lose aggro
-            var lightningShotTarget = Combat.Enemies.FirstOrDefault(r => r.ValidAttackUnit()
+            var lightningShotTarget = Combat.Enemies.FirstOrDefault(r => r.ValidDamageTarget()
                                                                     && r.NotInvulnerable()
                                                                     && r.Distance(Core.Me) >= Core.Me.CombatReach + r.CombatReach + GunbreakerSettings.Instance.LightningShotMinDistance
                                                                     && r.WithinSpellRange(20)

--- a/Magitek/Logic/Paladin/SingleTarget.cs
+++ b/Magitek/Logic/Paladin/SingleTarget.cs
@@ -30,7 +30,7 @@ namespace Magitek.Logic.Paladin
         {
             if (PaladinSettings.Instance.UseShieldLobToPullExtraEnemies)
             {
-                var pullTarget = Combat.Enemies.FirstOrDefault(r => r.ValidAttackUnit() && !r.Tapped
+                var pullTarget = Combat.Enemies.FirstOrDefault(r => r.ValidDamageTarget() && !r.Tapped
                                                         && r.WithinSpellRange(Spells.ShieldLob.Range)
                                                         && !r.WithinSpellRange(Spells.FastBlade.Range)
                                                         && r.TargetGameObject != Core.Me);
@@ -63,7 +63,8 @@ namespace Magitek.Logic.Paladin
                 return false;
 
             var shieldLobTarget = Combat.Enemies.FirstOrDefault(r =>
-                !r.WithinSpellRange(Spells.FastBlade.Range)
+                r.CanBeDamagedByMe()
+                && !r.WithinSpellRange(Spells.FastBlade.Range)
                 && r.WithinSpellRange(Spells.ShieldLob.Range)
                 && r.TargetGameObject != Core.Me);
 

--- a/Magitek/Logic/Sage/SingleTarget.cs
+++ b/Magitek/Logic/Sage/SingleTarget.cs
@@ -126,6 +126,12 @@ namespace Magitek.Logic.Sage
             }
             bool CanDot(GameObject unit)
             {
+                // A target our damage cannot reach never takes the DoT, so it stays missing the aura
+                // and is re-picked on the very next pulse. This search does not pass through
+                // ThoroughCanAttack, so the damageable check has to happen here.
+                if (!unit.CanBeDamagedByMe())
+                    return false;
+
                 // Check dosis since no eukrasia buff yet.
                 if (!Spells.Dosis.CanCast(unit))
                     return false;

--- a/Magitek/Logic/Scholar/SingleTarget.cs
+++ b/Magitek/Logic/Scholar/SingleTarget.cs
@@ -79,6 +79,12 @@ namespace Magitek.Logic.Scholar
         }
         public static bool CanBio(GameObject unit)
         {
+            // A target our damage cannot reach never takes the DoT, so it stays missing the aura and
+            // is re-picked on the very next pulse. The multi-target search does not pass through
+            // ThoroughCanAttack, so the damageable check has to happen here.
+            if (!unit.CanBeDamagedByMe())
+                return false;
+
             if (!ScholarSettings.Instance.BioUseTimeTillDeath)
                 return true;
 

--- a/Magitek/Logic/Warrior/SingleTarget.cs
+++ b/Magitek/Logic/Warrior/SingleTarget.cs
@@ -22,7 +22,7 @@ namespace Magitek.Logic.Warrior
         {
             if (WarriorSettings.Instance.UseTomahawkToPullExtraEnemies)
             {
-                var pullTarget = Combat.Enemies.FirstOrDefault(r => r.ValidAttackUnit() && !r.Tapped
+                var pullTarget = Combat.Enemies.FirstOrDefault(r => r.ValidDamageTarget() && !r.Tapped
                                                         && r.WithinSpellRange(Spells.Tomahawk.Range)
                                                         && !r.WithinSpellRange(Spells.HeavySwing.Range)
                                                         && r.TargetGameObject != Core.Me);
@@ -58,7 +58,8 @@ namespace Magitek.Logic.Warrior
             //    return false;
 
             var tomahawkTarget = Combat.Enemies.FirstOrDefault(r =>
-                !r.WithinSpellRange(Spells.HeavySwing.Range)
+                r.CanBeDamagedByMe()
+                && !r.WithinSpellRange(Spells.HeavySwing.Range)
                 && r.WithinSpellRange(Spells.Tomahawk.Range)
                 && r.TargetGameObject != Core.Me);
 

--- a/Magitek/Logic/WhiteMage/SingleTarget.cs
+++ b/Magitek/Logic/WhiteMage/SingleTarget.cs
@@ -129,6 +129,12 @@ namespace Magitek.Logic.WhiteMage
 
             bool CanDot(GameObject unit)
             {
+                // A target our damage cannot reach never takes the DoT, so it stays missing the aura
+                // and is re-picked on the very next pulse. This search does not pass through
+                // ThoroughCanAttack, so the damageable check has to happen here.
+                if (!unit.CanBeDamagedByMe())
+                    return false;
+
                 if (!WhiteMageSettings.Instance.UseTTDForDot)
                     return true;
 


### PR DESCRIPTION
Follow-on to #214. That PR gated damage on `ThoroughCanAttack()` / `CanBeDamagedByMe()`, which covers every rotation that casts at `CurrentTarget`. It does not cover the paths that pick a *secondary* target straight out of `Combat.Enemies` — multi-target DoT application and the tank ranged pulls — because those never pass through that gate.

`NotInvulnerable()` is aura-only by design, so an enemy we cannot damage legitimately stays in `Combat.Enemies` (interrupts, Provoke and the defensive paths need to see it). The fix therefore gates at the decision points rather than filtering the collection.

**Why it loops rather than just wasting one GCD:** the DoT never applies to a target our damage cannot reach, so the aura check still reports it as missing on the next pulse and the same target is selected again. For Scholar that also starves everything below it in `Combat()`, because `BioMultipleTargets()` returns true each time.

**Tested:** Not tested in game.

The bug itself is reproduced, but the fix is not. Occult Crescent: North Horn, Fated/Epic Villain duel, SCH Lv100, holding Fated Hero against the Epic Villain head:

- 44 Biolysis casts into the head we could not damage, every one flagged as a no-damage hit, versus 8 on the head we could
- Broil IV fell to 1 cast for the whole engagement, from ~65 in comparable prior runs
- Seven earlier runs of the same duel on a build whose `Combat.Enemies` already excluded the immune head show 0-2 stray casts, so this is the gap and not normal behaviour

I could not validate the fix because the build I test on filters those targets out of `Combat.Enemies` locally, which masks the defect. Confirming it needs a Hero/Villain duel on a master-based build.

**Sources:** no new claims about game behaviour. The immunity rules are #214's (`ImmunityLogic` / `ImmunityEncounters`), unchanged here. `CanBeDamagedByMe()` is damage-type aware, so a physical ranged pull is not blocked against a magic-immune target.

**Removed:** nothing. Two call sites move from `ValidAttackUnit()` to `ValidDamageTarget()`, which is `ValidAttackUnit()` plus the damage check, so no existing condition is dropped.

**Deliberately not changed** — these must keep seeing enemies we cannot damage:

- `Roles/Tank.cs` (x2) - Provoke is enmity, not damage
- `Roles/VariantDungeon.cs`, `Roles/CommonPvp.cs` - PvP has its own model
- `Bard/Utility.cs` - Repelling Shot is self-positioning
- `Logic/CustomOpenerLogic.cs` - user-authored gambit conditions
- `Roles/OccultCrescent.cs` - already uses `ValidDamageTarget()`

Generated with [Claude Code](https://claude.com/claude-code)