### PR TITLE
Core - Fix the client freezing on zone changes, job changes and casts

### DIFF
--- a/Magitek/Magitek.cs
+++ b/Magitek/Magitek.cs
@@ -111,9 +111,23 @@ namespace Magitek
                 // Set the current zone
                 CurrentZone = WorldManager.ZoneId;
 
-                // Run the shit we need to
-                GambitsViewModel.Instance.ApplyGambits();
-                OpenersViewModel.Instance.ApplyOpeners();
+                // Run the shit we need to.
+                // InvokeAsync, never Invoke, same as the other zone/job handlers below: this
+                // fires on the bot pulse thread, which must not block on the dispatcher while
+                // it holds the frame lock. Exceptions are caught inside the delegate because
+                // InvokeAsync surfaces them nowhere.
+                Application.Current.Dispatcher.InvokeAsync(delegate
+                {
+                    try
+                    {
+                        GambitsViewModel.Instance.ApplyGambits();
+                        OpenersViewModel.Instance.ApplyOpeners();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Zone refresh after level up failed: {ex.Message}");
+                    }
+                });
             }
 
             #endregion
@@ -128,21 +142,35 @@ namespace Magitek
                 CurrentJob = Core.Me.CurrentJob;
                 Logger.WriteInfo("Job Changed");
 
-                // Run the shit we need to
-                Application.Current.Dispatcher.Invoke(delegate
+                // Run the shit we need to.
+                // InvokeAsync, never Invoke: this handler runs on the bot pulse thread, which
+                // holds the frame lock, and the delegate reads frame-cached game state on the
+                // UI thread, which takes that same lock. Blocking here while the UI thread
+                // waits on the lock deadlocked the whole client - a thread dump of a wedged RB
+                // caught the two threads waiting on each other. Nothing below depends on this
+                // finishing first, and exceptions are caught inside the delegate because
+                // InvokeAsync surfaces them nowhere.
+                Application.Current.Dispatcher.InvokeAsync(delegate
                 {
-                    GambitsViewModel.Instance.ApplyGambits();
-                    OpenersViewModel.Instance.ApplyOpeners();
-                    // First unregister all existing Magitek hotkeys
-                    UnregisterAllMagitekHotkeys();
-                    // Then load the toggles for the current job
-                    TogglesManager.LoadTogglesForCurrentJob();
-                    // Register opener hotkey
-                    RegisterOpenerHotkey();
-                    // Register reset opener hotkey
-                    RegisterResetOpenerHotkey();
-                    // Register hold PvP burst hotkey
-                    RegisterHoldPvpBurstHotkey();
+                    try
+                    {
+                        GambitsViewModel.Instance.ApplyGambits();
+                        OpenersViewModel.Instance.ApplyOpeners();
+                        // First unregister all existing Magitek hotkeys
+                        UnregisterAllMagitekHotkeys();
+                        // Then load the toggles for the current job
+                        TogglesManager.LoadTogglesForCurrentJob();
+                        // Register opener hotkey
+                        RegisterOpenerHotkey();
+                        // Register reset opener hotkey
+                        RegisterResetOpenerHotkey();
+                        // Register hold PvP burst hotkey
+                        RegisterHoldPvpBurstHotkey();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Job change refresh failed: {ex.Message}");
+                    }
                 });
 
                 HookBehaviors();
@@ -162,20 +190,30 @@ namespace Magitek
                 // Set the current zone
                 CurrentZone = WorldManager.ZoneId;
 
-                Application.Current.Dispatcher.Invoke(delegate
+                // InvokeAsync for the same reason as the class-changed handler above: blocking the
+                // pulse thread here wedged the bot on every zone transition, which is far more
+                // common than a job change.
+                Application.Current.Dispatcher.InvokeAsync(delegate
                 {
-                    GambitsViewModel.Instance.ApplyGambits();
-                    OpenersViewModel.Instance.ApplyOpeners();
-                    // First unregister all existing Magitek hotkeys
-                    UnregisterAllMagitekHotkeys();
-                    // Then load the toggles for the current job
-                    TogglesManager.LoadTogglesForCurrentJob();
-                    // Register opener hotkey
-                    RegisterOpenerHotkey();
-                    // Register reset opener hotkey
-                    RegisterResetOpenerHotkey();
-                    // Register hold PvP burst hotkey
-                    RegisterHoldPvpBurstHotkey();
+                    try
+                    {
+                        GambitsViewModel.Instance.ApplyGambits();
+                        OpenersViewModel.Instance.ApplyOpeners();
+                        // First unregister all existing Magitek hotkeys
+                        UnregisterAllMagitekHotkeys();
+                        // Then load the toggles for the current job
+                        TogglesManager.LoadTogglesForCurrentJob();
+                        // Register opener hotkey
+                        RegisterOpenerHotkey();
+                        // Register reset opener hotkey
+                        RegisterResetOpenerHotkey();
+                        // Register hold PvP burst hotkey
+                        RegisterHoldPvpBurstHotkey();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"Zone change refresh failed: {ex.Message}");
+                    }
                 });
             }
 
