### PR TITLE
Magitek - Restore compatibility with RebornBuddy 1.0.900

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Authoritative guidance for developers working on the Magitek routine.
 - Build: `dotnet build Magitek\Magitek.sln`
   - **Note:** The solution file is in the `Magitek` subdirectory, not the workspace root.
   - On Windows PowerShell, use semicolon separators: `cd Magitek; dotnet build Magitek.sln`
-- Magitek targets **.NET 8.0 (net8.0-windows8.0)** and is loaded inside RebornBuddy.
+- Magitek targets **.NET 10.0 (net10.0-windows8.0)** and is loaded inside RebornBuddy (1.0.900 and later run on .NET 10).
 - C# Language Version: **C# 10** (enforced via `<LangVersion>10</LangVersion>` in Magitek.csproj).
 - Preferred IDE: Visual Studio 2022 or JetBrains Rider with the Windows workload.
 

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -87,7 +87,7 @@
       <Version>4.1.0</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.9037-rc.1" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.902" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net10.0-windows8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <SccProjectName></SccProjectName>
     <SccLocalPath></SccLocalPath>
@@ -87,7 +87,7 @@
       <Version>4.1.0</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.803" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.9037-rc.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/MagitekLoader/MagitekLoader.cs
+++ b/MagitekLoader/MagitekLoader.cs
@@ -130,8 +130,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
 #endif
     private static readonly Color LogColor = Colors.CornflowerBlue;
 
-    private static readonly string GreyMagicAssembly = Path.Combine(Environment.CurrentDirectory, @"GreyMagic.dll");
-
     private string _currentDirectory = string.Empty;
     private string _projectAssembly = string.Empty;
     private string _versionPath = string.Empty;
@@ -188,7 +186,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
     private void RedirectAssembly()
     {
         AppDomain.CurrentDomain.AssemblyResolve += Handler;
-        AppDomain.CurrentDomain.AssemblyResolve += GreyMagicHandler;
     }
 
     Assembly? Handler(object sender, ResolveEventArgs args)
@@ -196,12 +193,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
         var name = Assembly.GetEntryAssembly()?.GetName().Name;
         var requestedAssembly = new AssemblyName(args.Name);
         return requestedAssembly.Name != name ? null : Assembly.GetEntryAssembly();
-    }
-
-    Assembly? GreyMagicHandler(object sender, ResolveEventArgs args)
-    {
-        var requestedAssembly = new AssemblyName(args.Name);
-        return requestedAssembly.Name != "GreyMagic" ? null : Assembly.LoadFrom(GreyMagicAssembly);
     }
 
     private static Assembly? LoadAssembly(string path, MagitekLoadContext context)

--- a/MagitekLoader/MagitekLoader.csproj
+++ b/MagitekLoader/MagitekLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <SccProjectName></SccProjectName>
     <SccLocalPath></SccLocalPath>
@@ -33,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.803" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.902" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What this changes

Retargets Magitek to `net10.0-windows8.0` and moves the reference assemblies from `1.0.803` to the `1.0.90xx` line. The diff is the project file plus the AGENTS.md runtime line (kept in step per Codex review) — recompiling against the new references is the whole fix, no logic changed.

**Offered as a potential candidate rather than the answer.** You may well have a different plan for the .NET 10 move — multi-targeting, holding for a stable reference release, or your own build setup — and this is just the smallest change that produced a working build in the meantime. Happy to close this in favor of whatever you prefer.

## Why

On RebornBuddy 1.0.900+ every current Magitek build is hard-broken, not degraded: GreyMagic no longer ships as a separate assembly (its types moved into RebornBuddy.dll), so the old binary's references into GreyMagic no longer resolve. Observed symptom: `ZoomHack.Toggle()` throws `MissingFieldException` out of `OnStart` and the bot thread dies the moment Start is pressed.

## The prerelease pin — resolved (maintainer)

Superseded: this now pins the stable **`1.0.902`**, not `1.0.9037-rc.1`.

The 1.0.90xx line does have stable releases (`1.0.900`, `1.0.901`, `1.0.902`), and RebornBuddy
itself ships a `RebornBuddyRefs.props` naming `1.0.902` — the vendor stating what plugins
should reference. `1.0.902` also matches the shipped `RebornBuddy.dll` exactly.

The two are interchangeable at compile time: a full public API diff of both reference
assemblies (types, methods, fields) is **identical — 8936 entries each, zero added, zero
removed**. The only differences are the version stamp and the obfuscation seed, which
randomizes internal type names per build. Given that, pinning the version actually shipped
is the conservative choice.

## Game-behavior assumptions I could not verify

None — build-level change, no game-behavior claims.

## Tested

RB 1.0.901, a full evening of play (Occult Crescent, dungeon and alliance roulettes): clean start, no ZoomHack throw, routine ran normally throughout. Runtime testing was done together with #263 — the two are independent (#263 builds and runs against current master's `1.0.803` references as well).

## Build

- [x] `dotnet build` clean in `Magitek/` (0 errors)
- [x] No unrelated files in the diff (csproj + the AGENTS.md runtime line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




---

## Maintainer additions

Two commits on top of the original:

- **`Magitek - Build against the RebornBuddy release you actually run`** — the pin change above.
- **`Core - Stop the loader from breaking other plugins after the GreyMagic merge`** —
  `MagitekLoader` registered a process-wide `AssemblyResolve` handler that did
  `Assembly.LoadFrom(...GreyMagic.dll)` on a file RebornBuddy no longer ships. Since an
  exception thrown from a resolve handler propagates to whatever triggered the load, that
  turned any *other* plugin's GreyMagic request into a hard `FileNotFoundException` — the
  same shape as the ATB loader throw in the original crash log. The handler is removed rather
  than guarded: GreyMagic's types are now defined inside `RebornBuddy.dll`, so default
  resolution is correct, and there are no pre-1.0.900 installs to support.
  `MagitekLoader.csproj` moves to net10 / `1.0.902` alongside it, so local builds validate the
  loader source against the same surface RebornBuddy compiles it with at runtime.

### Verification

- `GreyMagic.dll`, `ff14bot.dll`, `TreeSharp.dll` and `Clio.Utilities.dll` are all absent from a
  1.0.902 install; `GreyMagic.*` types are now defined directly inside `RebornBuddy.dll` with no
  type forwarder, which is why old binaries fail hard rather than degrade.
- The retarget is mandatory, not cosmetic: the 1.0.902 package ships `ref/net10.0-windows7.0/`
  only, and net8 rejects it with `NU1202`.
- Warning sets are identical between master (net8 / 1.0.803) and this branch
  (net10 / 1.0.902) — `CS0618` x16, `CS0168` x12, `CS8603` x4 — so no API contract shifted.
  `MSB3246` disappears; the only new diagnostic is advisory `NU1510`.
- Built clean (0 errors) and run in-game on RebornBuddy 1.0.902.