@@ -323,28 +361,46 @@ namespace Magitek
             {
                 Logger.WriteInfo("Entering PVP Zone. Switching to PvP CombatRoutine.");
                 BaseSettings.Instance.ActivePvpCombatRoutine = true;
-                Application.Current.Dispatcher.Invoke(delegate
+                // InvokeAsync: same block as the class-changed and map-changed handlers, and the same
+                // deadlock - the delegate reads game state on the UI thread, which contends the frame
+                // lock against the pulse thread.
+                Application.Current.Dispatcher.InvokeAsync(delegate
                 {
-                    GambitsViewModel.Instance.ApplyGambits();
-                    OpenersViewModel.Instance.ApplyOpeners();
-                    TogglesManager.LoadTogglesForCurrentJob();
+                    try
+                    {
+                        GambitsViewModel.Instance.ApplyGambits();
+                        OpenersViewModel.Instance.ApplyOpeners();
+                        TogglesManager.LoadTogglesForCurrentJob();
 
-                    // Start PvP aggro count overlay when entering PvP
-                    OverlayManager.StartPvpAggroCountOverlay();
+                        // Start PvP aggro count overlay when entering PvP
+                        OverlayManager.StartPvpAggroCountOverlay();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"PvP routine switch failed: {ex.Message}");
+                    }
                 });
             }
             else if (!WorldManager.InPvP && BaseSettings.Instance.ActivePvpCombatRoutine)
             {
                 Logger.WriteInfo("Leaving PVP Zone. Switching to PvE CombatRoutine.");
                 BaseSettings.Instance.ActivePvpCombatRoutine = false;
-                Application.Current.Dispatcher.Invoke(delegate
+                // InvokeAsync, as above - fourth copy of this same block.
+                Application.Current.Dispatcher.InvokeAsync(delegate
                 {
-                    GambitsViewModel.Instance.ApplyGambits();
-                    OpenersViewModel.Instance.ApplyOpeners();
-                    TogglesManager.LoadTogglesForCurrentJob();
+                    try
+                    {
+                        GambitsViewModel.Instance.ApplyGambits();
+                        OpenersViewModel.Instance.ApplyOpeners();
+                        TogglesManager.LoadTogglesForCurrentJob();
 
-                    // Stop PvP aggro count overlay when leaving PvP
-                    OverlayManager.StopPvpAggroCountOverlay();
+                        // Stop PvP aggro count overlay when leaving PvP
+                        OverlayManager.StopPvpAggroCountOverlay();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"PvE routine switch failed: {ex.Message}");
+                    }
                 });
             }
 

--- a/Magitek/Utilities/Casting.cs
+++ b/Magitek/Utilities/Casting.cs
@@ -58,7 +58,15 @@ namespace Magitek.Utilities
                 SpellCastHistory.Remove(SpellCastHistory.Last());
 
                 if (BaseSettings.Instance.DebugSpellCastHistory)
-                    Application.Current.Dispatcher.Invoke(delegate { Debug.Instance.SpellCastHistory = new List<SpellCastHistoryItem>(SpellCastHistory); });
+                {
+                    // Copy the list on this thread, then hand the finished snapshot to the UI:
+                    // the rotation keeps mutating SpellCastHistory, so a copy taken later on the
+                    // dispatcher can tear or throw. InvokeAsync for the same reason as the twin
+                    // call in CheckForSuccessfulCast below - the rotation must never block on
+                    // the dispatcher.
+                    var snapshot = new List<SpellCastHistoryItem>(SpellCastHistory);
+                    _ = Application.Current.Dispatcher.InvokeAsync(delegate { Debug.Instance.SpellCastHistory = snapshot; });
+                }
             }
 
             // If we're not casting we can return false to keep going down the tree
@@ -346,7 +354,16 @@ namespace Magitek.Utilities
             });
 
             if (BaseSettings.Instance.DebugSpellCastHistory)
-                Application.Current.Dispatcher.Invoke(delegate { Debug.Instance.SpellCastHistory = new List<SpellCastHistoryItem>(SpellCastHistory); });
+            {
+                // InvokeAsync, never Invoke: this runs on the pulse thread while it holds the
+                // frame lock, so blocking here deadlocks the whole client. A thread dump of a
+                // wedged RB caught this exact call - the pulse thread waiting on the dispatcher,
+                // the UI thread sitting in Monitor.Enter reading frame-cached game state for a
+                // job handler. Neither side could finish. The list is copied on this thread
+                // because the rotation keeps mutating it; nothing reads the result back.
+                var snapshot = new List<SpellCastHistoryItem>(SpellCastHistory);
+                _ = Application.Current.Dispatcher.InvokeAsync(delegate { Debug.Instance.SpellCastHistory = snapshot; });
+            }
 
             #endregion
 

--- a/Magitek/ViewModels/OpenersViewModel.cs
+++ b/Magitek/ViewModels/OpenersViewModel.cs
@@ -438,16 +438,33 @@ namespace Magitek.ViewModels
 
             try
             {
-                Application.Current.Dispatcher.Invoke(delegate
+                // Read the frame-cached values on the calling thread, not in the delegate:
+                // Core.Me.CurrentJob and WorldManager.ZoneId take the frame lock, and a
+                // UI-thread frame-lock wait while a bot-thread caller blocks on the dispatcher
+                // is the deadlock a thread dump caught here. InvokeAsync plus these locals
+                // keeps this method safe from any thread. OpenerGroups itself stays on the
+                // dispatcher - the UI mutates it there. The catch moves inside the delegate
+                // because InvokeAsync surfaces exceptions nowhere.
+                var currentJob = Core.Me.CurrentJob;
+                var currentZone = WorldManager.ZoneId;
+
+                Application.Current.Dispatcher.InvokeAsync(delegate
                 {
-                    if (OpenerGroups == null || OpenerGroups.Count == 0)
-                        return;
+                    try
+                    {
+                        if (OpenerGroups == null || OpenerGroups.Count == 0)
+                            return;
 
-                    var openers = OpenerGroups.Where(r =>
-                        r.Job == Core.Me.CurrentJob && (r.ZoneId == WorldManager.ZoneId || r.ZoneId == 1)).ToList();
-                    CustomOpenerLogic.OpenerGroups = new List<OpenerGroup>(openers);
+                        var openers = OpenerGroups.Where(r =>
+                            r.Job == currentJob && (r.ZoneId == currentZone || r.ZoneId == 1)).ToList();
+                        CustomOpenerLogic.OpenerGroups = new List<OpenerGroup>(openers);
 
-                    Logger.WriteInfo($"Added {openers.Count} Openers For This Zone");
+                        Logger.WriteInfo($"Added {openers.Count} Openers For This Zone");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex.Message);
+                    }
                 });
             }
             catch (Exception e)


### PR DESCRIPTION
## What this changes

The rotation (pulse) thread no longer blocks on the WPF dispatcher anywhere. Five transition handlers (class change, map change, the level-up handler's stale-zone fallback, PvP enter/leave) and the two debug spell-history refreshes in `Casting` now use `InvokeAsync`, and `ApplyOpeners` reads `Core.Me.CurrentJob` / `WorldManager.ZoneId` into locals *before* the dispatcher call so the marshalled delegate no longer touches game state at all.

## Why

On RB 1.0.900+ the whole client could freeze on a zone or job change — no error, no log line, process alive but unresponsive until killed. A thread dump of a frozen client showed a two-lock inversion:

- the pulse thread held the frame lock and was blocked in `Dispatcher.Invoke` (refreshing the debug spell-cast history from `Casting.CheckForSuccessfulCast`)
- the UI thread was inside the class-changed handler's marshalled delegate, in `ApplyOpeners`' LINQ predicate, blocked reading a frame-cached value (`Core.Me.CurrentJob`) — which takes that same frame lock

Neither thread could finish. The race most likely existed before .NET 10 and the runtime bump changed the timing enough to make it fire in normal play; zone changes hit it most because they are the most common transition.

## Game-behavior assumptions I could not verify

| # | Assumption | Based on | Confidence | If wrong, the impact is |
|---|-----------|----------|------------|-------------------------|
| 1 | Nothing depends on gambits/openers/toggles being reapplied synchronously inside a transition handler — a few pulses of the previous set during a transition is acceptable | read every call site; dispatcher FIFO preserves relative order | high | a transition could briefly run with the previous zone/job's gambit or toggle set |

## What changed beyond the Invoke-to-InvokeAsync swap (and why)

- `ApplyOpeners`: the frame-cached reads are hoisted to the caller's thread, and the catch moved inside the queued delegate — queued work surfaces exceptions nowhere on its own. The `OpenerGroups` read stays on the dispatcher, because the UI mutates that collection there.
- `Casting`: the history list is copied on the rotation thread and the finished copy handed to the UI. Copying inside the queued delegate would race the rotation's own writes to the list.
- Every queued delegate got try/catch -> `Logger.Error`, since there is no `DispatcherUnhandledException` handler in the codebase and a failure in e.g. `ApplyGambits` would otherwise be completely silent now.
- Deliberately left blocking: `SettingsWindow` creation (the caller needs the returned window) and the overlay click handler (already on the UI thread).

## Tested

RB 1.0.901, a full evening of play: repeated duty enter/leave across roulettes (dungeon, alliance raid, Occult Crescent), job changes, phantom job swaps, casting through transitions. The previous build froze on the first zone change; this one never did. Runtime testing was on .NET 10 together with the reference-assembly PR (#264), but this branch does not depend on it — it builds clean against current master (net8.0 / 1.0.803 references, 0 errors).

## In-game test plan

1. Setup: any job, bot running; enable `Debug Spell Cast History` to exercise the worst path.
2. Trigger: enter and leave a duty repeatedly; change class mid-session.
3. Expect: `Added N Gambits` followed by `Added N Openers For This Zone` on each transition (the openers line now arrives after the toggle/hotkey lines — an ordering note, not a failure); no freeze.
4. If it fails: the client wedges with the log stopped after a transition line — capture a process dump before killing RB; the stacks are the evidence.

## Build

- [x] `dotnet build` clean in `Magitek/` (0 errors, against current master)
- [x] No unrelated files in the diff (3 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
