### PR TITLE
AST - Smarter card play and Helios Conjunction heal tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Authoritative guidance for developers working on the Magitek routine.
 - Build: `dotnet build Magitek\Magitek.sln`
   - **Note:** The solution file is in the `Magitek` subdirectory, not the workspace root.
   - On Windows PowerShell, use semicolon separators: `cd Magitek; dotnet build Magitek.sln`
-- Magitek targets **.NET 8.0 (net8.0-windows8.0)** and is loaded inside RebornBuddy.
+- Magitek targets **.NET 10.0 (net10.0-windows8.0)** and is loaded inside RebornBuddy (1.0.900 and later run on .NET 10).
 - C# Language Version: **C# 10** (enforced via `<LangVersion>10</LangVersion>` in Magitek.csproj).
 - Preferred IDE: Visual Studio 2022 or JetBrains Rider with the Windows workload.
 

--- a/Magitek/Extensions/CharacterExtensions.cs
+++ b/Magitek/Extensions/CharacterExtensions.cs
@@ -96,6 +96,27 @@ namespace Magitek.Extensions
             Auras.TheSpire,
         };
 
+        // The subset of HealerShields that OVERWRITE one another rather than stacking, so a target
+        // carrying any one of them cannot usefully be given another. Confirmed in game: our own
+        // Galvanize was replaced in the same millisecond a Sage's Eukrasian Prognosis landed, with
+        // 29s still on it. Cross-class, which is why this cannot be a per-job list.
+        public static uint[] PrimaryShields = new uint[]
+        {
+            Auras.Galvanize,
+            Auras.EukrasianDiagnosis,
+            Auras.EukrasianPrognosis,
+        };
+
+        /// <summary>
+        /// True when the unit already carries a primary shield from ANY healer, ours or another's.
+        /// Deliberately not own-aura only: these overwrite each other, so someone else's shield
+        /// still makes ours redundant.
+        /// </summary>
+        public static bool HasPrimaryShield(this Character unit, int msLeft = 0)
+        {
+            return unit != null && unit.HasAnyAura(PrimaryShields, false, msLeft);
+        }
+
         public static uint[] BuffIgnore = new uint[]
         {
             Auras.DancePartner,

--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -176,6 +176,18 @@ namespace Magitek.Extensions
 
         }
 
+        /// <summary>
+        /// Whether the unit already carries a magical barrier that another one would waste.
+        /// <para>
+        /// Adloquium and Succor state that the effect "cannot be stacked with certain sage barrier
+        /// effects", so Galvanize and the Eukrasian barriers are mutually exclusive — re-shielding someone
+        /// who has either throws the cast away. Catalyze is deliberately excluded: it sits alongside
+        /// Galvanize rather than replacing it, so its presence says nothing about whether a fresh barrier
+        /// would land.
+        /// </para>
+        /// </summary>
+        /// <param name="msLeft">Only count a barrier with at least this long remaining, so one about to
+        /// lapse doesn't block a replacement.</param>
         // A dispel strips a BENEFICIAL status from an enemy, so a helper used to decide whether to
         // dispel has to ignore debuffs. Named for what it actually asks: the old name read as the
         // opposite of what it did, and let a dispel re-fire forever on an enemy that merely carries a

--- a/Magitek/Logic/Astrologian/Buff.cs
+++ b/Magitek/Logic/Astrologian/Buff.cs
@@ -91,6 +91,9 @@ namespace Magitek.Logic.Astrologian
             if (!Spells.Divination.IsKnownAndReady())
                 return false;
 
+            if (Cards.HoldDivinationForDraw())
+                return false;
+
             // Added check to see if more than configured allies are around
             var divinationTargets = Group.CastableAlliesWithin30.Count(r => r.IsAlive);
 

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -4,105 +4,148 @@ using ff14bot.Objects;
 using Magitek.Extensions;
 using Magitek.Models.Astrologian;
 using Magitek.Utilities;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using static ff14bot.Managers.ActionResourceManager.Astrologian;
+using Auras = Magitek.Utilities.Auras;
 
 namespace Magitek.Logic.Astrologian
 {
     internal static class Cards
     {
+        // The next draw overwrites the hand, so play out anything held this close to it.
+        private const int DrawDumpWindowSeconds = 10;
 
-        public static AstrologianCard GetDrawnCard()
+        // Failsafe: a play condition stuck false used to wedge the draw permanently.
+        private const int DrawStallBreakSeconds = 15;
+
+        // Divination will wait at most this long for a draw to put a damage card in hand.
+        private const int HoldDivinationForDrawSeconds = 10;
+
+        private static DateTime _readyDrawBlockedSince = DateTime.MinValue;
+
+        // Mirror of the Play I hold: no damage card in hand and a draw about to land means
+        // waiting puts the fresh Balance or Spear inside the window.
+        public static bool HoldDivinationForDraw()
         {
-            var drawnCards = CurrentCards;
-
-            foreach (var card in drawnCards)
-            {
-                if (card == AstrologianCard.None)
-                    continue;
-
-                return card;
-            }
-
-            return AstrologianCard.None;
-        }
-        public static async Task<bool> PlayCards()
-        {
-            var drawnCard = GetDrawnCard();
-
-            var cardDrawn = drawnCard != AstrologianCard.None;
-
-            /*
-            Looks like Arcana is now filled with either the Crown Draw, Or the Arcana Draw with Arcana Draw taking priority.
-            
-            The Card ID's have changed... but there's some goof with Reborn where whether or not you have Lord, Lady, or nothing, the Card ID drawn changes:
-                None = 0, 112, 128
-                Balance = 1, 113, 129.
-                Bole = 2, 114, 130.
-                Arrow = 3, 115, 131.
-                Spear = 4, 116, 132.
-                Ewer = 5, 117, 133.
-                Spire = 6, 118, 134.
-
-            There's some temporary workarounds above until reborn has this fixed.
-
-            */
-
-            //if (ActionManager.CanCast(Spells.Draw, Core.Me)
-            //    && AstrologianSettings.Instance.UseDraw
-            //    && !cardDrawn)
-            //     if (await Spells.Draw.Cast(Core.Me))
-            //       await Coroutine.Wait(700, () => GetDrawnCard() != AstrologianCard.None);
-
-            if (!cardDrawn)
+            if (!AstrologianSettings.Instance.AlignCardsWithDivination)
                 return false;
 
-            //if (Core.Me.InCombat && Spells.MinorArcana.IsKnownAndReady() && AstrologianSettings.Instance.UseMinorArcana)
-            //    if (!Core.Me.HasAnyAura(new uint[] { Auras.LadyOfCrownsDrawn, Auras.LordOfCrownsDrawn }))
-            //        return await Spells.MinorArcana.Cast(Core.Me);
+            if (CurrentCards.Any(card => card == AstrologianCard.Balance || card == AstrologianCard.Spear))
+                return false;
 
-            //if (Combat.CombatTotalTimeLeft <= AstrologianSettings.Instance.DontPlayWhenCombatTimeIsLessThan)
-            //    return false;
+            var drawCooldown = DrawCooldownRemainingSeconds();
 
-            //if (await RedrawOrDrawAgain(drawnCard))
-            //    return true;
+            return drawCooldown != null && drawCooldown <= HoldDivinationForDrawSeconds;
+        }
 
-            if (Globals.InParty && Core.Me.InCombat && AstrologianSettings.Instance.Play)
-            {
-                switch (drawnCard)
-                {
-                    case AstrologianCard.Balance:
-                        return await Spells.PlayI.Masked().Cast(MeleeDpsOrTank());
-                    case AstrologianCard.Spear:
-                        return await Spells.PlayI.Masked().Cast(RangedDpsOrHealer());
-                    case AstrologianCard.Bole:
-                        return await Spells.PlayII.Masked().Cast(Tank());
-                    case AstrologianCard.Arrow:
-                        return await Spells.PlayII.Masked().Cast(Tank());
-                    case AstrologianCard.Ewer:
-                        return await Spells.PlayIII.Masked().Cast(Tank());
-                    case AstrologianCard.Spire:
-                        return await Spells.PlayIII.Masked().Cast(Tank());
-                }
-            }
-
+        public static async Task<bool> PlayCards()
+        {
             if (!AstrologianSettings.Instance.Play)
                 return false;
 
-            if (!Globals.InParty && Core.Me.InCombat)
-                switch (drawnCard)
+            if (!Core.Me.InCombat)
+                return false;
+
+            // A card's identity tells us its slot.
+            var playICard = AstrologianCard.None;
+            var playIICard = AstrologianCard.None;
+            var playIIICard = AstrologianCard.None;
+
+            foreach (var card in CurrentCards)
+            {
+                switch (card)
                 {
                     case AstrologianCard.Balance:
                     case AstrologianCard.Spear:
-                        return await Spells.PlayI.Masked().Cast(Core.Me);
+                        playICard = card;
+                        break;
+
                     case AstrologianCard.Bole:
                     case AstrologianCard.Arrow:
-                        return await Spells.PlayII.Masked().Cast(Core.Me);
+                        playIICard = card;
+                        break;
+
                     case AstrologianCard.Ewer:
                     case AstrologianCard.Spire:
-                        return await Spells.PlayIII.Masked().Cast(Core.Me);
+                        playIIICard = card;
+                        break;
                 }
+            }
+
+            if (playICard == AstrologianCard.None
+                && playIICard == AstrologianCard.None
+                && playIIICard == AstrologianCard.None)
+                return false;
+
+            var drawCooldown = DrawCooldownRemainingSeconds();
+
+            // No draw known (deep sync) means nothing can overwrite the hand, so never dump.
+            var dumping = drawCooldown != null && drawCooldown <= DrawDumpWindowSeconds;
+
+            // Damage card first: once its Divination hold releases, every weave window it
+            // spends behind Arrow or Spire is burst window lost. While held it returns
+            // false and the utility cards get the windows anyway.
+            if (playICard != AstrologianCard.None)
+            {
+                // Compared against the draw cooldown, not a constant: holding only when
+                // Divination lands first is what stops the hold from ever delaying a draw.
+                var holdForDivination = AstrologianSettings.Instance.AlignCardsWithDivination
+                                        && AstrologianSettings.Instance.Divination
+                                        && Spells.Divination.IsKnown()
+                                        && !Core.Me.HasAura(Auras.Divination, true)
+                                        && drawCooldown != null
+                                        && Spells.Divination.Cooldown.TotalSeconds <= drawCooldown
+                                        && !dumping;
+
+                if (!holdForDivination)
+                {
+                    var target = playICard == AstrologianCard.Balance ? MeleeDpsOrTank() : RangedDpsOrHealer();
+
+                    if (await Spells.PlayI.Masked().Cast(target))
+                        return true;
+                }
+            }
+
+            // Peek, not the responder: a card is additive and must not consume the mechanic.
+            if (playIICard != AstrologianCard.None)
+            {
+                var busterTarget = FightLogic.Peek.EnemyIsCastingTankBuster();
+                var target = (GameObject)busterTarget ?? MainTankOrFallback();
+
+                if (dumping
+                    || busterTarget != null
+                    || target.CurrentHealthPercent <= AstrologianSettings.Instance.PlayUtilityCardHealthPercent)
+                    if (await Spells.PlayII.Masked().Cast(target))
+                        return true;
+            }
+
+            if (playIIICard == AstrologianCard.Spire)
+            {
+                var busterTarget = FightLogic.Peek.EnemyIsCastingTankBuster();
+                var target = (GameObject)busterTarget ?? MainTankOrFallback();
+
+                if (dumping
+                    || busterTarget != null
+                    || target.CurrentHealthPercent <= AstrologianSettings.Instance.PlayUtilityCardHealthPercent)
+                    if (await Spells.PlayIII.Masked().Cast(target))
+                        return true;
+            }
+
+            if (playIIICard == AstrologianCard.Ewer)
+            {
+                var target = (GameObject)Group.CastableAlliesWithin30
+                                 .Where(a => a.CurrentHealth > 0)
+                                 .OrderBy(a => a.CurrentHealthPercent)
+                                 .FirstOrDefault()
+                             ?? MainTankOrFallback();
+
+                if (dumping
+                    || target.CurrentHealthPercent <= AstrologianSettings.Instance.PlayUtilityCardHealthPercent)
+                    if (await Spells.PlayIII.Masked().Cast(target))
+                        return true;
+            }
 
             return false;
         }
@@ -114,25 +157,84 @@ namespace Magitek.Logic.Astrologian
             if (!Core.Me.InCombat && Globals.InSanctuaryOrSafeZone)
                 return false;
 
-            foreach (var card in CurrentCards)
-            {
-                if (card != AstrologianCard.None)
-                    return false;
-            }
-
             // The two draws are one alternating button under the hood (shared recast, and the
             // client swaps the base action to whichever draw is active), so they cannot be
             // toggled separately — one setting governs drawing as a whole.
             if (!AstrologianSettings.Instance.DrawCards)
                 return false;
 
-            if (Spells.AstralDraw.IsKnownAndReady())
-                return await Spells.AstralDraw.Cast(Core.Me);
+            var readyDraw = Spells.AstralDraw.IsKnownAndReady() ? Spells.AstralDraw
+                : Spells.UmbralDraw.IsKnownAndReady() ? Spells.UmbralDraw
+                : null;
 
-            if (Spells.UmbralDraw.IsKnownAndReady())
-                return await Spells.UmbralDraw.Cast(Core.Me);
+            var handEmpty = CurrentCards.All(card => card == AstrologianCard.None);
 
-            return false;
+            if (handEmpty)
+            {
+                _readyDrawBlockedSince = DateTime.MinValue;
+
+                if (readyDraw == null)
+                    return false;
+
+                return await readyDraw.Cast(Core.Me);
+            }
+
+            // Out of combat nothing can wedge — plays are combat-gated — so a held hand just waits for the pull.
+            if (readyDraw == null || !Core.Me.InCombat)
+            {
+                _readyDrawBlockedSince = DateTime.MinValue;
+                return false;
+            }
+
+            // Stall-breaker: a ready draw blocked by a non-empty hand for this long means
+            // the play conditions have wedged, so draw anyway and accept the overwrite —
+            // the draw's MP restore and fresh cards beat whatever is being held.
+            if (_readyDrawBlockedSince == DateTime.MinValue)
+            {
+                _readyDrawBlockedSince = DateTime.Now;
+                return false;
+            }
+
+            if (DateTime.Now - _readyDrawBlockedSince <= TimeSpan.FromSeconds(DrawStallBreakSeconds))
+                return false;
+
+            if (!await readyDraw.Cast(Core.Me))
+                return false;
+
+            _readyDrawBlockedSince = DateTime.MinValue;
+            return true;
+        }
+
+        // Remaining time on the shared draw recast, or null when no draw is known. The two
+        // draws alternate as one button and share the recast, so whichever reports as known
+        // carries the real remaining time; taking the minimum over the known ones covers
+        // either of them (or both) being known without caring which is active.
+        private static double? DrawCooldownRemainingSeconds()
+        {
+            double? remaining = null;
+
+            if (Spells.AstralDraw.IsKnown())
+                remaining = Spells.AstralDraw.Cooldown.TotalSeconds;
+
+            if (Spells.UmbralDraw.IsKnown())
+            {
+                var umbral = Spells.UmbralDraw.Cooldown.TotalSeconds;
+
+                if (remaining == null || umbral < remaining)
+                    remaining = umbral;
+            }
+
+            return remaining;
+        }
+
+        private static GameObject MainTankOrFallback()
+        {
+            var mainTank = Group.CastableAlliesWithin30.FirstOrDefault(a => a.CurrentHealth > 0 && a.IsTank(mainTank: true));
+
+            if (mainTank != null)
+                return mainTank;
+
+            return Tank();
         }
 
         private static GameObject Tank()
@@ -159,12 +261,12 @@ namespace Magitek.Logic.Astrologian
             // The pool boundary IS the potency bracket, deliberately: off-role recipients get
             // only 3%, and a full-potency tank (~two-thirds of a DPS's output at 6%) out-gains
             // a half-potency ranged DPS — so with no melee DPS alive the tank is the right call.
-            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
+            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && !a.HasAura(Auras.Weakness) && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
 
             //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
-                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
+                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && !a.HasAura(Auras.Weakness) && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
                 return extendedAlly.FirstOrDefault(Core.Me);
             }
             return ally.FirstOrDefault(Core.Me);
@@ -178,12 +280,12 @@ namespace Magitek.Logic.Astrologian
             // a DPS makes more of the buff than a healer, so DPS sort ahead inside the bracket.
             // Same deliberate pool boundary as The Balance: a half-potency melee DPS does not
             // out-gain a full-potency healer's-bracket recipient, so off-role DPS stay excluded.
-            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
+            var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && !a.HasAura(Auras.Weakness) && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
 
             //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
-                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
+                var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && !a.HasAura(Auras.Weakness) && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
                 return extendedAlly.FirstOrDefault(Core.Me);
             }
             return ally.FirstOrDefault(Core.Me);

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -23,29 +23,37 @@ namespace Magitek.Logic.Astrologian
             if (!cards.Any(c => c != AstrologianCard.None))
                 return false;
 
-            if (Globals.InParty && Core.Me.InCombat)
+            if (Globals.InParty && Core.Me.InCombat && AstrologianSettings.Instance.Play)
             {
+                // --- PLAY I (Damage Buffs) ---
                 if (cards.Contains(AstrologianCard.Balance))
+                {
                     return await Spells.PlayI.Masked().Cast(MeleeDpsOrTank());
+                }
                 if (cards.Contains(AstrologianCard.Spear))
+                {
                     return await Spells.PlayI.Masked().Cast(RangedDpsOrHealer());
+                }
 
-                if (cards.Contains(AstrologianCard.Arrow) || cards.Contains(AstrologianCard.Bole))
-                    return await Spells.PlayII.Masked().Cast(Tank());
+                // --- PLAY II (Defensives: Bole / Arrow) ---
+                if (cards.Contains(AstrologianCard.Bole) || cards.Contains(AstrologianCard.Arrow))
+                {
+                    var defensiveTarget = Tank();
+                    if (defensiveTarget != null && defensiveTarget.CurrentHealthPercent <= AstrologianSettings.Instance.PlayDefensiveCardHealthPercent)
+                    {
+                        return await Spells.PlayII.Masked().Cast(defensiveTarget);
+                    }
+                }
 
-                if (cards.Contains(AstrologianCard.Spire) || cards.Contains(AstrologianCard.Ewer))
-                    return await Spells.PlayIII.Masked().Cast(Tank());
-            }
-            else if (!Globals.InParty && Core.Me.InCombat)
-            {
-                if (cards.Contains(AstrologianCard.Balance) || cards.Contains(AstrologianCard.Spear))
-                    return await Spells.PlayI.Masked().Cast(Core.Me);
-
-                if (cards.Contains(AstrologianCard.Arrow) || cards.Contains(AstrologianCard.Bole))
-                    return await Spells.PlayII.Masked().Cast(Core.Me);
-
-                if (cards.Contains(AstrologianCard.Spire) || cards.Contains(AstrologianCard.Ewer))
-                    return await Spells.PlayIII.Masked().Cast(Core.Me);
+                // --- PLAY III (Utility: Ewer / Spire) ---
+                if (cards.Contains(AstrologianCard.Ewer) || cards.Contains(AstrologianCard.Spire))
+                {
+                    var utilityTarget = Tank();
+                    if (utilityTarget != null && utilityTarget.CurrentHealthPercent <= AstrologianSettings.Instance.PlayDefensiveCardHealthPercent)
+                    {
+                        return await Spells.PlayIII.Masked().Cast(utilityTarget);
+                    }
+                }
             }
 
             return false;
@@ -78,7 +86,7 @@ namespace Magitek.Logic.Astrologian
 
             return false;
         }
-            private static GameObject Tank()
+        private static GameObject Tank()
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -23,16 +23,25 @@ namespace Magitek.Logic.Astrologian
             if (!cards.Any(c => c != AstrologianCard.None))
                 return false;
 
-            if (Globals.InParty && Core.Me.InCombat && AstrologianSettings.Instance.Play)
+            // Removed Globals.InParty check so the Astrologian can buff themselves during solo combat
+            if (Core.Me.InCombat)
             {
                 // --- PLAY I (Damage Buffs) ---
                 if (cards.Contains(AstrologianCard.Balance))
                 {
-                    return await Spells.PlayI.Masked().Cast(MeleeDpsOrTank());
+                    var target = MeleeDpsOrTank();
+                    if (target != null)
+                    {
+                        return await Spells.PlayI.Masked().Cast(target);
+                    }
                 }
                 if (cards.Contains(AstrologianCard.Spear))
                 {
-                    return await Spells.PlayI.Masked().Cast(RangedDpsOrHealer());
+                    var target = RangedDpsOrHealer();
+                    if (target != null)
+                    {
+                        return await Spells.PlayI.Masked().Cast(target);
+                    }
                 }
 
                 // --- PLAY II (Defensives: Bole / Arrow) ---
@@ -86,10 +95,12 @@ namespace Magitek.Logic.Astrologian
 
             return false;
         }
+
         private static GameObject Tank()
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
+            
             //If in light party, allow ally to have more than one card aura.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && a.IsTank()).OrderBy(GetWeight);
 
@@ -105,6 +116,7 @@ namespace Magitek.Logic.Astrologian
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
+            
             // The Balance gives melee DPS and tanks the full 6%, but a DPS converts the buff
             // into far more damage than a tank, so DPS sort ahead of tanks inside the bracket.
             // The pool boundary IS the potency bracket, deliberately: off-role recipients get
@@ -124,6 +136,7 @@ namespace Magitek.Logic.Astrologian
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
+            
             // The Spear gives ranged DPS and healers the full 6%; same reasoning as The Balance,
             // a DPS makes more of the buff than a healer, so DPS sort ahead inside the bracket.
             // Same deliberate pool boundary as The Balance: a half-potency melee DPS does not

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -12,58 +12,97 @@ namespace Magitek.Logic.Astrologian
 {
     internal static class Cards
     {
+
+        public static AstrologianCard GetDrawnCard()
+        {
+            var drawnCards = CurrentCards;
+
+            foreach (var card in drawnCards)
+            {
+                if (card == AstrologianCard.None)
+                    continue;
+
+                return card;
+            }
+
+            return AstrologianCard.None;
+        }
         public static async Task<bool> PlayCards()
         {
+            var drawnCard = GetDrawnCard();
+
+            var cardDrawn = drawnCard != AstrologianCard.None;
+
+            /*
+            Looks like Arcana is now filled with either the Crown Draw, Or the Arcana Draw with Arcana Draw taking priority.
+            
+            The Card ID's have changed... but there's some goof with Reborn where whether or not you have Lord, Lady, or nothing, the Card ID drawn changes:
+                None = 0, 112, 128
+                Balance = 1, 113, 129.
+                Bole = 2, 114, 130.
+                Arrow = 3, 115, 131.
+                Spear = 4, 116, 132.
+                Ewer = 5, 117, 133.
+                Spire = 6, 118, 134.
+
+            There's some temporary workarounds above until reborn has this fixed.
+
+            */
+
+            //if (ActionManager.CanCast(Spells.Draw, Core.Me)
+            //    && AstrologianSettings.Instance.UseDraw
+            //    && !cardDrawn)
+            //     if (await Spells.Draw.Cast(Core.Me))
+            //       await Coroutine.Wait(700, () => GetDrawnCard() != AstrologianCard.None);
+
+            if (!cardDrawn)
+                return false;
+
+            //if (Core.Me.InCombat && Spells.MinorArcana.IsKnownAndReady() && AstrologianSettings.Instance.UseMinorArcana)
+            //    if (!Core.Me.HasAnyAura(new uint[] { Auras.LadyOfCrownsDrawn, Auras.LordOfCrownsDrawn }))
+            //        return await Spells.MinorArcana.Cast(Core.Me);
+
+            //if (Combat.CombatTotalTimeLeft <= AstrologianSettings.Instance.DontPlayWhenCombatTimeIsLessThan)
+            //    return false;
+
+            //if (await RedrawOrDrawAgain(drawnCard))
+            //    return true;
+
+            if (Globals.InParty && Core.Me.InCombat && AstrologianSettings.Instance.Play)
+            {
+                switch (drawnCard)
+                {
+                    case AstrologianCard.Balance:
+                        return await Spells.PlayI.Masked().Cast(MeleeDpsOrTank());
+                    case AstrologianCard.Spear:
+                        return await Spells.PlayI.Masked().Cast(RangedDpsOrHealer());
+                    case AstrologianCard.Bole:
+                        return await Spells.PlayII.Masked().Cast(Tank());
+                    case AstrologianCard.Arrow:
+                        return await Spells.PlayII.Masked().Cast(Tank());
+                    case AstrologianCard.Ewer:
+                        return await Spells.PlayIII.Masked().Cast(Tank());
+                    case AstrologianCard.Spire:
+                        return await Spells.PlayIII.Masked().Cast(Tank());
+                }
+            }
+
             if (!AstrologianSettings.Instance.Play)
                 return false;
 
-            var cards = CurrentCards.ToList();
-
-            // Check if any card is drawn
-            if (!cards.Any(c => c != AstrologianCard.None))
-                return false;
-
-            // Removed Globals.InParty check so the Astrologian can buff themselves during solo combat
-            if (Core.Me.InCombat)
-            {
-                // --- PLAY I (Damage Buffs) ---
-                if (cards.Contains(AstrologianCard.Balance))
+            if (!Globals.InParty && Core.Me.InCombat)
+                switch (drawnCard)
                 {
-                    var target = MeleeDpsOrTank();
-                    if (target != null)
-                    {
-                        return await Spells.PlayI.Masked().Cast(target);
-                    }
+                    case AstrologianCard.Balance:
+                    case AstrologianCard.Spear:
+                        return await Spells.PlayI.Masked().Cast(Core.Me);
+                    case AstrologianCard.Bole:
+                    case AstrologianCard.Arrow:
+                        return await Spells.PlayII.Masked().Cast(Core.Me);
+                    case AstrologianCard.Ewer:
+                    case AstrologianCard.Spire:
+                        return await Spells.PlayIII.Masked().Cast(Core.Me);
                 }
-                if (cards.Contains(AstrologianCard.Spear))
-                {
-                    var target = RangedDpsOrHealer();
-                    if (target != null)
-                    {
-                        return await Spells.PlayI.Masked().Cast(target);
-                    }
-                }
-
-                // --- PLAY II (Defensives: Bole / Arrow) ---
-                if (cards.Contains(AstrologianCard.Bole) || cards.Contains(AstrologianCard.Arrow))
-                {
-                    var defensiveTarget = Tank();
-                    if (defensiveTarget != null && defensiveTarget.CurrentHealthPercent <= AstrologianSettings.Instance.PlayDefensiveCardHealthPercent)
-                    {
-                        return await Spells.PlayII.Masked().Cast(defensiveTarget);
-                    }
-                }
-
-                // --- PLAY III (Utility: Ewer / Spire) ---
-                if (cards.Contains(AstrologianCard.Ewer) || cards.Contains(AstrologianCard.Spire))
-                {
-                    var utilityTarget = Tank();
-                    if (utilityTarget != null && utilityTarget.CurrentHealthPercent <= AstrologianSettings.Instance.PlayDefensiveCardHealthPercent)
-                    {
-                        return await Spells.PlayIII.Masked().Cast(utilityTarget);
-                    }
-                }
-            }
 
             return false;
         }
@@ -100,10 +139,9 @@ namespace Magitek.Logic.Astrologian
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
-            
-            //If in light party, allow ally to have more than one card aura.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && a.IsTank()).OrderBy(GetWeight);
 
+            //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
                 var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && a.IsTank()).OrderBy(GetWeight);
@@ -116,7 +154,6 @@ namespace Magitek.Logic.Astrologian
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
-            
             // The Balance gives melee DPS and tanks the full 6%, but a DPS converts the buff
             // into far more damage than a tank, so DPS sort ahead of tanks inside the bracket.
             // The pool boundary IS the potency bracket, deliberately: off-role recipients get
@@ -124,6 +161,7 @@ namespace Magitek.Logic.Astrologian
             // a half-potency ranged DPS — so with no melee DPS alive the tank is the right call.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
 
+            //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
                 var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
@@ -136,13 +174,13 @@ namespace Magitek.Logic.Astrologian
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
-            
             // The Spear gives ranged DPS and healers the full 6%; same reasoning as The Balance,
             // a DPS makes more of the buff than a healer, so DPS sort ahead inside the bracket.
             // Same deliberate pool boundary as The Balance: a half-potency melee DPS does not
             // out-gain a full-potency healer's-bracket recipient, so off-role DPS stay excluded.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
 
+            //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
                 var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
@@ -155,37 +193,80 @@ namespace Magitek.Logic.Astrologian
         {
             switch (c.CurrentJob)
             {
-                case ClassJobType.Astrologian: return AstrologianSettings.Instance.AstCardWeight;
+                case ClassJobType.Astrologian:
+                    return AstrologianSettings.Instance.AstCardWeight;
+
                 case ClassJobType.Monk:
-                case ClassJobType.Pugilist: return AstrologianSettings.Instance.MnkCardWeight;
+                case ClassJobType.Pugilist:
+                    return AstrologianSettings.Instance.MnkCardWeight;
+
                 case ClassJobType.BlackMage:
-                case ClassJobType.Thaumaturge: return AstrologianSettings.Instance.BlmCardWeight;
+                case ClassJobType.Thaumaturge:
+                    return AstrologianSettings.Instance.BlmCardWeight;
+
                 case ClassJobType.Dragoon:
-                case ClassJobType.Lancer: return AstrologianSettings.Instance.DrgCardWeight;
-                case ClassJobType.Samurai: return AstrologianSettings.Instance.SamCardWeight;
-                case ClassJobType.Machinist: return AstrologianSettings.Instance.MchCardWeight;
+                case ClassJobType.Lancer:
+                    return AstrologianSettings.Instance.DrgCardWeight;
+
+                case ClassJobType.Samurai:
+                    return AstrologianSettings.Instance.SamCardWeight;
+
+                case ClassJobType.Machinist:
+                    return AstrologianSettings.Instance.MchCardWeight;
+
                 case ClassJobType.Summoner:
-                case ClassJobType.Arcanist: return AstrologianSettings.Instance.SmnCardWeight;
+                case ClassJobType.Arcanist:
+                    return AstrologianSettings.Instance.SmnCardWeight;
+
                 case ClassJobType.Bard:
-                case ClassJobType.Archer: return AstrologianSettings.Instance.BrdCardWeight;
+                case ClassJobType.Archer:
+                    return AstrologianSettings.Instance.BrdCardWeight;
+
                 case ClassJobType.Ninja:
-                case ClassJobType.Rogue: return AstrologianSettings.Instance.NinCardWeight;
-                case ClassJobType.RedMage: return AstrologianSettings.Instance.RdmCardWeight;
-                case ClassJobType.Dancer: return AstrologianSettings.Instance.DncCardWeight;
+                case ClassJobType.Rogue:
+                    return AstrologianSettings.Instance.NinCardWeight;
+
+                case ClassJobType.RedMage:
+                    return AstrologianSettings.Instance.RdmCardWeight;
+
+                case ClassJobType.Dancer:
+                    return AstrologianSettings.Instance.DncCardWeight;
+
                 case ClassJobType.Paladin:
-                case ClassJobType.Gladiator: return AstrologianSettings.Instance.PldCardWeight;
+                case ClassJobType.Gladiator:
+                    return AstrologianSettings.Instance.PldCardWeight;
+
                 case ClassJobType.Warrior:
-                case ClassJobType.Marauder: return AstrologianSettings.Instance.WarCardWeight;
-                case ClassJobType.DarkKnight: return AstrologianSettings.Instance.DrkCardWeight;
-                case ClassJobType.Gunbreaker: return AstrologianSettings.Instance.GnbCardWeight;
+                case ClassJobType.Marauder:
+                    return AstrologianSettings.Instance.WarCardWeight;
+
+                case ClassJobType.DarkKnight:
+                    return AstrologianSettings.Instance.DrkCardWeight;
+
+                case ClassJobType.Gunbreaker:
+                    return AstrologianSettings.Instance.GnbCardWeight;
+
                 case ClassJobType.WhiteMage:
-                case ClassJobType.Conjurer: return AstrologianSettings.Instance.WhmCardWeight;
-                case ClassJobType.Scholar: return AstrologianSettings.Instance.SchCardWeight;
-                case ClassJobType.Reaper: return AstrologianSettings.Instance.RprCardWeight;
-                case ClassJobType.Sage: return AstrologianSettings.Instance.SgeCardWeight;
-                case ClassJobType.Pictomancer: return AstrologianSettings.Instance.PctCardWeight;
-                case ClassJobType.Viper: return AstrologianSettings.Instance.VprCardWeight;
-                case ClassJobType.BlueMage: return AstrologianSettings.Instance.BluCardWeight;
+                case ClassJobType.Conjurer:
+                    return AstrologianSettings.Instance.WhmCardWeight;
+
+                case ClassJobType.Scholar:
+                    return AstrologianSettings.Instance.SchCardWeight;
+
+                case ClassJobType.Reaper:
+                    return AstrologianSettings.Instance.RprCardWeight;
+
+                case ClassJobType.Sage:
+                    return AstrologianSettings.Instance.SgeCardWeight;
+
+                case ClassJobType.Pictomancer:
+                    return AstrologianSettings.Instance.PctCardWeight;
+
+                case ClassJobType.Viper:
+                    return AstrologianSettings.Instance.VprCardWeight;
+
+                case ClassJobType.BlueMage:
+                    return AstrologianSettings.Instance.BluCardWeight;
             }
 
             return c.CurrentJob == ClassJobType.Adventurer ? 70 : 0;

--- a/Magitek/Logic/Astrologian/Cards.cs
+++ b/Magitek/Logic/Astrologian/Cards.cs
@@ -12,97 +12,41 @@ namespace Magitek.Logic.Astrologian
 {
     internal static class Cards
     {
-
-        public static AstrologianCard GetDrawnCard()
-        {
-            var drawnCards = CurrentCards;
-
-            foreach (var card in drawnCards)
-            {
-                if (card == AstrologianCard.None)
-                    continue;
-
-                return card;
-            }
-
-            return AstrologianCard.None;
-        }
         public static async Task<bool> PlayCards()
         {
-            var drawnCard = GetDrawnCard();
-
-            var cardDrawn = drawnCard != AstrologianCard.None;
-
-            /*
-            Looks like Arcana is now filled with either the Crown Draw, Or the Arcana Draw with Arcana Draw taking priority.
-            
-            The Card ID's have changed... but there's some goof with Reborn where whether or not you have Lord, Lady, or nothing, the Card ID drawn changes:
-                None = 0, 112, 128
-                Balance = 1, 113, 129.
-                Bole = 2, 114, 130.
-                Arrow = 3, 115, 131.
-                Spear = 4, 116, 132.
-                Ewer = 5, 117, 133.
-                Spire = 6, 118, 134.
-
-            There's some temporary workarounds above until reborn has this fixed.
-
-            */
-
-            //if (ActionManager.CanCast(Spells.Draw, Core.Me)
-            //    && AstrologianSettings.Instance.UseDraw
-            //    && !cardDrawn)
-            //     if (await Spells.Draw.Cast(Core.Me))
-            //       await Coroutine.Wait(700, () => GetDrawnCard() != AstrologianCard.None);
-
-            if (!cardDrawn)
-                return false;
-
-            //if (Core.Me.InCombat && Spells.MinorArcana.IsKnownAndReady() && AstrologianSettings.Instance.UseMinorArcana)
-            //    if (!Core.Me.HasAnyAura(new uint[] { Auras.LadyOfCrownsDrawn, Auras.LordOfCrownsDrawn }))
-            //        return await Spells.MinorArcana.Cast(Core.Me);
-
-            //if (Combat.CombatTotalTimeLeft <= AstrologianSettings.Instance.DontPlayWhenCombatTimeIsLessThan)
-            //    return false;
-
-            //if (await RedrawOrDrawAgain(drawnCard))
-            //    return true;
-
-            if (Globals.InParty && Core.Me.InCombat && AstrologianSettings.Instance.Play)
-            {
-                switch (drawnCard)
-                {
-                    case AstrologianCard.Balance:
-                        return await Spells.PlayI.Masked().Cast(MeleeDpsOrTank());
-                    case AstrologianCard.Spear:
-                        return await Spells.PlayI.Masked().Cast(RangedDpsOrHealer());
-                    case AstrologianCard.Bole:
-                        return await Spells.PlayII.Masked().Cast(Tank());
-                    case AstrologianCard.Arrow:
-                        return await Spells.PlayII.Masked().Cast(Tank());
-                    case AstrologianCard.Ewer:
-                        return await Spells.PlayIII.Masked().Cast(Tank());
-                    case AstrologianCard.Spire:
-                        return await Spells.PlayIII.Masked().Cast(Tank());
-                }
-            }
-
             if (!AstrologianSettings.Instance.Play)
                 return false;
 
-            if (!Globals.InParty && Core.Me.InCombat)
-                switch (drawnCard)
-                {
-                    case AstrologianCard.Balance:
-                    case AstrologianCard.Spear:
-                        return await Spells.PlayI.Masked().Cast(Core.Me);
-                    case AstrologianCard.Bole:
-                    case AstrologianCard.Arrow:
-                        return await Spells.PlayII.Masked().Cast(Core.Me);
-                    case AstrologianCard.Ewer:
-                    case AstrologianCard.Spire:
-                        return await Spells.PlayIII.Masked().Cast(Core.Me);
-                }
+            var cards = CurrentCards.ToList();
+
+            // Check if any card is drawn
+            if (!cards.Any(c => c != AstrologianCard.None))
+                return false;
+
+            if (Globals.InParty && Core.Me.InCombat)
+            {
+                if (cards.Contains(AstrologianCard.Balance))
+                    return await Spells.PlayI.Masked().Cast(MeleeDpsOrTank());
+                if (cards.Contains(AstrologianCard.Spear))
+                    return await Spells.PlayI.Masked().Cast(RangedDpsOrHealer());
+
+                if (cards.Contains(AstrologianCard.Arrow) || cards.Contains(AstrologianCard.Bole))
+                    return await Spells.PlayII.Masked().Cast(Tank());
+
+                if (cards.Contains(AstrologianCard.Spire) || cards.Contains(AstrologianCard.Ewer))
+                    return await Spells.PlayIII.Masked().Cast(Tank());
+            }
+            else if (!Globals.InParty && Core.Me.InCombat)
+            {
+                if (cards.Contains(AstrologianCard.Balance) || cards.Contains(AstrologianCard.Spear))
+                    return await Spells.PlayI.Masked().Cast(Core.Me);
+
+                if (cards.Contains(AstrologianCard.Arrow) || cards.Contains(AstrologianCard.Bole))
+                    return await Spells.PlayII.Masked().Cast(Core.Me);
+
+                if (cards.Contains(AstrologianCard.Spire) || cards.Contains(AstrologianCard.Ewer))
+                    return await Spells.PlayIII.Masked().Cast(Core.Me);
+            }
 
             return false;
         }
@@ -134,14 +78,13 @@ namespace Magitek.Logic.Astrologian
 
             return false;
         }
-
-        private static GameObject Tank()
+            private static GameObject Tank()
         {
             //Get party size
             int partySize = Group.CastableAlliesWithin30.Count();
+            //If in light party, allow ally to have more than one card aura.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && a.IsTank()).OrderBy(GetWeight);
 
-            //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
                 var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && a.IsTank()).OrderBy(GetWeight);
@@ -161,7 +104,6 @@ namespace Magitek.Logic.Astrologian
             // a half-potency ranged DPS — so with no melee DPS alive the tank is the right call.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
 
-            //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
                 var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsTank() || a.IsMeleeDps())).OrderBy(a => a.IsTank() ? 1 : 0).ThenBy(GetWeight);
@@ -180,7 +122,6 @@ namespace Magitek.Logic.Astrologian
             // out-gain a full-potency healer's-bracket recipient, so off-role DPS stay excluded.
             var ally = Group.CastableAlliesWithin30.Where(a => !a.HasAnyCardAura() && a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
 
-            //If in light party, allow ally to have more than one card aura.
             if (partySize <= 4)
             {
                 var extendedAlly = Group.CastableAlliesWithin30.Where(a => a.CurrentHealth > 0 && (a.IsHealer() || a.IsRangedDpsCard())).OrderBy(a => a.IsHealer() ? 1 : 0).ThenBy(GetWeight);
@@ -193,80 +134,37 @@ namespace Magitek.Logic.Astrologian
         {
             switch (c.CurrentJob)
             {
-                case ClassJobType.Astrologian:
-                    return AstrologianSettings.Instance.AstCardWeight;
-
+                case ClassJobType.Astrologian: return AstrologianSettings.Instance.AstCardWeight;
                 case ClassJobType.Monk:
-                case ClassJobType.Pugilist:
-                    return AstrologianSettings.Instance.MnkCardWeight;
-
+                case ClassJobType.Pugilist: return AstrologianSettings.Instance.MnkCardWeight;
                 case ClassJobType.BlackMage:
-                case ClassJobType.Thaumaturge:
-                    return AstrologianSettings.Instance.BlmCardWeight;
-
+                case ClassJobType.Thaumaturge: return AstrologianSettings.Instance.BlmCardWeight;
                 case ClassJobType.Dragoon:
-                case ClassJobType.Lancer:
-                    return AstrologianSettings.Instance.DrgCardWeight;
-
-                case ClassJobType.Samurai:
-                    return AstrologianSettings.Instance.SamCardWeight;
-
-                case ClassJobType.Machinist:
-                    return AstrologianSettings.Instance.MchCardWeight;
-
+                case ClassJobType.Lancer: return AstrologianSettings.Instance.DrgCardWeight;
+                case ClassJobType.Samurai: return AstrologianSettings.Instance.SamCardWeight;
+                case ClassJobType.Machinist: return AstrologianSettings.Instance.MchCardWeight;
                 case ClassJobType.Summoner:
-                case ClassJobType.Arcanist:
-                    return AstrologianSettings.Instance.SmnCardWeight;
-
+                case ClassJobType.Arcanist: return AstrologianSettings.Instance.SmnCardWeight;
                 case ClassJobType.Bard:
-                case ClassJobType.Archer:
-                    return AstrologianSettings.Instance.BrdCardWeight;
-
+                case ClassJobType.Archer: return AstrologianSettings.Instance.BrdCardWeight;
                 case ClassJobType.Ninja:
-                case ClassJobType.Rogue:
-                    return AstrologianSettings.Instance.NinCardWeight;
-
-                case ClassJobType.RedMage:
-                    return AstrologianSettings.Instance.RdmCardWeight;
-
-                case ClassJobType.Dancer:
-                    return AstrologianSettings.Instance.DncCardWeight;
-
+                case ClassJobType.Rogue: return AstrologianSettings.Instance.NinCardWeight;
+                case ClassJobType.RedMage: return AstrologianSettings.Instance.RdmCardWeight;
+                case ClassJobType.Dancer: return AstrologianSettings.Instance.DncCardWeight;
                 case ClassJobType.Paladin:
-                case ClassJobType.Gladiator:
-                    return AstrologianSettings.Instance.PldCardWeight;
-
+                case ClassJobType.Gladiator: return AstrologianSettings.Instance.PldCardWeight;
                 case ClassJobType.Warrior:
-                case ClassJobType.Marauder:
-                    return AstrologianSettings.Instance.WarCardWeight;
-
-                case ClassJobType.DarkKnight:
-                    return AstrologianSettings.Instance.DrkCardWeight;
-
-                case ClassJobType.Gunbreaker:
-                    return AstrologianSettings.Instance.GnbCardWeight;
-
+                case ClassJobType.Marauder: return AstrologianSettings.Instance.WarCardWeight;
+                case ClassJobType.DarkKnight: return AstrologianSettings.Instance.DrkCardWeight;
+                case ClassJobType.Gunbreaker: return AstrologianSettings.Instance.GnbCardWeight;
                 case ClassJobType.WhiteMage:
-                case ClassJobType.Conjurer:
-                    return AstrologianSettings.Instance.WhmCardWeight;
-
-                case ClassJobType.Scholar:
-                    return AstrologianSettings.Instance.SchCardWeight;
-
-                case ClassJobType.Reaper:
-                    return AstrologianSettings.Instance.RprCardWeight;
-
-                case ClassJobType.Sage:
-                    return AstrologianSettings.Instance.SgeCardWeight;
-
-                case ClassJobType.Pictomancer:
-                    return AstrologianSettings.Instance.PctCardWeight;
-
-                case ClassJobType.Viper:
-                    return AstrologianSettings.Instance.VprCardWeight;
-
-                case ClassJobType.BlueMage:
-                    return AstrologianSettings.Instance.BluCardWeight;
+                case ClassJobType.Conjurer: return AstrologianSettings.Instance.WhmCardWeight;
+                case ClassJobType.Scholar: return AstrologianSettings.Instance.SchCardWeight;
+                case ClassJobType.Reaper: return AstrologianSettings.Instance.RprCardWeight;
+                case ClassJobType.Sage: return AstrologianSettings.Instance.SgeCardWeight;
+                case ClassJobType.Pictomancer: return AstrologianSettings.Instance.PctCardWeight;
+                case ClassJobType.Viper: return AstrologianSettings.Instance.VprCardWeight;
+                case ClassJobType.BlueMage: return AstrologianSettings.Instance.BluCardWeight;
             }
 
             return c.CurrentJob == ClassJobType.Adventurer ? 70 : 0;

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -22,7 +22,7 @@ namespace Magitek.Logic.Astrologian
 
         public static bool NeedAoEHealing()
         {
-            var targets = Group.CastableAlliesWithin30.Where(r => r.CurrentHealthPercent <= AstrologianSettings.Instance.AoEHealThreshold);
+            var targets = Group.CastableAlliesWithin30.Where(r => r.CurrentHealthPercent <= AstrologianSettings.Instance.AoEHealHealthPercent);
 
             var needAoEHealing = targets.Count() >= AoeThreshold;
 
@@ -453,26 +453,26 @@ namespace Magitek.Logic.Astrologian
             if (AstrologianSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;
 
-            var spell = Spells.HeliosConjunction.IsKnown() ? Spells.HeliosConjunction : Spells.AspectedHelios;
-            uint aura = Spells.HeliosConjunction.IsKnown() ? (uint)Auras.HeliosConjunction : (uint)Auras.AspectedHelios;
-
-            if (Casting.LastSpell == spell)
+            if (AstrologianSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;
 
-            if (!spell.IsKnown())
+            // Add check to ensure we don't double cast
+            if (Casting.LastSpell == Spells.AspectedHelios)
+                return false;
+
+            if (!Spells.AspectedHelios.IsKnown())
                 return false;
 
             var alliesNeedingRegen = Group.CastableAlliesWithin15.Where(r => !Utilities.Routines.Astrologian.DontDiurnalBenefic.Contains(r.Name)
                 && r.CurrentHealth > 0
                 && !r.HasMyAura(Auras.AspectedBenefic)
                 && !r.HasMyAura(Auras.AspectedHelios)
-                && !r.HasMyAura(Auras.HeliosConjunction)
                 && r.CurrentHealthPercent <= AstrologianSettings.Instance.DiurnalBeneficHealthPercent).ToList();
 
             if (alliesNeedingRegen.Count() <= AoeThreshold)
                 return false;
 
-            return await spell.HealAura(Core.Me, aura);
+            return await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios);
         }
 
         private static async Task<bool> AspectedBeneficHealers()
@@ -537,20 +537,16 @@ namespace Magitek.Logic.Astrologian
             if (!AstrologianSettings.Instance.DiurnalHelios)
                 return false;
 
-            // Dawntrail Update: Dynamic mapping for Helios Conjunction with explicit uint casting
-            var spell = Spells.HeliosConjunction.IsKnown() ? Spells.HeliosConjunction : Spells.AspectedHelios;
-            uint aura = Spells.HeliosConjunction.IsKnown() ? (uint)Auras.HeliosConjunction : (uint)Auras.AspectedHelios;
-
-            if (!spell.IsKnownAndReady())
+            if (!Spells.AspectedHelios.IsKnownAndReady())
                 return false;
 
             if (Core.Me.HasAura(Auras.NeutralSect) &&
                 Group.CastableAlliesWithin15.Count(x => !x.HasAura(Auras.NeutralSectShield)) >= AoeThreshold && !Core.Me.HasAura(Auras.NeutralSectShield))
                 return MovementManager.IsMoving
                     ? await SwiftCastAspectedHelios()
-                    : await spell.HealAura(Core.Me, (uint)Auras.NeutralSectShield, false);
+                    : await Spells.AspectedHelios.HealAura(Core.Me, Auras.NeutralSectShield, false);
 
-            if (Casting.LastSpell == spell)
+            if (Casting.LastSpell == Spells.AspectedHelios)
                 return false;
 
             if (Core.Me.CurrentManaPercent <= AstrologianSettings.Instance.DiurnalHeliosMinManaPercent)
@@ -558,7 +554,7 @@ namespace Magitek.Logic.Astrologian
 
             var diurnalHeliosCount =
                 PartyManager.VisibleMembers.Select(r => r.BattleCharacter).Count(r => r.CurrentHealth > 0 &&
-                                                        r.WithinSpellRange(spell.Radius) &&
+                                                        r.WithinSpellRange(Spells.AspectedHelios.Radius) &&
                                                         r.CurrentHealthPercent <=
                                                         AstrologianSettings.Instance.DiurnalHeliosHealthPercent &&
                                                         !r.HasAura(Auras.AspectedHelios, true) && !r.HasAura(Auras.HeliosConjunction, true));
@@ -568,7 +564,7 @@ namespace Magitek.Logic.Astrologian
                 if (await SwiftCastAspectedHelios())
                     return true;
 
-                return await spell.HealAura(Core.Me, aura);
+                return await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios);
             }
             return false;
         }
@@ -584,12 +580,9 @@ namespace Magitek.Logic.Astrologian
             if (!await Buff.Swiftcast())
                 return false;
 
-            var spell = Spells.HeliosConjunction.IsKnown() ? Spells.HeliosConjunction : Spells.AspectedHelios;
-            uint aura = Spells.HeliosConjunction.IsKnown() ? (uint)Auras.HeliosConjunction : (uint)Auras.AspectedHelios;
-
             while (Core.Me.HasAura(Auras.Swiftcast))
             {
-                if (await spell.HealAura(Core.Me, aura, false))
+                if (await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios, false))
                     return true;
 
                 await Coroutine.Yield();

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -453,26 +453,26 @@ namespace Magitek.Logic.Astrologian
             if (AstrologianSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;
 
-            if (AstrologianSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
+            var spell = Spells.HeliosConjunction.IsKnown() ? Spells.HeliosConjunction : Spells.AspectedHelios;
+            uint aura = Spells.HeliosConjunction.IsKnown() ? (uint)Auras.HeliosConjunction : (uint)Auras.AspectedHelios;
+
+            if (Casting.LastSpell == spell)
                 return false;
 
-            // Add check to ensure we don't double cast
-            if (Casting.LastSpell == Spells.AspectedHelios)
-                return false;
-
-            if (!Spells.AspectedHelios.IsKnown())
+            if (!spell.IsKnown())
                 return false;
 
             var alliesNeedingRegen = Group.CastableAlliesWithin15.Where(r => !Utilities.Routines.Astrologian.DontDiurnalBenefic.Contains(r.Name)
                 && r.CurrentHealth > 0
                 && !r.HasMyAura(Auras.AspectedBenefic)
                 && !r.HasMyAura(Auras.AspectedHelios)
+                && !r.HasMyAura(Auras.HeliosConjunction)
                 && r.CurrentHealthPercent <= AstrologianSettings.Instance.DiurnalBeneficHealthPercent).ToList();
 
             if (alliesNeedingRegen.Count() <= AoeThreshold)
                 return false;
 
-            return await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios);
+            return await spell.HealAura(Core.Me, aura);
         }
 
         private static async Task<bool> AspectedBeneficHealers()
@@ -537,16 +537,20 @@ namespace Magitek.Logic.Astrologian
             if (!AstrologianSettings.Instance.DiurnalHelios)
                 return false;
 
-            if (!Spells.AspectedHelios.IsKnownAndReady())
+            // Dawntrail Update: Dynamic mapping for Helios Conjunction with explicit uint casting
+            var spell = Spells.HeliosConjunction.IsKnown() ? Spells.HeliosConjunction : Spells.AspectedHelios;
+            uint aura = Spells.HeliosConjunction.IsKnown() ? (uint)Auras.HeliosConjunction : (uint)Auras.AspectedHelios;
+
+            if (!spell.IsKnownAndReady())
                 return false;
 
             if (Core.Me.HasAura(Auras.NeutralSect) &&
                 Group.CastableAlliesWithin15.Count(x => !x.HasAura(Auras.NeutralSectShield)) >= AoeThreshold && !Core.Me.HasAura(Auras.NeutralSectShield))
                 return MovementManager.IsMoving
                     ? await SwiftCastAspectedHelios()
-                    : await Spells.AspectedHelios.HealAura(Core.Me, Auras.NeutralSectShield, false);
+                    : await spell.HealAura(Core.Me, (uint)Auras.NeutralSectShield, false);
 
-            if (Casting.LastSpell == Spells.AspectedHelios)
+            if (Casting.LastSpell == spell)
                 return false;
 
             if (Core.Me.CurrentManaPercent <= AstrologianSettings.Instance.DiurnalHeliosMinManaPercent)
@@ -554,7 +558,7 @@ namespace Magitek.Logic.Astrologian
 
             var diurnalHeliosCount =
                 PartyManager.VisibleMembers.Select(r => r.BattleCharacter).Count(r => r.CurrentHealth > 0 &&
-                                                        r.WithinSpellRange(Spells.AspectedHelios.Radius) &&
+                                                        r.WithinSpellRange(spell.Radius) &&
                                                         r.CurrentHealthPercent <=
                                                         AstrologianSettings.Instance.DiurnalHeliosHealthPercent &&
                                                         !r.HasAura(Auras.AspectedHelios, true) && !r.HasAura(Auras.HeliosConjunction, true));
@@ -564,7 +568,7 @@ namespace Magitek.Logic.Astrologian
                 if (await SwiftCastAspectedHelios())
                     return true;
 
-                return await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios);
+                return await spell.HealAura(Core.Me, aura);
             }
             return false;
         }
@@ -580,9 +584,12 @@ namespace Magitek.Logic.Astrologian
             if (!await Buff.Swiftcast())
                 return false;
 
+            var spell = Spells.HeliosConjunction.IsKnown() ? Spells.HeliosConjunction : Spells.AspectedHelios;
+            uint aura = Spells.HeliosConjunction.IsKnown() ? (uint)Auras.HeliosConjunction : (uint)Auras.AspectedHelios;
+
             while (Core.Me.HasAura(Auras.Swiftcast))
             {
-                if (await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios, false))
+                if (await spell.HealAura(Core.Me, aura, false))
                     return true;
 
                 await Coroutine.Yield();

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -453,9 +453,6 @@ namespace Magitek.Logic.Astrologian
             if (AstrologianSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
                 return false;
 
-            if (AstrologianSettings.Instance.DisableSingleHealWhenNeedAoeHealing && NeedAoEHealing())
-                return false;
-
             // Add check to ensure we don't double cast
             if (Casting.LastSpell == Spells.AspectedHelios)
                 return false;
@@ -463,16 +460,20 @@ namespace Magitek.Logic.Astrologian
             if (!Spells.AspectedHelios.IsKnown())
                 return false;
 
+            // RB masks the spell to Helios Conjunction at 96+, but not the aura it applies.
+            var heliosAura = (uint)(Spells.HeliosConjunction.IsKnown() ? Auras.HeliosConjunction : Auras.AspectedHelios);
+
             var alliesNeedingRegen = Group.CastableAlliesWithin15.Where(r => !Utilities.Routines.Astrologian.DontDiurnalBenefic.Contains(r.Name)
                 && r.CurrentHealth > 0
                 && !r.HasMyAura(Auras.AspectedBenefic)
                 && !r.HasMyAura(Auras.AspectedHelios)
+                && !r.HasMyAura(Auras.HeliosConjunction)
                 && r.CurrentHealthPercent <= AstrologianSettings.Instance.DiurnalBeneficHealthPercent).ToList();
 
             if (alliesNeedingRegen.Count() <= AoeThreshold)
                 return false;
 
-            return await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios);
+            return await Spells.AspectedHelios.HealAura(Core.Me, heliosAura);
         }
 
         private static async Task<bool> AspectedBeneficHealers()
@@ -564,7 +565,10 @@ namespace Magitek.Logic.Astrologian
                 if (await SwiftCastAspectedHelios())
                     return true;
 
-                return await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios);
+                // RB masks the spell to Helios Conjunction at 96+, but not the aura it applies.
+                var heliosAura = (uint)(Spells.HeliosConjunction.IsKnown() ? Auras.HeliosConjunction : Auras.AspectedHelios);
+
+                return await Spells.AspectedHelios.HealAura(Core.Me, heliosAura);
             }
             return false;
         }
@@ -580,9 +584,11 @@ namespace Magitek.Logic.Astrologian
             if (!await Buff.Swiftcast())
                 return false;
 
+            var heliosAura = (uint)(Spells.HeliosConjunction.IsKnown() ? Auras.HeliosConjunction : Auras.AspectedHelios);
+
             while (Core.Me.HasAura(Auras.Swiftcast))
             {
-                if (await Spells.AspectedHelios.HealAura(Core.Me, Auras.AspectedHelios, false))
+                if (await Spells.AspectedHelios.HealAura(Core.Me, heliosAura, false))
                     return true;
 
                 await Coroutine.Yield();

--- a/Magitek/Logic/Astrologian/Heals.cs
+++ b/Magitek/Logic/Astrologian/Heals.cs
@@ -22,7 +22,7 @@ namespace Magitek.Logic.Astrologian
 
         public static bool NeedAoEHealing()
         {
-            var targets = Group.CastableAlliesWithin30.Where(r => r.CurrentHealthPercent <= AstrologianSettings.Instance.AoEHealHealthPercent);
+            var targets = Group.CastableAlliesWithin30.Where(r => r.CurrentHealthPercent <= AstrologianSettings.Instance.AoEHealThreshold);
 
             var needAoEHealing = targets.Count() >= AoeThreshold;
 

--- a/Magitek/Logic/Sage/Heal.cs
+++ b/Magitek/Logic/Sage/Heal.cs
@@ -170,10 +170,10 @@ namespace Magitek.Logic.Sage
                     if (unit.CurrentHealthPercent > SageSettings.Instance.EukrasianDiagnosisHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.EukrasianDiagnosis))
-                        return false;
-
-                    if (unit.HasAura(Auras.Galvanize))
+                    // Any primary shield, ours or another healer's. This previously checked
+                    // Eukrasian Diagnosis and Galvanize but not Eukrasian Prognosis, so a target
+                    // already carrying Prognosis could have it overwritten by Diagnosis.
+                    if (unit.HasPrimaryShield())
                         return false;
 
                     if (!SageSettings.Instance.EukrasianDiagnosisOnlyHealer && !SageSettings.Instance.EukrasianDiagnosisOnlyTank)
@@ -243,9 +243,7 @@ namespace Magitek.Logic.Sage
                 return false;
 
             var targets = Group.CastableAlliesWithin20.Where(r => r.CurrentHealthPercent <= SageSettings.Instance.EukrasianPrognosisHealthPercent &&
-                                                                !r.HasAura(Auras.EukrasianDiagnosis) &&
-                                                                !r.HasAura(Auras.EukrasianPrognosis) &&
-                                                                !r.HasAura(Auras.Galvanize));
+                                                                !r.HasPrimaryShield());
 
             var needEukrasianPrognosis = targets.Count() >= AoeNeedHealing;
 

--- a/Magitek/Logic/Sage/HealFightLogic.cs
+++ b/Magitek/Logic/Sage/HealFightLogic.cs
@@ -90,9 +90,7 @@ namespace Magitek.Logic.Sage
                 && Spells.Eukrasia.IsKnown()
                 && Heal.IsEukrasiaReady())
             {
-                var targets = Group.CastableAlliesWithin20.Where(r => !r.HasAura(Auras.EukrasianDiagnosis)
-                                                                && !r.HasAura(Auras.EukrasianPrognosis)
-                                                                && !r.HasAura(Auras.Galvanize));
+                var targets = Group.CastableAlliesWithin20.Where(r => !r.HasPrimaryShield());
                 var tankCheck = !SageSettings.Instance.FightLogic_RespectOnlyTank
                     || targets.Any(r => r.IsTank());
 
@@ -154,9 +152,7 @@ namespace Magitek.Logic.Sage
 
             if (SageSettings.Instance.FightLogic_EukrasianDiagnosis
                 && Spells.Eukrasia.IsKnown()
-                && !target.HasAura(Auras.EukrasianDiagnosis)
-                && !target.HasAura(Auras.Galvanize)
-                && !target.HasAura(Auras.EukrasianPrognosis)
+                && !target.HasPrimaryShield()
                 && Heal.IsEukrasiaReady())
             {
                 if (BaseSettings.Instance.DebugFightLogic)

--- a/Magitek/Logic/Scholar/Buff.cs
+++ b/Magitek/Logic/Scholar/Buff.cs
@@ -72,7 +72,9 @@ namespace Magitek.Logic.Scholar
                     return false;
             }
 
-            return await Coroutine.Wait(5000, () => Core.Me.Pet != null);
+            // Summon fired; FairySummonCooldown (10s) + the Pet != null guard at the top prevent a
+            // double-summon, so there's no need to block the pulse waiting for the pet to materialize.
+            return true;
         }
 
         public static async Task<bool> SummonSeraph()
@@ -177,7 +179,7 @@ namespace Magitek.Logic.Scholar
                 // Check if tank needs Adloquium for buff
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasAura(Auras.Galvanize));
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasPrimaryShield());
                     if (tankAdloTarget != null)
                         return true;
                 }
@@ -195,7 +197,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.Galvanize))
+                    if (unit.HasPrimaryShield())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -212,7 +214,7 @@ namespace Magitek.Logic.Scholar
             }
 
             // Solo check
-            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasAura(Auras.Galvanize))
+            if (Core.Me.CurrentHealthPercent <= ScholarSettings.Instance.AdloquiumHpPercent && !Core.Me.HasPrimaryShield())
                 return true;
 
             return false;
@@ -223,22 +225,25 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Succor)
                 return false;
 
+            // Mirrors the gate in Heal.Succor so this stays a truthful prediction of whether Succor
+            // would actually fire: health decides the threshold, shields only decide whether the
+            // barrier is worth anything.
             var aoeNeedHealing = Heal.AoeNeedHealing;
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
-                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasAura(Auras.Galvanize)) >= aoeNeedHealing;
+                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent) >= aoeNeedHealing;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
+                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
+                                                                      !r.HasPrimaryShield()) > 0;
 
-            return needSuccor;
+            return needSuccor && needShields;
         }
 
         public static async Task<bool> Swiftcast()
         {
-            if (await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast))
-            {
-                return await Coroutine.Wait(15000, () => Core.Me.HasAura(Auras.Swiftcast, true, 7000));
-            }
-
-            return false;
+            // NOTE: this Scholar-local Swiftcast is unused — the live rez path uses Roles.Healer.Swiftcast.
+            // CastAura sends the cast; nothing here reads the aura afterward, so no blocking wait is needed
+            // (the old Wait(15000, ...) could freeze the routine for up to 15s).
+            return await Spells.Swiftcast.CastAura(Core.Me, Auras.Swiftcast);
         }
         public static async Task<bool> ForceSeraph()
         {
@@ -253,8 +258,16 @@ namespace Magitek.Logic.Scholar
 
         public static async Task<bool> EmergencyTactics()
         {
+            // The master opt-out outranks the armed short-circuit: a manually applied Emergency
+            // Tactics must not be auto-consumed by the conversion callers while the feature is off.
             if (!ScholarSettings.Instance.EmergencyTactics)
                 return false;
+
+            // Already armed and unconsumed: the objective is met, don't burn a second charge. A live
+            // run re-cast ET three times inside one Seraphism window because the conversion callers
+            // below had no awareness the aura was already up.
+            if (Core.Me.HasAura(Auras.EmergencyTactics))
+                return true;
 
             if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
                 return false;
@@ -262,13 +275,12 @@ namespace Magitek.Logic.Scholar
             if (!await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics))
                 return false;
 
-            return await Coroutine.Wait(1500, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
-
-            //if (await Spells.EmergencyTactics.CastAura(Core.Me, Auras.EmergencyTactics)) {
-            //    return await Coroutine.Wait(1700, () => Core.Me.HasAura(Auras.EmergencyTactics, true));
-            //}
-
-            //return false;
+            // Keep the arm→heal pair atomic: Emergency Tactics is instant (aura ~200ms), and the
+            // paired shield heal must clear its animation lock. One bounded wait per 15s cooldown
+            // is cheaper than the pairing drifting between pulses — a retarget, a co-healer
+            // top-off, or a higher-priority heal could otherwise waste or misdirect the armed
+            // conversion.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
         public static async Task<bool> Aetherflow()
@@ -300,9 +312,14 @@ namespace Magitek.Logic.Scholar
                 return false;
             if (Spells.DeploymentTactics.Cooldown.TotalMilliseconds > 1500)
                 return false;
+            // Deployment Tactics copies the barrier with only the time left on the original, and does not
+            // refresh it, so spreading one that is about to lapse spends a two minute cooldown on a shield
+            // that vanishes moments later. Require enough left on it to be worth the cooldown.
+            var minimumShieldMs = ScholarSettings.Instance.DeploymentTacticsMinimumShieldSeconds * 1000;
+
             // Find someone who has the right amount of allies around them based on the users settings
             var deploymentTacticsTarget = Group.CastableAlliesWithin30.FirstOrDefault(r =>
-                r.HasAura(Auras.Galvanize, true)
+                r.HasAura(Auras.Galvanize, true, minimumShieldMs)
                 && r.HasAura(Auras.Catalyze, true)
                 //Range now 30y
                 && Group.CastableAlliesWithin30.Count(x => x.Distance(r) <= 30 + x.CombatReach) >= ScholarSettings.Instance.DeploymentTacticsAllyInRange);

--- a/Magitek/Logic/Scholar/Heal.cs
+++ b/Magitek/Logic/Scholar/Heal.cs
@@ -11,6 +11,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Auras = Magitek.Utilities.Auras;
+using ScholarRoutine = Magitek.Utilities.Routines.Scholar;
 
 namespace Magitek.Logic.Scholar
 {
@@ -54,7 +55,7 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
-            if (!await Spells.Adloquium.Heal(target, false)) return false;
+            if (!await ScholarRoutine.AdloquiumSpell.Heal(target, false)) return false;
             ScholarSettings.Instance.ForceAdlo = false;
             TogglesManager.ResetToggles();
             return true;
@@ -86,6 +87,8 @@ namespace Magitek.Logic.Scholar
             if (target == null)
                 target = Core.Me;
 
+            // Deliberately NOT HasPrimaryShield(): Excogitation is a delayed heal, not a barrier, so
+            // the Adloquium/Succor non-stacking rule does not apply. This keeps the original check.
             if (target.HasAura(Auras.Galvanize))
                 return false;
 
@@ -111,7 +114,7 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.ForceSuccor)
                 return false;
 
-            if (!await Spells.Succor.Cast(Core.Me)) return false;
+            if (!await ScholarRoutine.SuccorSpell.Cast(Core.Me)) return false;
             ScholarSettings.Instance.ForceSuccor = false;
             TogglesManager.ResetToggles();
             return true;
@@ -122,13 +125,16 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.ForceEmergencySuccor)
                 return false;
 
-            if (!Spells.EmergencyTactics.IsKnownAndReady())
+            // Ready OR already armed: the helper below fires Emergency Tactics on one pulse and the
+            // follow-up heal consumes the aura on a later one, so "on cooldown but armed" must pass
+            // this gate or the forced Succor and the toggle reset become unreachable.
+            if (!Spells.EmergencyTactics.IsKnownAndReady() && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
-            if (!await UsedEmergencyTactics())
+            if (!await UsedEmergencyTactics(forced: true))
                 return false;
 
-            if (!await Spells.Succor.Cast(Core.Me)) return false;
+            if (!await ScholarRoutine.SuccorSpell.Cast(Core.Me)) return false;
             ScholarSettings.Instance.ForceEmergencySuccor = false;
             TogglesManager.ResetToggles();
             return true;
@@ -169,22 +175,46 @@ namespace Magitek.Logic.Scholar
             return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
         }
 
-        private static async Task<bool> UsedEmergencyTactics()
+        /// <summary>
+        /// True when the AUTOMATIC Emergency Tactics conversion could run right now — the same
+        /// gate set UsedEmergencyTactics enforces (the master opt-out, ready-or-armed). Target
+        /// selection consults this so it never picks an ally that only the conversion could
+        /// serve while the conversion itself would refuse.
+        /// </summary>
+        private static bool EmergencyTacticsConvertible()
         {
+            if (!ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
+            return Spells.EmergencyTactics.IsKnownAndReady() || Core.Me.HasAura(Auras.EmergencyTactics);
+        }
+
+        private static async Task<bool> UsedEmergencyTactics(bool forced = false)
+        {
+            // Same master opt-out as Buff.EmergencyTactics, in the same position: this helper is
+            // reachable from Accession/Manifestation barrier branches without any settings check
+            // in between, and disabling the feature must disable every automatic ET. The explicit
+            // force toggle is user intent, not automation, so it bypasses only this check.
+            if (!forced && !ScholarSettings.Instance.EmergencyTactics)
+                return false;
+
             if (Core.Me.HasAura(Auras.EmergencyTactics))
                 return true;
+
             if (!await Spells.EmergencyTactics.Cast(Core.Me))
                 return false;
-            if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics)))
-                return false;
-            return await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Succor.Id, Core.Me));
+
+            // Keep the arm→heal pair atomic (see Buff.EmergencyTactics): a bounded wait for the
+            // aura and the paired heal's castability, so the conversion cannot drift to another
+            // target or caller between pulses.
+            return await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.EmergencyTactics) && ActionManager.CanCast(Spells.Succor.Id, Core.Me));
         }
 
         private static async Task<bool> UsedAdloquium()
         {
             if (Core.Me.HasAura(Auras.Galvanize))
                 return true;
-            if (!await Spells.Adloquium.Cast(Core.Me))
+            if (!await ScholarRoutine.AdloquiumSpell.Cast(Core.Me))
                 return false;
             if (!await Coroutine.Wait(2000, () => Core.Me.HasAura(Auras.Galvanize)))
                 return false;
@@ -195,12 +225,13 @@ namespace Magitek.Logic.Scholar
         {
             if (Core.Me.HasAura(Auras.Galvanize))
                 return true;
-            if (!await Spells.Succor.Cast(Core.Me))
+            if (!await ScholarRoutine.SuccorSpell.Cast(Core.Me))
                 return false;
             return await Coroutine.Wait(2500, () => Core.Me.HasAura(Auras.Galvanize));
         }
 
         #endregion
+
 
         public static async Task<bool> Physick()
         {
@@ -240,7 +271,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Adloquium || !ScholarSettings.Instance.EmergencyTacticsAdloquium)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             if (Globals.InParty)
@@ -253,7 +286,7 @@ namespace Magitek.Logic.Scholar
                 if (!await Buff.EmergencyTactics())
                     return false;
 
-                return await Spells.Adloquium.Heal(adloTarget, false);
+                return await ScholarRoutine.AdloquiumSpell.Heal(adloTarget, false);
             }
 
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.EmergencyTacticsAdloquiumHealthPercent)
@@ -262,7 +295,7 @@ namespace Magitek.Logic.Scholar
             if (!await Buff.EmergencyTactics())
                 return false;
 
-            return await Spells.Adloquium.Heal(Core.Me, false);
+            return await ScholarRoutine.AdloquiumSpell.Heal(Core.Me, false);
 
             bool CanAdlo(Character unit)
             {
@@ -302,14 +335,14 @@ namespace Magitek.Logic.Scholar
                 if (ScholarSettings.Instance.AdloquiumTankForBuff && Globals.HealTarget?.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                 {
                     // Pick any tank who doesn't have Galvanize on them
-                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasAura(Auras.Galvanize));
+                    var tankAdloTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => r.IsTank() && !r.HasPrimaryShield());
 
                     if (tankAdloTarget == null)
                         return false;
 
                     await UseRecitation();
 
-                    return await Spells.Adloquium.HealAura(tankAdloTarget, Auras.Galvanize, false);
+                    return await ScholarRoutine.AdloquiumSpell.HealAura(tankAdloTarget, Auras.Galvanize, false);
                 }
 
                 var adloTarget = Group.CastableAlliesWithin30.FirstOrDefault(CanAdlo);
@@ -319,7 +352,7 @@ namespace Magitek.Logic.Scholar
 
                 await UseRecitation();
 
-                return await Spells.Adloquium.HealAura(adloTarget, Auras.Galvanize);
+                return await ScholarRoutine.AdloquiumSpell.HealAura(adloTarget, Auras.Galvanize);
 
                 bool CanAdlo(Character unit)
                 {
@@ -329,7 +362,7 @@ namespace Magitek.Logic.Scholar
                     if (unit.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent)
                         return false;
 
-                    if (unit.HasAura(Auras.Galvanize))
+                    if (unit.HasPrimaryShield())
                         return false;
 
                     if (unit.HasAura(Auras.Excogitation))
@@ -345,10 +378,10 @@ namespace Magitek.Logic.Scholar
                 }
             }
 
-            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasAura(Auras.Galvanize))
+            if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.AdloquiumHpPercent || Core.Me.HasPrimaryShield())
                 return false;
 
-            return await Spells.Adloquium.HealAura(Core.Me, Auras.Galvanize);
+            return await ScholarRoutine.AdloquiumSpell.HealAura(Core.Me, Auras.Galvanize);
 
             async Task UseRecitation()
             {
@@ -362,9 +395,12 @@ namespace Magitek.Logic.Scholar
                     return;
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Adloquium.Id, Core.Me));
             }
         }
 
@@ -374,7 +410,9 @@ namespace Magitek.Logic.Scholar
             if (!ScholarSettings.Instance.Succor || !ScholarSettings.Instance.EmergencyTactics || !ScholarSettings.Instance.EmergencyTacticsSuccor)
                 return false;
 
-            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero)
+            // On cooldown but ARMED still proceeds: the cast and the converted heal now happen on
+            // different pulses, and this gate runs before the aura branch can consume the buff.
+            if (Spells.EmergencyTactics.Cooldown != TimeSpan.Zero && !Core.Me.HasAura(Auras.EmergencyTactics))
                 return false;
 
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
@@ -386,10 +424,9 @@ namespace Magitek.Logic.Scholar
             if (!await Buff.EmergencyTactics())
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await ScholarRoutine.SuccorSpell.Heal(Core.Me);
         }
 
         public static async Task<bool> Succor()
@@ -403,19 +440,28 @@ namespace Magitek.Logic.Scholar
             //if (Casting.LastSpell == Spells.Succor)
             //    return false;
 
+            // How many need HEALING decides whether to cast; whether anyone still needs a SHIELD
+            // is a separate question. Folding the shield check into the count let a co-healer's
+            // barriers push the wounded total under the threshold and skip Succor altogether, even
+            // though its direct heal still lands on everyone. Same split as Accession below.
             var needSuccor = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
-                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
-                                                                     !r.HasAura(Auras.Galvanize)) >= AoeNeedHealing;
+                                                                     r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent) >= AoeNeedHealing;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive &&
+                                                                      r.CurrentHealthPercent <= ScholarSettings.Instance.SuccorHpPercent &&
+                                                                      !r.HasPrimaryShield()) > 0;
 
             if (!needSuccor)
                 return false;
 
-            if (await Spells.Succor.Heal(Core.Me))
-            {
-                return await Coroutine.Wait(2500, () => Casting.LastSpell == Spells.Succor || MovementManager.IsMoving);
-            }
+            // Everyone who needs healing is already shielded: the barrier would be overwritten for
+            // nothing. EmergencyTacticsSuccor runs before this and converts the barrier to a pure
+            // heal, which is the path that covers this case.
+            if (!needShields)
+                return false;
 
-            return false;
+            // The cast-tracker holds the pulse while Succor is casting, so it won't re-fire — no need to
+            // block here confirming LastSpell.
+            return await ScholarRoutine.SuccorSpell.Heal(Core.Me);
         }
 
         public static async Task<bool> Accession()
@@ -430,7 +476,7 @@ namespace Magitek.Logic.Scholar
                 return false;
 
             var needAccession = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent) >= AoeNeedHealing;
-            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasAura(Auras.Galvanize)) > 0;
+            var needShields = Group.CastableAlliesWithin20.Count(r => r.IsAlive && r.CurrentHealthPercent <= ScholarSettings.Instance.AccessionHpPercent && !r.HasPrimaryShield()) > 0;
 
             if (!needAccession)
                 return false;
@@ -461,12 +507,20 @@ namespace Magitek.Logic.Scholar
 
             if (Globals.InParty)
             {
-                var ManifestationTarget = Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate);
+                // A target already carrying a barrier is only actionable through the Emergency
+                // Tactics conversion. When that path cannot run, skip barriered allies in the
+                // pick — otherwise the first barriered ally latches this method every pulse
+                // while a shieldable ally further down the weight order goes without.
+                var etConvertible = EmergencyTacticsConvertible();
+
+                var ManifestationTarget = etConvertible
+                    ? Group.CastableAlliesWithin30.FirstOrDefault(CanLustrate)
+                    : Group.CastableAlliesWithin30.FirstOrDefault(r => CanLustrate(r) && !r.HasPrimaryShield());
 
                 if (ManifestationTarget == null)
                     return false;
 
-                var needsShields = !ManifestationTarget.HasAura(Auras.Galvanize);
+                var needsShields = !ManifestationTarget.HasPrimaryShield();
 
                 if (!needsShields && !await UsedEmergencyTactics())
                     return false;
@@ -480,7 +534,7 @@ namespace Magitek.Logic.Scholar
             if (Core.Me.CurrentHealthPercent > ScholarSettings.Instance.ManifestationHpPercent)
                 return false;
 
-            var needsShieldsMe = !Core.Me.HasAura(Auras.Galvanize);
+            var needsShieldsMe = !Core.Me.HasPrimaryShield();
 
             if (!needsShieldsMe && !await UsedEmergencyTactics())
                 return false;
@@ -575,10 +629,12 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Excogitation.Id, Core.Me));
             }
         }
 
@@ -664,10 +720,12 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Lustrate.Id, Core.Me));
             }
         }
 
@@ -703,10 +761,12 @@ namespace Magitek.Logic.Scholar
                 if (!await Spells.Recitation.Cast(Core.Me))
                     return;
 
-                if (!await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation)))
-                    return;
-
-                await Coroutine.Wait(1000, () => ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
+                // Recitation is instant, but the paired heal must also clear its animation lock —
+                // one capped wait on both (instead of the old two sequential 1s stalls) keeps the
+                // guaranteed-crit pairing on this pulse. The pairing is best-effort, not atomic:
+                // if the wait times out the pulse ends between the two casts, and the damage
+                // rotation can spend a GCD before the heal lands, wasting the Recitation.
+                await Coroutine.Wait(1000, () => Core.Me.HasAura(Auras.Recitation) && ActionManager.CanCast(Spells.Indomitability.Id, Core.Me));
             }
         }
 
@@ -725,13 +785,36 @@ namespace Magitek.Logic.Scholar
             if (Spells.SacredSoil.Cooldown != TimeSpan.Zero)
                 return false;
 
-            var sacredSoilTarget = Group.CastableAlliesWithin30.FirstOrDefault(r => PartyManager.VisibleMembers.Count(x => x.BattleCharacter.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
-                    && x.BattleCharacter.WithinSpellRange(Spells.SacredSoil.Radius)) >= AoeNeedHealing);
+            // The count is "wounded allies within Soil's radius of me" — it never depended on the lambda
+            // parameter, so the old FirstOrDefault picked an arbitrary first party member and could drop
+            // the circle away from the very cluster it counted. Trigger on the count, then place the
+            // circle by coverage of the SAME wounded set — centering on the whole party would pull the
+            // placement toward a healthy remote cluster when the party is split. The frame-cached ally
+            // list already excludes dead and despawned members, so a corpse at 0% can neither trigger
+            // the count nor win placement.
+            var wounded = Group.CastableAlliesWithin30
+                .Where(x => x.CurrentHealthPercent < ScholarSettings.Instance.SacredSoilHpPercent
+                    && x.WithinSpellRange(Spells.SacredSoil.Radius))
+                .ToList();
 
-            if (sacredSoilTarget == null)
+            if (wounded.Count < AoeNeedHealing)
                 return false;
 
-            return await Spells.SacredSoil.Cast(sacredSoilTarget);
+            if (!ScholarSettings.Instance.SacredSoilCenterParty)
+                return await Spells.SacredSoil.Cast(Core.Me);
+
+            // Same placement pattern the other healers use (WhiteMage Asylum/Liturgy, WhiteMage and
+            // Astrologian HealFightLogic): centre the circle on the most central ally, tie-broken by
+            // proximity to us. It deliberately follows the bulk of the party rather than chasing a
+            // wounded outlier, because the party is expected to group and dropping the circle on a
+            // straggler covers fewer people.
+            var targets = Group.CastableAlliesWithin30.OrderBy(r =>
+                Group.CastableAlliesWithin30.Sum(ot => r.Distance(ot.Location))
+            ).ThenBy(t => Core.Me.Distance(t.Location));
+
+            var soilTarget = targets.FirstOrDefault(Core.Me);
+
+            return await Spells.SacredSoil.Cast(soilTarget);
         }
 
         public static async Task<bool> Resurrection()

--- a/Magitek/Magitek.csproj
+++ b/Magitek/Magitek.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows8.0</TargetFramework>
+    <TargetFramework>net10.0-windows8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <SccProjectName></SccProjectName>
     <SccLocalPath></SccLocalPath>
@@ -87,7 +87,7 @@
       <Version>4.1.0</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.803" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.902" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -497,6 +497,14 @@ namespace Magitek.Models.Astrologian
 
         [Setting]
         [DefaultValue(true)]
+        public bool AlignCardsWithDivination { get; set; }
+
+        [Setting]
+        [DefaultValue(80)]
+        public int PlayUtilityCardHealthPercent { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
         public bool CardRuleDefaultToMinorArcana { get; set; }
 
         [Setting]

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -438,7 +438,6 @@ namespace Magitek.Models.Astrologian
         [DefaultValue(true)]
         public bool AutomaticallyDispelAnythingThatsDispellable { get; set; }
 
-
         #endregion
 
         #region AlliancesAndPets
@@ -494,10 +493,10 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(25)]
         public int DontPlayWhenCombatTimeIsLessThan { get; set; }
+
         [Setting]
         [DefaultValue(50.0f)]
         public float PlayDefensiveCardHealthPercent { get; set; }
-
 
         [Setting]
         [DefaultValue(true)]
@@ -518,105 +517,179 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(1)]
         public int LordOfCrownsEnemies { get; set; }
-        #endregion
-        [Setting]
-        [DefaultValue(70.0f)]
-        public float AoEHealThreshold { get; set; }
 
+        #endregion
 
         #region Card Weights
 
         #region Tanks
         [Setting]
-        [DefaultValue(1)]
-        public int PldCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(2)]
-        public int WarCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(3)]
-        public int DrkCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(4)]
-        public int GnbCardWeight { get; set; }
-
-        #endregion
-
-        #region heals
-        [Setting]
-        [DefaultValue(5)]
-        public int WhmCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(6)]
-        public int SchCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(7)]
-        public int AstCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(8)]
-        public int SgeCardWeight { get; set; }
-
-        #endregion
-
-        #region meleeDPS
-        [Setting]
-        [DefaultValue(9)]
-        public int MnkCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(10)]
-        public int DrgCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(11)]
-        public int NinCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(12)]
-        public int SamCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(13)]
-        public int RprCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(14)]
-        public int VprCardWeight { get; set; }
-
-        #endregion
-
-        #region physicalRangeDPS
-        [Setting]
-        [DefaultValue(15)]
-        public int BrdCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(16)]
-        public int MchCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(17)]
-        public int DncCardWeight { get; set; }
-
-
-        #endregion
-
-        #region magicalRangeDPS
-        [Setting]
-        [DefaultValue(18)]
-        public int BlmCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(19)]
-        public int SmnCardWeight { get; set; }
+        [DefaultValue(70)]
+        public int PldBalanceWeight { get; set; }
         [Setting]
         [DefaultValue(20)]
-        public int RdmCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(21)]
-        public int PctCardWeight { get; set; }
-        [Setting]
-        [DefaultValue(22)]
-        public int BluCardWeight { get; set; }
+        public int PldSpearWeight { get; set; }
 
+        [Setting]
+        [DefaultValue(70)]
+        public int WarBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(20)]
+        public int WarSpearWeight { get; set; }
 
+        [Setting]
+        [DefaultValue(70)]
+        public int DrkBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(20)]
+        public int DrkSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(70)]
+        public int GnbBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(20)]
+        public int GnbSpearWeight { get; set; }
+        #endregion
+
+        #region Healers
+        [Setting]
+        [DefaultValue(20)]
+        public int WhmBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(70)]
+        public int WhmSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(20)]
+        public int SchBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(70)]
+        public int SchSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(20)]
+        public int AstBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(70)]
+        public int AstSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(20)]
+        public int SgeBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(70)]
+        public int SgeSpearWeight { get; set; }
+        #endregion
+
+        #region Melee DPS
+        [Setting]
+        [DefaultValue(100)]
+        public int MnkBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(30)]
+        public int MnkSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(100)]
+        public int DrgBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(30)]
+        public int DrgSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(100)]
+        public int NinBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(30)]
+        public int NinSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(100)]
+        public int SamBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(30)]
+        public int SamSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(100)]
+        public int RprBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(30)]
+        public int RprSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(100)]
+        public int VprBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(30)]
+        public int VprSpearWeight { get; set; }
+        #endregion
+
+        #region Physical Ranged DPS
+        [Setting]
+        [DefaultValue(30)]
+        public int BrdBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int BrdSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int MchBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int MchSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int DncBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int DncSpearWeight { get; set; }
+        #endregion
+
+        #region Magical Ranged DPS
+        [Setting]
+        [DefaultValue(30)]
+        public int BlmBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int BlmSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int SmnBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int SmnSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int RdmBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int RdmSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int PctBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int PctSpearWeight { get; set; }
+
+        [Setting]
+        [DefaultValue(30)]
+        public int BluBalanceWeight { get; set; }
+        [Setting]
+        [DefaultValue(100)]
+        public int BluSpearWeight { get; set; }
         #endregion
 
         #endregion
 
         #region FightLogic
+
         [Setting]
         [DefaultValue(true)]
         public bool FightLogicNeutralSect { get; set; }
@@ -652,9 +725,11 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(true)]
         public bool FightLogicExaltation { get; set; }
+
         #endregion
 
         #region PVP
+
         [Setting]
         [DefaultValue(true)]
         public bool Pvp_FallMalefic { get; set; }
@@ -718,7 +793,7 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(2)]
         public int Pvp_LordOfCrownsEnemies { get; set; }
-        #endregion
 
+        #endregion
     }
 }

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -494,10 +494,6 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(25)]
         public int DontPlayWhenCombatTimeIsLessThan { get; set; }
-        [Setting]
-        [DefaultValue(50.0f)]
-        public float PlayDefensiveCardHealthPercent { get; set; }
-
 
         [Setting]
         [DefaultValue(true)]
@@ -519,10 +515,6 @@ namespace Magitek.Models.Astrologian
         [DefaultValue(1)]
         public int LordOfCrownsEnemies { get; set; }
         #endregion
-        [Setting]
-        [DefaultValue(70.0f)]
-        public float AoEHealThreshold { get; set; }
-
 
         #region Card Weights
 

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -494,6 +494,10 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(25)]
         public int DontPlayWhenCombatTimeIsLessThan { get; set; }
+        [Setting]
+        [DefaultValue(50.0f)]
+        public float PlayDefensiveCardHealthPercent { get; set; }
+
 
         [Setting]
         [DefaultValue(true)]
@@ -515,6 +519,10 @@ namespace Magitek.Models.Astrologian
         [DefaultValue(1)]
         public int LordOfCrownsEnemies { get; set; }
         #endregion
+        [Setting]
+        [DefaultValue(70.0f)]
+        public float AoEHealThreshold { get; set; }
+
 
         #region Card Weights
 

--- a/Magitek/Models/Astrologian/AstrologianSettings.cs
+++ b/Magitek/Models/Astrologian/AstrologianSettings.cs
@@ -438,6 +438,7 @@ namespace Magitek.Models.Astrologian
         [DefaultValue(true)]
         public bool AutomaticallyDispelAnythingThatsDispellable { get; set; }
 
+
         #endregion
 
         #region AlliancesAndPets
@@ -493,10 +494,10 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(25)]
         public int DontPlayWhenCombatTimeIsLessThan { get; set; }
-
         [Setting]
         [DefaultValue(50.0f)]
         public float PlayDefensiveCardHealthPercent { get; set; }
+
 
         [Setting]
         [DefaultValue(true)]
@@ -517,179 +518,105 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(1)]
         public int LordOfCrownsEnemies { get; set; }
-
         #endregion
+        [Setting]
+        [DefaultValue(70.0f)]
+        public float AoEHealThreshold { get; set; }
+
 
         #region Card Weights
 
         #region Tanks
         [Setting]
-        [DefaultValue(70)]
-        public int PldBalanceWeight { get; set; }
+        [DefaultValue(1)]
+        public int PldCardWeight { get; set; }
         [Setting]
-        [DefaultValue(20)]
-        public int PldSpearWeight { get; set; }
+        [DefaultValue(2)]
+        public int WarCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(3)]
+        public int DrkCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(4)]
+        public int GnbCardWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(70)]
-        public int WarBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(20)]
-        public int WarSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(70)]
-        public int DrkBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(20)]
-        public int DrkSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(70)]
-        public int GnbBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(20)]
-        public int GnbSpearWeight { get; set; }
         #endregion
 
-        #region Healers
+        #region heals
         [Setting]
-        [DefaultValue(20)]
-        public int WhmBalanceWeight { get; set; }
+        [DefaultValue(5)]
+        public int WhmCardWeight { get; set; }
         [Setting]
-        [DefaultValue(70)]
-        public int WhmSpearWeight { get; set; }
+        [DefaultValue(6)]
+        public int SchCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(7)]
+        public int AstCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(8)]
+        public int SgeCardWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(20)]
-        public int SchBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(70)]
-        public int SchSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(20)]
-        public int AstBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(70)]
-        public int AstSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(20)]
-        public int SgeBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(70)]
-        public int SgeSpearWeight { get; set; }
         #endregion
 
-        #region Melee DPS
+        #region meleeDPS
         [Setting]
-        [DefaultValue(100)]
-        public int MnkBalanceWeight { get; set; }
+        [DefaultValue(9)]
+        public int MnkCardWeight { get; set; }
         [Setting]
-        [DefaultValue(30)]
-        public int MnkSpearWeight { get; set; }
+        [DefaultValue(10)]
+        public int DrgCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(11)]
+        public int NinCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(12)]
+        public int SamCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(13)]
+        public int RprCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(14)]
+        public int VprCardWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(100)]
-        public int DrgBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(30)]
-        public int DrgSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(100)]
-        public int NinBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(30)]
-        public int NinSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(100)]
-        public int SamBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(30)]
-        public int SamSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(100)]
-        public int RprBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(30)]
-        public int RprSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(100)]
-        public int VprBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(30)]
-        public int VprSpearWeight { get; set; }
         #endregion
 
-        #region Physical Ranged DPS
+        #region physicalRangeDPS
         [Setting]
-        [DefaultValue(30)]
-        public int BrdBalanceWeight { get; set; }
+        [DefaultValue(15)]
+        public int BrdCardWeight { get; set; }
         [Setting]
-        [DefaultValue(100)]
-        public int BrdSpearWeight { get; set; }
+        [DefaultValue(16)]
+        public int MchCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(17)]
+        public int DncCardWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(30)]
-        public int MchBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(100)]
-        public int MchSpearWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(30)]
-        public int DncBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(100)]
-        public int DncSpearWeight { get; set; }
         #endregion
 
-        #region Magical Ranged DPS
+        #region magicalRangeDPS
         [Setting]
-        [DefaultValue(30)]
-        public int BlmBalanceWeight { get; set; }
+        [DefaultValue(18)]
+        public int BlmCardWeight { get; set; }
         [Setting]
-        [DefaultValue(100)]
-        public int BlmSpearWeight { get; set; }
+        [DefaultValue(19)]
+        public int SmnCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(20)]
+        public int RdmCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(21)]
+        public int PctCardWeight { get; set; }
+        [Setting]
+        [DefaultValue(22)]
+        public int BluCardWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(30)]
-        public int SmnBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(100)]
-        public int SmnSpearWeight { get; set; }
 
-        [Setting]
-        [DefaultValue(30)]
-        public int RdmBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(100)]
-        public int RdmSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(30)]
-        public int PctBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(100)]
-        public int PctSpearWeight { get; set; }
-
-        [Setting]
-        [DefaultValue(30)]
-        public int BluBalanceWeight { get; set; }
-        [Setting]
-        [DefaultValue(100)]
-        public int BluSpearWeight { get; set; }
         #endregion
 
         #endregion
 
         #region FightLogic
-
         [Setting]
         [DefaultValue(true)]
         public bool FightLogicNeutralSect { get; set; }
@@ -725,11 +652,9 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(true)]
         public bool FightLogicExaltation { get; set; }
-
         #endregion
 
         #region PVP
-
         [Setting]
         [DefaultValue(true)]
         public bool Pvp_FallMalefic { get; set; }
@@ -793,7 +718,7 @@ namespace Magitek.Models.Astrologian
         [Setting]
         [DefaultValue(2)]
         public int Pvp_LordOfCrownsEnemies { get; set; }
-
         #endregion
+
     }
 }

--- a/Magitek/Models/Scholar/ScholarSettings.cs
+++ b/Magitek/Models/Scholar/ScholarSettings.cs
@@ -248,6 +248,10 @@ namespace Magitek.Models.Scholar
         public int DeploymentTacticsAllyInRange { get; set; }
 
         [Setting]
+        [DefaultValue(15)]
+        public int DeploymentTacticsMinimumShieldSeconds { get; set; }
+
+        [Setting]
         [DefaultValue(true)]
         public bool Excogitation { get; set; }
 

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -1207,23 +1207,7 @@ namespace Magitek.Properties {
                 return ResourceManager.GetString("Astrologian_ToolTip_This_will_automatically_cast_N", resourceCulture);
             }
         }
-        /// <summary>
-        ///   Looks up a localized string similar to Play Defensive Card Health %.
-        /// </summary>
-        public static string Astrologian_Content_PlayDefensiveCardHealthPercent {
-            get {
-                return ResourceManager.GetString("Astrologian_Content_PlayDefensiveCardHealthPercent", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to AoE Heal Health Threshold %.
-        /// </summary>
-        public static string Astrologian_Content_AoEHealThreshold {
-            get {
-                return ResourceManager.GetString("Astrologian_Content_AoEHealThreshold", resourceCulture);
-            }
-        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Apex Arrow.
         /// </summary>
@@ -12960,6 +12944,15 @@ namespace Magitek.Properties {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Only spread a shield with at least this many seconds left:.
+        /// </summary>
+        public static string Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds {
+            get {
+                return ResourceManager.GetString("Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Deployment Tactics Crit Adlo When.
         /// </summary>

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Magitek.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Align damage cards (Balance, Spear) with Divination.
+        /// </summary>
+        public static string Astrologian_Content_Align_Cards_With_Divination {
+            get {
+                return ResourceManager.GetString("Astrologian_Content_Align_Cards_With_Divination", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Always With Enhanced Benefic.
         /// </summary>
         public static string Astrologian_Content_Always_With_Enhanced_Benefic {
@@ -1002,6 +1011,15 @@ namespace Magitek.Properties {
         public static string Astrologian_Text_PCT {
             get {
                 return ResourceManager.GetString("Astrologian_Text_PCT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Play utility cards (Bole, Arrow, Ewer, Spire) at or below.
+        /// </summary>
+        public static string Astrologian_Text_Play_Utility_Cards_Below {
+            get {
+                return ResourceManager.GetString("Astrologian_Text_Play_Utility_Cards_Below", resourceCulture);
             }
         }
         

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -1207,7 +1207,23 @@ namespace Magitek.Properties {
                 return ResourceManager.GetString("Astrologian_ToolTip_This_will_automatically_cast_N", resourceCulture);
             }
         }
-        
+        /// <summary>
+        ///   Looks up a localized string similar to Play Defensive Card Health %.
+        /// </summary>
+        public static string Astrologian_Content_PlayDefensiveCardHealthPercent {
+            get {
+                return ResourceManager.GetString("Astrologian_Content_PlayDefensiveCardHealthPercent", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AoE Heal Health Threshold %.
+        /// </summary>
+        public static string Astrologian_Content_AoEHealThreshold {
+            get {
+                return ResourceManager.GetString("Astrologian_Content_AoEHealThreshold", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Apex Arrow.
         /// </summary>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -657,6 +657,9 @@
   <data name="Astrologian_Content_Play_Cards" xml:space="preserve">
     <value>Play Cards</value>
   </data>
+  <data name="Astrologian_Content_Align_Cards_With_Divination" xml:space="preserve">
+    <value>Align damage cards (Balance, Spear) with Divination</value>
+  </data>
   <data name="Astrologian_Text_Milliseconds_Left" xml:space="preserve">
     <value>Milliseconds Left</value>
   </data>
@@ -3997,6 +4000,9 @@ Does not work if Lightspeed is disabled.</value>
   </data>
   <data name="Astrologian_Text_Dont_Play_Cards_When_There_is_Less_Than_30_Seconds" xml:space="preserve">
     <value>Dont Play Cards When There is Less Than 30 Seconds</value>
+  </data>
+  <data name="Astrologian_Text_Play_Utility_Cards_Below" xml:space="preserve">
+    <value>Play utility cards (Bole, Arrow, Ewer, Spire) at or below</value>
   </data>
   <data name="Astrologian_Text_Always_Do_Damage_If_Target_Time_Till_Death_Is_Less_Than" xml:space="preserve">
     <value>Always Do Damage If Target Time Till Death Is Less Than</value>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -3179,6 +3179,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="Scholar_Content_Deployment_Tactics_Crit_Adlo_When" xml:space="preserve">
     <value>Deployment Tactics Crit Adlo When</value>
   </data>
+  <data name="Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds" xml:space="preserve">
+    <value>Only spread a shield with at least this many seconds left:</value>
+  </data>
   <data name="Scholar_Content_Only_When_We_Do_Not_Have_Any_Aethe" xml:space="preserve">
     <value>Only When We Do Not Have Any Aetherflow</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -657,6 +657,9 @@
   <data name="Astrologian_Content_Play_Cards" xml:space="preserve">
     <value>发牌</value>
   </data>
+  <data name="Astrologian_Content_Align_Cards_With_Divination" xml:space="preserve">
+    <value>输出卡（太阳神之衡、战争神之枪）配合占卜使用</value>
+  </data>
   <data name="Astrologian_Text_Milliseconds_Left" xml:space="preserve">
     <value>剩余毫秒数</value>
   </data>
@@ -3998,6 +4001,9 @@
   </data>
   <data name="Astrologian_Text_Dont_Play_Cards_When_There_is_Less_Than_30_Seconds" xml:space="preserve">
     <value>当剩余时间少于30秒时不发卡</value>
+  </data>
+  <data name="Astrologian_Text_Play_Utility_Cards_Below" xml:space="preserve">
+    <value>当血量低于或等于以下值时打出辅助卡（干、箭、瓶、塔）</value>
   </data>
   <data name="Astrologian_Text_Always_Do_Damage_If_Target_Time_Till_Death_Is_Less_Than" xml:space="preserve">
     <value>如果目标的死亡倒计时少于[xx]则总是造成伤害</value>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -3180,6 +3180,9 @@
   <data name="Scholar_Content_Deployment_Tactics_Crit_Adlo_When" xml:space="preserve">
     <value>当[xx]时对暴击鼓舞使用展开战术</value>
   </data>
+  <data name="Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds" xml:space="preserve">
+    <value>仅展开剩余时间不低于此秒数的盾：</value>
+  </data>
   <data name="Scholar_Content_Only_When_We_Do_Not_Have_Any_Aethe" xml:space="preserve">
     <value>仅当我们没有任何以太超流时</value>
   </data>

--- a/Magitek/Rotations/Astrologian.cs
+++ b/Magitek/Rotations/Astrologian.cs
@@ -59,6 +59,16 @@ namespace Magitek.Rotations
                 if (await Cards.PlayCards()) return true;
             }
 
+            // Cards double-weave while Divination is up so the Balance shares its window
+            // instead of waiting a full GCD behind it.
+            if (AstrologianSettings.Instance.WeaveOGCDHeals
+                && Core.Me.HasAura(Auras.Divination, true)
+                && GlobalCooldown.CanWeave(2)
+                && !GlobalCooldown.IsLateWeaveWindow())
+            {
+                if (await Cards.PlayCards()) return true;
+            }
+
             if (Globals.InActiveDuty || Core.Me.InCombat)
             {
                 if (AstrologianSettings.Instance.WeaveOGCDHeals && GlobalCooldown.CanWeave(1))
@@ -131,6 +141,16 @@ namespace Magitek.Rotations
                 if (await Cards.PlayCards()) return true;
 
 
+            }
+
+            // Cards double-weave while Divination is up so the Balance shares its window
+            // instead of waiting a full GCD behind it.
+            if (AstrologianSettings.Instance.WeaveOGCDHeals
+                && Core.Me.HasAura(Auras.Divination, true)
+                && GlobalCooldown.CanWeave(2)
+                && !GlobalCooldown.IsLateWeaveWindow())
+            {
+                if (await Cards.PlayCards()) return true;
             }
 
             if (Globals.InActiveDuty || Core.Me.InCombat)

--- a/Magitek/Rotations/Scholar.cs
+++ b/Magitek/Rotations/Scholar.cs
@@ -138,6 +138,12 @@ namespace Magitek.Rotations
 
             async Task<bool> DoHeal()
             {
+                // Doom kills on expiry unless the carrier is healed to full, so it outranks
+                // everything else we could do for an alliance member. This is the same shared
+                // handler the party path uses; the castable collection has already been switched
+                // to the alliance above, so it scans them without any alliance-specific logic.
+                if (await CommonFightLogic.FightLogic_Doom(ScholarSettings.Instance.Physick, Spells.Physick)) return true;
+
                 if (await Logic.Scholar.Heal.Resurrection()) return true;
 
                 if (ScholarSettings.Instance.HealAllianceOnlyPhysick)

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -113,9 +113,7 @@ namespace Magitek.Utilities
                 return null;
             FlHandledCastingSpellId.Clear();
 
-            var output = enemyLogic.TankBusters.Contains(enemy.CastingSpellId)
-                ? Group.CastableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
-                : null;
+            var output = MatchTankBuster(enemyLogic, enemy);
 
             if (output != null && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo(
@@ -138,30 +136,7 @@ namespace Magitek.Utilities
                 return null;
             FlHandledCastingSpellId.Clear();
 
-            // Every tank stacks for a shared buster, so every tank takes a share and every tank wants
-            // covering. Healers pass this result straight to a cast, so it has to name a tank they can
-            // actually reach — CastableTanks is our own party, not the alliance.
-            //
-            // Prefer the tank being aimed at when they are in our party. In an alliance raid the target is
-            // usually in a different party, and the tank we can reach is ours, stacking in to share the
-            // damage — so fall back to them rather than returning nothing. Returning the target alone left
-            // a healer in another party doing nothing while their tank ate a share; returning a non-target
-            // alone shielded the co-tank while the tank being hit went uncovered.
-            //
-            // CastableTanks is built before Group applies any distance filter, so it can name a tank well
-            // outside heal range. Naming one satisfies the preferred-target branch, skips the fallback and
-            // then fails the caller's own CanCast — no mitigation at all. Restrict both branches to tanks
-            // inside standard heal range so the fallback can still find the co-tank we can reach.
-            //
-            // WithinSpellRange, not the CastableAlliesWithin30 list: that list is built from raw
-            // centre-to-centre distance, so a large tank whose edge is well inside 30y can fall out of it
-            // and be passed over for a co-tank while the game would have allowed the cast.
-            var reachableTanks = Group.CastableTanks.Where(x => x.WithinSpellRange(30)).ToList();
-
-            var output = enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
-                ? reachableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
-                  ?? reachableTanks.FirstOrDefault()
-                : null;
+            var output = MatchSharedTankBuster(enemyLogic, enemy);
 
             if (output != null && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo(
@@ -212,7 +187,7 @@ namespace Magitek.Utilities
                     return false;
                 FlHandledCastingSpellId.Clear();
 
-                var output = enemyLogic.Aoes.Contains(enemy.CastingSpellId);
+                var output = MatchAoe(enemyLogic, enemy);
 
                 if (output && DebugSettings.Instance.DebugFightLogic)
                     Logger.WriteInfo($"[AOE Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name}");
@@ -269,7 +244,7 @@ namespace Magitek.Utilities
                 return false;
             FlHandledCastingSpellId.Clear();
 
-            var output = enemyLogic.BigAoes.Contains(enemy.CastingSpellId);
+            var output = MatchBigAoe(enemyLogic, enemy);
 
             if (output && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo(
@@ -292,12 +267,185 @@ namespace Magitek.Utilities
                 return false;
             FlHandledCastingSpellId.Clear();
 
-            var output = enemyLogic.Knockbacks.Contains(enemy.CastingSpellId);
+            var output = MatchKnockback(enemyLogic, enemy);
 
             if (output && DebugSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo($"[Knockback Detected] {encounter.Name} {enemy.Name} casting {enemy.SpellCastInfo.Name}");
 
             return output;
+        }
+
+        // Single source of truth for what each detection category matches. The responder methods
+        // above layer their gates (IsFlReady, the answered-once ledger, debug logging) on top of
+        // these, and Peek below exposes them without any of that — keep the matching itself here
+        // so the two surfaces can never drift apart.
+
+        private static Character MatchTankBuster(Enemy enemyLogic, BattleCharacter enemy)
+        {
+            return enemyLogic.TankBusters.Contains(enemy.CastingSpellId)
+                ? Group.CastableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
+                : null;
+        }
+
+        private static Character MatchSharedTankBuster(Enemy enemyLogic, BattleCharacter enemy)
+        {
+            // Every tank stacks for a shared buster, so every tank takes a share and every tank wants
+            // covering. Healers pass this result straight to a cast, so it has to name a tank they can
+            // actually reach — CastableTanks is our own party, not the alliance.
+            //
+            // Prefer the tank being aimed at when they are in our party. In an alliance raid the target is
+            // usually in a different party, and the tank we can reach is ours, stacking in to share the
+            // damage — so fall back to them rather than returning nothing. Returning the target alone left
+            // a healer in another party doing nothing while their tank ate a share; returning a non-target
+            // alone shielded the co-tank while the tank being hit went uncovered.
+            //
+            // CastableTanks is built before Group applies any distance filter, so it can name a tank well
+            // outside heal range. Naming one satisfies the preferred-target branch, skips the fallback and
+            // then fails the caller's own CanCast — no mitigation at all. Restrict both branches to tanks
+            // inside standard heal range so the fallback can still find the co-tank we can reach.
+            //
+            // WithinSpellRange, not the CastableAlliesWithin30 list: that list is built from raw
+            // centre-to-centre distance, so a large tank whose edge is well inside 30y can fall out of it
+            // and be passed over for a co-tank while the game would have allowed the cast.
+            var reachableTanks = Group.CastableTanks.Where(x => x.WithinSpellRange(30)).ToList();
+
+            return enemyLogic.SharedTankBusters.Contains(enemy.CastingSpellId)
+                ? reachableTanks.FirstOrDefault(x => x == enemy.TargetCharacter)
+                  ?? reachableTanks.FirstOrDefault()
+                : null;
+        }
+
+        private static bool MatchAoe(Enemy enemyLogic, BattleCharacter enemy)
+        {
+            return enemyLogic.Aoes.Contains(enemy.CastingSpellId);
+        }
+
+        private static bool MatchBigAoe(Enemy enemyLogic, BattleCharacter enemy)
+        {
+            return enemyLogic.BigAoes.Contains(enemy.CastingSpellId);
+        }
+
+        private static bool MatchKnockback(Enemy enemyLogic, BattleCharacter enemy)
+        {
+            return enemyLogic.Knockbacks.Contains(enemy.CastingSpellId);
+        }
+
+        /// <summary>
+        /// Read-only queries over the same detection matching the responder methods above use. A peek
+        /// answers "is a mechanic incoming that it is time to react to", not "is a cast bar up".
+        /// <para>
+        /// Every peek waits out the configured fight logic response delay before answering, exactly as
+        /// the responder call sites do through <see cref="HodlCastTimeRemaining"/> — so nothing acting
+        /// on a peek can react to a mechanic faster than a real response would. The delay is baked in
+        /// here rather than left to the call site precisely so a caller cannot forget it.
+        /// </para>
+        /// <para>
+        /// Nothing in here touches the answered-once ledger, gates on <see cref="IsFlReady"/>, or
+        /// starts the response stopwatch — asking a question never changes whether a responder still
+        /// answers. A peek also keeps reporting a mechanic the responders have already answered, on
+        /// purpose: peek callers are ADDITIVE, riding alongside the real response (aiming a card at
+        /// the tank about to be hit while mitigation also fires), so going blind the moment a
+        /// responder answers — which is what honoring <see cref="IsFlReady"/> would do — would defeat
+        /// them exactly when they matter.
+        /// </para>
+        /// <para>
+        /// Use these from job logic for targeting and priority hints only — choosing where to aim
+        /// something that is being cast anyway. Anything cast BECAUSE a mechanic is incoming is a
+        /// response and belongs in the responder methods via <see cref="DoAndBuffer"/>, so the
+        /// answer-once bookkeeping and response pacing still apply to it.
+        /// </para>
+        /// </summary>
+        public static class Peek
+        {
+            /// <summary>
+            /// The same human-plausibility pacing every responder call site applies before acting.
+            /// Measuring the CACHED enemy's cast progress matches responder behaviour for lock-on
+            /// detections too: an unrelated cast early in its bar holds those back at the responder
+            /// call sites, so it holds the peek back the same way.
+            /// </summary>
+            private static bool ResponseDelayElapsed()
+            {
+                return HodlCastTimeRemaining(hodlTillDurationInPct: DebugSettings.Instance.FightLogicResponseDelay);
+            }
+
+            /// <summary>The tank about to be hit by a catalogued tankbuster (falling back to shared busters), or null.</summary>
+            public static Character EnemyIsCastingTankBuster()
+            {
+                if (!ResponseDelayElapsed())
+                    return null;
+
+                var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
+
+                if (enemyLogic?.TankBusters == null || enemy == null || encounter == null)
+                    return EnemyIsCastingSharedTankBuster();
+
+                return MatchTankBuster(enemyLogic, enemy);
+            }
+
+            /// <summary>The reachable tank taking a catalogued shared tankbuster, or null.</summary>
+            public static Character EnemyIsCastingSharedTankBuster()
+            {
+                if (!ResponseDelayElapsed())
+                    return null;
+
+                var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
+
+                if (enemyLogic?.SharedTankBusters == null || enemy == null || encounter == null)
+                    return null;
+
+                return MatchSharedTankBuster(enemyLogic, enemy);
+            }
+
+            /// <summary>Whether a catalogued AoE is incoming — a matching cast, an encounter AoE lock-on, or (when enabled) a common lock-on.</summary>
+            public static bool EnemyIsCastingAoe()
+            {
+                if (!ResponseDelayElapsed())
+                    return false;
+
+                var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
+
+                if (enemy != null && enemyLogic?.Aoes != null && encounter != null && MatchAoe(enemyLogic, enemy))
+                    return true;
+
+                if (enemyLogic?.AoeLockOns != null && CheckAoeLockOns(enemyLogic.AoeLockOns).found)
+                    return true;
+
+                if (DebugSettings.Instance.FightLogicIncludeCommonAoeLockOnsTest && CheckAoeLockOns(CommonAoeLockOns).found)
+                    return true;
+
+                return false;
+            }
+
+            /// <summary>Whether a catalogued big AoE is incoming (falling back to <see cref="EnemyIsCastingAoe"/> for enemies with no big-AoE list).</summary>
+            public static bool EnemyIsCastingBigAoe()
+            {
+                if (!ResponseDelayElapsed())
+                    return false;
+
+                var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
+
+                if (enemyLogic == null || enemy == null || encounter == null)
+                    return false;
+
+                if (enemyLogic.BigAoes == null)
+                    return EnemyIsCastingAoe();
+
+                return MatchBigAoe(enemyLogic, enemy);
+            }
+
+            /// <summary>Whether a catalogued knockback is incoming.</summary>
+            public static bool EnemyIsCastingKnockback()
+            {
+                if (!ResponseDelayElapsed())
+                    return false;
+
+                var (encounter, enemyLogic, enemy) = GetEnemyLogicAndEnemy();
+
+                if (enemyLogic?.Knockbacks == null || enemy == null || encounter == null)
+                    return false;
+
+                return MatchKnockback(enemyLogic, enemy);
+            }
         }
 
         public static bool ZoneHasFightLogic()

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -2483,7 +2483,9 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19306 //Inscrutability
+                            19306, //Inscrutability
+                            19322 //Ectoplasmic Ray - stack. Damage lands as 19320 on all four
+                                  //players 5.25s after this cast, up to 30.4% of a health bar.
                         },
                         BigAoes = null
                     },
@@ -2496,7 +2498,9 @@ namespace Magitek.Utilities
                         },
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19306 //Inscrutability
+                            19306, //Inscrutability
+                            19322 //Ectoplasmic Ray - stack. Damage lands as 19320 on all four
+                                  //players 5.25s after this cast, up to 30.4% of a health bar.
                         },
                         BigAoes = null
                     },
@@ -2506,7 +2510,14 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint>() {
-                            19288 //The Final Verse
+                            19288, //The Final Verse
+                            19296 //Open Hearth - 4 hits from one cast, all four players, 33.1%
+                        },
+                        AoeLockOns = new List<uint>() {
+                            62, //Open Hearth's stack marker
+                            96 //Wanderer's Pyre marks three players in the same millisecond as
+                               //its cast. Both of these are on the global common-marker set,
+                               //which is inert unless the enemy declares it.
                         },
                         BigAoes = null
                     },
@@ -2515,6 +2526,40 @@ namespace Magitek.Utilities
                         Name = "Rukshs Dheem",
                         TankBusters = new List<uint>() {
                             19340 //Bonebreaker
+                        },
+                        SharedTankBusters = null,
+                        Aoes = new List<uint>() {
+                            //Each of these fires as a PAIR sharing one cast time: a self-targeted
+                            //id with EffectRange 0, and the id that carries the geometry and the
+                            //damage. Both show a cast bar, so both are listed - which one the
+                            //client reports as the enemy's current cast is not something we can
+                            //tell from a log, and an id that never matches is simply inert.
+                            //Measured 2026-08-20: the r0 half dealt zero damage every time.
+                            19323, //Seabed Ceremony - the most frequent damage in the fight,
+                                   //7 casts in one clear, up to 41.7%. This half is single r0.
+                            19324, //Seabed Ceremony - circle r60, carries the damage (7/7 hits)
+                            19325, //Falling Water - marks TWO players at once, and not the tanks,
+                                   //so the party answer is the right one. This half is single r0.
+                            19326, //Falling Water - circle r8, carries the damage
+                            19327, //Flying Fount - stack, up to 52.1%. This half is single r0.
+                            19328 //Flying Fount - circle r6, carries the damage
+                        },
+                        AoeLockOns = new List<uint>() {
+                            62 //Flying Fount's stack marker
+                        },
+                        BigAoes = null
+                    },
+                    //Trash, not a boss - the only such entry here. Included on a player ruling:
+                    //Barreling Smash is a lock-on charge along a line at whoever it picks, and it
+                    //is worth a single-target barrier on that player. Filed under TankBusters
+                    //because that is the path that shields the named target; the victim is not
+                    //necessarily a tank. No head marker precedes it (checked type-27 lines in the
+                    //8s before each cast), so the 5.0s cast bar is the only signal we get.
+                    new Enemy {
+                        Id = 9280,
+                        Name = "Io Ousia",
+                        TankBusters = new List<uint>() {
+                            20004 //Barreling Smash - line charge, 30.5% on its single victim
                         },
                         SharedTankBusters = null,
                         Aoes = null,
@@ -4534,11 +4579,37 @@ namespace Magitek.Utilities
                     }
                 }
             },
+            // Anima's Oblivion (cast id 25359) is left out on purpose. Measured 2026-08-19:
+            // the cast bar runs ~6.0s, then 23697 ticks 15 times across all four players at
+            // ~10.6% of a health bar each over the next 4.3s, and only then does 23872 land for
+            // 49.1% - 13.1s after the cast starts. Reacting on the cast puts a barrier up in time
+            // for the chip damage, which consumes it, so it is gone before the hit that matters;
+            // Sacred Soil's 15s survives but with under 2s to spare.
+            //
+            // What would make it catalogueable is a per-mechanic reaction delay. HodlCastTimeRemaining
+            // already resolves (encounter, enemyLogic, enemy) and every job reaches it - the four
+            // healer HealFightLogic files and CommonFightLogic alike - so a hold keyed on
+            // enemy.CastingSpellId would let this one entry react at cast-end instead of cast-start
+            // without touching any other reaction. Flagging rather than building it: the shape of
+            // that (data on the mechanic vs a lookup in FightLogic) is your call.
             new Encounter {
                 ZoneId = ZoneId.TheTowerOfBabil,
                 Name = "Dungeon: The Tower of Babil",
                 Expansion = FfxivExpansion.Endwalker,
                 Enemies = new List<Enemy> {
+                    new Enemy {
+                        Id = 10279,
+                        Name = "Barnabas",
+                        TankBusters = null,
+                        SharedTankBusters = null,
+                        Aoes = new List<uint> {
+                            25324 //Shocking Force
+                        },
+                        AoeLockOns = new List<uint> {
+                            62 //Shocking Force stacks the party on one marked player ~5s ahead
+                        },
+                        BigAoes = null
+                    },
                     new Enemy {
                         Id = 10281,
                         Name = "Lugae",
@@ -4565,8 +4636,15 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
-                            25344 //Mega Graviton
+                            25344, //Mega Graviton
+                            25352, //Erupting Pain
+                            25351, //Erupting Pain (second cast id)
+                            25347  //Boundless Pain - casts as 25347, lands as 25348
                         },
+                        AoeLockOns = new List<uint> {
+                            139 //Erupting Pain marks every player ~5s before the hit
+                        },
+                        // 25359, //Oblivion - deliberately NOT catalogued; see the note above this encounter
                         BigAoes = null
                     },
                     new Enemy {
@@ -4575,8 +4653,15 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
-                            25344 //Mega Graviton
+                            25344, //Mega Graviton
+                            25352, //Erupting Pain
+                            25351, //Erupting Pain (second cast id)
+                            25347  //Boundless Pain - casts as 25347, lands as 25348
                         },
+                        AoeLockOns = new List<uint> {
+                            139 //Erupting Pain marks every player ~5s before the hit
+                        },
+                        // 25359, //Oblivion - deliberately NOT catalogued; see the note above this encounter
                         BigAoes = null
                     }
                 }
@@ -6515,6 +6600,59 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         Aoes = new List<uint> {
                             43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14049,
+                        Name = "Pale Headsman",
+                        TankBusters = new List<uint> {
+                            43589, // Relentless Torment - the tank's duel mechanic. Follows Will
+                                   // Breaker (44856), which is the interruptible half. Four hits in
+                                   // 1.8s totalling 55.9% of a health bar.
+                        },
+                        Aoes = new List<uint> {
+                            43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14048,
+                        Name = "Ravenous Headsman",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14050,
+                        Name = "Pestilent Headsman",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            43578, // Head-splitting Roar
+                        },
+                        AoeLockOns = null,
+                        Knockbacks = null,
+                        SharedTankBusters = null,
+                        BigAoes = null
+                    },
+                    new Enemy {
+                        Id = 14239,
+                        Name = "Hooded Headsman",
+                        TankBusters = null,
+                        Aoes = new List<uint> {
+                            43579, // Head-splitting Roar - this one casts the sibling id, and it is
+                                   // the half that lands the damage: 25.3% on all four.
                         },
                         AoeLockOns = null,
                         Knockbacks = null,

--- a/Magitek/Utilities/Routines/Astrologian.cs
+++ b/Magitek/Utilities/Routines/Astrologian.cs
@@ -34,7 +34,7 @@ namespace Magitek.Utilities.Routines
 
             if (Casting.CastingSpell != Spells.Ascend && Casting.SpellTarget?.CurrentHealth < 1)
             {
-                Logger.Error($@"Stopped Resurrection: Unit Died");
+                Logger.Error($@"Stopped Cast: Unit Died");
                 return true;
             }
 

--- a/Magitek/Utilities/Routines/Sage.cs
+++ b/Magitek/Utilities/Routines/Sage.cs
@@ -59,7 +59,7 @@ namespace Magitek.Utilities.Routines
 
             if (Casting.CastingSpell != Spells.Egeiro && Casting.SpellTarget?.CurrentHealth < 1)
             {
-                Logger.Error($@"Stopped cast: Unit Died");
+                Logger.Error($@"Stopped Cast: Unit Died");
                 return true;
             }
 

--- a/Magitek/Utilities/Routines/Scholar.cs
+++ b/Magitek/Utilities/Routines/Scholar.cs
@@ -92,6 +92,18 @@ namespace Magitek.Utilities.Routines
             );
         }
 
+        // Seraphism masks Adloquium -> Manifestation (37015) and Succor -> Accession (37016), BOTH
+        // INSTANT. Casting the base id while masked still resolves (DoAction proxies), but every
+        // wait on the base cast BAR burns its full timeout: a live run measured 3.0s of dead air per
+        // attempt at two independent call sites, because IsCasting never flips for an instant
+        // masked action. Cast the resolved spell instead so the framework's timing data matches
+        // what actually executes. HasAura(Seraphism) is one aura scan - cheap enough for cast sites.
+        public static SpellData AdloquiumSpell =>
+            Core.Me.HasAura(Utilities.Auras.Seraphism) ? Spells.Manifestation : Spells.Adloquium;
+
+        public static SpellData SuccorSpell =>
+            Core.Me.HasAura(Utilities.Auras.Seraphism) ? Spells.Accession : Spells.Succor;
+
         public static int EnemiesInCone;
 
         public static void RefreshVars()

--- a/Magitek/Views/UserControls/Astrologian/Cards.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Cards.xaml
@@ -54,6 +54,16 @@
             </StackPanel>
         </controls:SettingsBlock>
 
+        <controls:SettingsBlock Margin="0,2" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5,0">
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="0,0,7,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Content_PlayDefensiveCardHealthPercent}" />
+                    <controls:Numeric Increment="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.PlayDefensiveCardHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="2,5">
                 <TextBlock Style="{DynamicResource TextBlockDefault}" HorizontalAlignment="Left" Text="{x:Static properties:Resources.Astrologian_Text_Card_Priority_First_to_Last}" />

--- a/Magitek/Views/UserControls/Astrologian/Cards.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Cards.xaml
@@ -54,16 +54,6 @@
             </StackPanel>
         </controls:SettingsBlock>
 
-        <controls:SettingsBlock Margin="0,2" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5,0">
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock Margin="0,0,7,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Content_PlayDefensiveCardHealthPercent}" />
-                    <controls:Numeric Increment="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.PlayDefensiveCardHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
         <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
             <StackPanel Margin="2,5">
                 <TextBlock Style="{DynamicResource TextBlockDefault}" HorizontalAlignment="Left" Text="{x:Static properties:Resources.Astrologian_Text_Card_Priority_First_to_Last}" />

--- a/Magitek/Views/UserControls/Astrologian/Cards.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Cards.xaml
@@ -51,6 +51,12 @@
                     <controls:Numeric Increment="1" MaxValue="60" MinValue="1" Value="{Binding AstrologianSettings.DontPlayWhenCombatTimeIsLessThan, Mode=TwoWay}" />
                     <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Seconds_Left_in_Combat}" />
                 </StackPanel>
+                <CheckBox Margin="0,5" Content="{x:Static properties:Resources.Astrologian_Content_Align_Cards_With_Divination}" IsChecked="{Binding AstrologianSettings.AlignCardsWithDivination, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Margin="0,0,7,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Play_Utility_Cards_Below}" />
+                    <controls:Numeric Increment="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.PlayUtilityCardHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/Magitek/Views/UserControls/Astrologian/Healing.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Healing.xaml
@@ -42,6 +42,20 @@
                 </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <StackPanel Margin="5,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Content_PlayDefensiveCardHealthPercent}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.PlayDefensiveCardHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+                <StackPanel Margin="5,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Content_AoEHealThreshold}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoEHealThreshold, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
 

--- a/Magitek/Views/UserControls/Astrologian/Healing.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Healing.xaml
@@ -1,7 +1,7 @@
 ﻿<UserControl x:Class="Magitek.Views.UserControls.Astrologian.Healing"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:properties="clr-namespace:Magitek.Properties"
+             xmlns:properties="clr-namespace:Magitek.Properties"
              xmlns:controls="clr-namespace:Magitek.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,275 +10,495 @@
              d:DesignWidth="500"
              mc:Ignorable="d">
 
-    <UserControl.DataContext>
-        <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
-    </UserControl.DataContext>
+        <UserControl.DataContext>
+                <Binding Source="{x:Static viewModels:BaseSettings.Instance}"/>
+        </UserControl.DataContext>
 
-    <UserControl.Resources>
-        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
-    </UserControl.Resources>
+        <UserControl.Resources>
+                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml"/>
+        </UserControl.Resources>
 
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="10">
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="10">
 
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Margin="5,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_AoE_Heal_When_Allies_Need_Healing}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Light_Party}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoeNeedHealingLightParty, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Full_Party}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoeNeedHealingFullParty, Mode=TwoWay}" />
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <StackPanel Margin="5,0"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_AoE_Heal_When_Allies_Need_Healing}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Light_Party}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.AoeNeedHealingLightParty, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Full_Party}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.AoeNeedHealingFullParty, Mode=TwoWay}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5,0"
+                                                        Orientation="Horizontal">
+                                                <CheckBox Grid.Column="0"
+                                                                Content="{x:Static properties:Resources.Astrologian_Content_Disable_Single_Healing_When_Allies_Need_AoE}"
+                                                                IsChecked="{Binding AstrologianSettings.DisableSingleHealWhenNeedAoeHealing, Mode=TwoWay}"
+                                                                Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                MinValue="1"
+                                                                Value="{Binding AstrologianSettings.AoEHealHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                                Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5,0"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Grid.Column="0"
+                                                          Content="{x:Static properties:Resources.Generic_Interrupt_Healing_If_Target_HP_Gets_Over}"
+                                                          IsChecked="{Binding AstrologianSettings.InterruptHealing, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric Grid.Column="1"
+                                                                  Margin="3,0"
+                                                                  Value="{Binding AstrologianSettings.InterruptHealingHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Grid.Column="2"
+                                                           VerticalAlignment="Center"
+                                                           FontSize="11"
+                                                           Foreground="White"
+                                                           Text="{x:Static properties:Resources.Generic_Percent}"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel Margin="5">
+                                        <StackPanel Margin="5,0"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Content_AoEHealThreshold}"/>
+                                                <controls:Numeric MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.AoEHealThreshold, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+
+                                <StackPanel Margin="5">
+                                        <Grid Margin="5">
+                                                <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                </Grid.ColumnDefinitions>
+
+                                                <CheckBox Grid.Column="0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Ascend}"
+                                                          IsChecked="{Binding AstrologianSettings.SlowcastRes, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Grid.Column="1"
+                                                          Margin="5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Swiftcast_Ascend}"
+                                                          IsChecked="{Binding AstrologianSettings.SwiftcastRes, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Grid.Column="2"
+                                                          Margin="5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Ascend_Out_of_Combat}"
+                                                          IsChecked="{Binding AstrologianSettings.ResOutOfCombat, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </Grid>
+                                        <StackPanel Margin="0,5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Resurrection_Delay}"/>
+                                                <controls:Numeric MinValue="0"
+                                                                  MaxValue="10"
+                                                                  Value="{Binding AstrologianSettings.ResDelay, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Seconds}"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel>
+                                        <Grid>
+                                                <Grid.RowDefinitions>
+                                                        <RowDefinition/>
+                                                        <RowDefinition/>
+                                                        <RowDefinition/>
+                                                        <RowDefinition/>
+                                                        <RowDefinition/>
+                                                        <RowDefinition/>
+                                                        <RowDefinition/>
+                                                </Grid.RowDefinitions>
+
+
+                                                <!--  Physick  -->
+                                                <Grid Grid.Row="0"
+                                                      Margin="5,5,0,2">
+                                                        <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="112"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+
+                                                        <CheckBox Grid.Column="0"
+                                                                  Content="{x:Static properties:Resources.Astrologian_Content_Benefic}"
+                                                                  IsChecked="{Binding AstrologianSettings.Benefic, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"/>
+                                                        <controls:Numeric Grid.Column="1"
+                                                                          MaxValue="100"
+                                                                          MinValue="1"
+                                                                          Value="{Binding AstrologianSettings.BeneficHealthPercent, Mode=TwoWay}"/>
+                                                        <TextBlock Grid.Column="2"
+                                                                   Margin="2,0,3,1"
+                                                                   Style="{DynamicResource TextBlockDefault}"
+                                                                   Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                                </Grid>
+
+                                                <Border Grid.Row="1"
+                                                        Padding="5,2"
+                                                        Background="{DynamicResource AlternatingSettingRow}">
+                                                        <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="112"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <CheckBox Grid.Column="0"
+                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Benefic_2}"
+                                                                          IsChecked="{Binding AstrologianSettings.Benefic2, Mode=TwoWay}"
+                                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                                <controls:Numeric Grid.Column="1"
+                                                                                  MaxValue="100"
+                                                                                  MinValue="1"
+                                                                                  Value="{Binding AstrologianSettings.Benefic2HealthPercent, Mode=TwoWay}"/>
+                                                                <TextBlock Grid.Column="2"
+                                                                           Margin="2,0,3,0"
+                                                                           Style="{DynamicResource TextBlockDefault}"
+                                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                                                <CheckBox Grid.Column="3"
+                                                                          Margin="2,0,3,0"
+                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Always_With_Enhanced_Benefic}"
+                                                                          IsChecked="{Binding AstrologianSettings.Benefic2AlwaysWithEnhancedBenefic2, Mode=TwoWay}"
+                                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                        </Grid>
+                                                </Border>
+
+                                                <Grid Grid.Row="2"
+                                                      Margin="5,2">
+                                                        <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="112"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                        </Grid.ColumnDefinitions>
+
+                                                        <CheckBox Grid.Column="0"
+                                                                  Content="{x:Static properties:Resources.Astrologian_Content_Essential_Dignity}"
+                                                                  IsChecked="{Binding AstrologianSettings.EssentialDignity, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"/>
+                                                        <controls:Numeric Grid.Column="1"
+                                                                          MaxValue="100"
+                                                                          MinValue="1"
+                                                                          Value="{Binding AstrologianSettings.EssentialDignityHealthPercent, Mode=TwoWay}"/>
+                                                        <TextBlock Grid.Column="2"
+                                                                   Margin="2,0,3,0"
+                                                                   Style="{DynamicResource TextBlockDefault}"
+                                                                   Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                                        <CheckBox Grid.Column="3"
+                                                                  Margin="2,0"
+                                                                  Content="{x:Static properties:Resources.Generic_On_Tank_Only}"
+                                                                  IsChecked="{Binding AstrologianSettings.EssentialDignityTankOnly, Mode=TwoWay}"
+                                                                  Style="{DynamicResource CheckBoxFlat}"/>
+                                                </Grid>
+
+                                                <Border Grid.Row="3"
+                                                        Padding="5,2"
+                                                        Background="{DynamicResource AlternatingSettingRow}">
+                                                        <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="112"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <CheckBox Grid.Column="0"
+                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Helios}"
+                                                                          IsChecked="{Binding AstrologianSettings.Helios, Mode=TwoWay}"
+                                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                                <controls:Numeric Grid.Column="1"
+                                                                                  MaxValue="100"
+                                                                                  MinValue="1"
+                                                                                  Value="{Binding AstrologianSettings.HeliosHealthPercent, Mode=TwoWay}"/>
+                                                                <TextBlock Grid.Column="2"
+                                                                           Margin="2,0,3,0"
+                                                                           Style="{DynamicResource TextBlockDefault}"
+                                                                           Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_and}"/>
+                                                                <controls:Numeric Grid.Column="5"
+                                                                                  MaxValue="100"
+                                                                                  MinValue="1"
+                                                                                  Value="{Binding AstrologianSettings.HeliosMinManaPercent, Mode=TwoWay}"/>
+                                                                <TextBlock Grid.Column="6"
+                                                                           Margin="2,0,3,0"
+                                                                           Style="{DynamicResource TextBlockDefault}"
+                                                                           Text="{x:Static properties:Resources.Astrologian_Text_Minimum_Mana_To_Use}"/>
+                                                        </Grid>
+                                                </Border>
+
+                                                <Border Grid.Row="4"
+                                                        Padding="5,2">
+                                                        <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="112"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <CheckBox Grid.Column="0"
+                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unco}"
+                                                                          IsChecked="{Binding AstrologianSettings.CollectiveUnconscious, Mode=TwoWay}"
+                                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                                <controls:Numeric Grid.Column="1"
+                                                                                  MaxValue="100"
+                                                                                  MinValue="1"
+                                                                                  Value="{Binding AstrologianSettings.CollectiveUnconsciousHealth, Mode=TwoWay}"/>
+                                                                <TextBlock Grid.Column="2"
+                                                                           Margin="2,0,3,0"
+                                                                           Style="{DynamicResource TextBlockDefault}"
+                                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                                        </Grid>
+                                                </Border>
+
+                                                <Border Grid.Row="5"
+                                                        Padding="5,2">
+                                                        <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="112"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <CheckBox Grid.Column="0"
+                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}"
+                                                                          IsChecked="{Binding AstrologianSettings.Exaltation, Mode=TwoWay}"
+                                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                                <controls:Numeric Grid.Column="1"
+                                                                                  MaxValue="100"
+                                                                                  MinValue="1"
+                                                                                  Value="{Binding AstrologianSettings.ExaltationHealthPercent, Mode=TwoWay}"/>
+                                                                <TextBlock Grid.Column="2"
+                                                                           Margin="2,0,3,0"
+                                                                           Style="{DynamicResource TextBlockDefault}"
+                                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                                        </Grid>
+                                                </Border>
+                                                <Border Grid.Row="6"
+                                                        Padding="5,2">
+                                                        <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="112"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                        <ColumnDefinition Width="Auto"/>
+                                                                </Grid.ColumnDefinitions>
+
+                                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}"
+                                                                          IsChecked="{Binding AstrologianSettings.Macrocosmos, Mode=TwoWay}"
+                                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                                <controls:Numeric Grid.Column="1"
+                                                                                  MaxValue="100"
+                                                                                  MinValue="1"
+                                                                                  Value="{Binding AstrologianSettings.MacrocosmosHealthPercent, Mode=TwoWay}"/>
+                                                                <TextBlock Grid.Column="2"
+                                                                           Margin="2,0,3,1"
+                                                                           Style="{DynamicResource TextBlockDefault}"
+                                                                           Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_to_Pre_emptively_M}"/>
+                                                        </Grid>
+                                                </Border>
+                                        </Grid>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <controls:SettingsBlock Margin="0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel>
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Synastry_When}"
+                                                          IsChecked="{Binding AstrologianSettings.Synastry, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <TextBlock Margin="2,0,3,0"
+                                                           Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}"/>
+                                                <controls:Numeric Margin="2,0"
+                                                                  MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.SynastryHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Margin="2,0,3,0"
+                                                           Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                                <CheckBox Margin="10,0"
+                                                          Content="{x:Static properties:Resources.Generic_On_Tank_Only}"
+                                                          IsChecked="{Binding AstrologianSettings.SynastryTankOnly, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Horoscope_When}"
+                                                          IsChecked="{Binding AstrologianSettings.Horoscope, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <TextBlock Margin="2,0,3,0"
+                                                           Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}"/>
+                                                <controls:Numeric Margin="2,0"
+                                                                  MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.HoroscopeHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Margin="2,0,3,0"
+                                                           Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
+
+                        <controls:SettingsBlock Margin="0,0,0,0"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel>
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Earthly_Star}"
+                                                          IsChecked="{Binding AstrologianSettings.EarthlyStar, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <controls:Numeric Margin="2,0"
+                                                                  MaxValue="10"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.EarthlyStarEnemiesNearTarget, Mode=TwoWay}"/>
+                                                <TextBlock Margin="2,0,3,0"
+                                                           Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Enemies_Near_Target}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5,0,0,0"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Stellar_Detonation}"
+                                                          IsChecked="{Binding AstrologianSettings.StellarDetonation, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5,0,0,0"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Burst_If}"/>
+                                                <controls:Numeric Margin="2,3"
+                                                                  MaxValue="10"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.EarthlyDominanceCount, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}"/>
+                                                <controls:Numeric Margin="2,3"
+                                                                  Increment="5"
+                                                                  MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.EarthlyDominanceHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5,0,0,0"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Explosion_If}"/>
+                                                <controls:Numeric Margin="2,3"
+                                                                  MaxValue="10"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.GiantDominanceCount, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}"/>
+                                                <controls:Numeric Margin="2,3"
+                                                                  Increment="5"
+                                                                  MaxValue="100"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.GiantDominanceHealthPercent, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5,0,0,0"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Detonate_Early_When_Pull_Ends_Within}"/>
+                                                <controls:Numeric Margin="2,3"
+                                                                  MaxValue="15"
+                                                                  MinValue="1"
+                                                                  Value="{Binding AstrologianSettings.StellarDetonationPullEndingSeconds, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Seconds}"/>
+                                        </StackPanel>
+                                </StackPanel>
+
+
+                        </controls:SettingsBlock>
+
+                        <controls:SettingsBlock Margin="0,5,0,5"
+                                                Background="{DynamicResource ClassSelectorBackground}">
+                                <StackPanel>
+                                        <StackPanel Margin="5,5,0,0"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Weave_OGCD_Heals}"
+                                                          IsChecked="{Binding AstrologianSettings.WeaveOGCDHeals, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                        </StackPanel>
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Margin="0,0,3,0"
+                                                           Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Astrologian_Text_Fight_Logic}"/>
+                                                <CheckBox Margin="0,0,5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}"
+                                                          IsChecked="{Binding AstrologianSettings.FightLogic_Exaltation, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_f}"/>
+                                                <CheckBox Margin="0,0,5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unconscious}"
+                                                          IsChecked="{Binding AstrologianSettings.FightLogic_CollectiveUnconscious, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_C}"/>
+                                                <CheckBox Margin="0,0,5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}"
+                                                          IsChecked="{Binding AstrologianSettings.FightLogic_Macrocosmos, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_M}"/>
+                                                <CheckBox Margin="0,0,5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Neutral_Sect}"
+                                                          IsChecked="{Binding AstrologianSettings.FightLogic_NeutralSectAspectedHelios, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_N}"/>
+                                                <CheckBox Margin="0,0,5,0"
+                                                          Content="{x:Static properties:Resources.Astrologian_Content_Lightspeed}"
+                                                          IsChecked="{Binding AstrologianSettings.FightLogic_Lightspeed, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_L}"/>
+
+                                        </StackPanel>
+                                </StackPanel>
+                        </controls:SettingsBlock>
                 </StackPanel>
-                <StackPanel Margin="5,0" Orientation="Horizontal">
-                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Disable_Single_Healing_When_Allies_Need_AoE}" IsChecked="{Binding AstrologianSettings.DisableSingleHealWhenNeedAoeHealing, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoEHealHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-                <StackPanel Margin="5,0" Orientation="Horizontal">
-                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Generic_Interrupt_Healing_If_Target_HP_Gets_Over}" IsChecked="{Binding AstrologianSettings.InterruptHealing, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Grid.Column="1" Margin="3,0" Value="{Binding AstrologianSettings.InterruptHealingHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Grid.Column="2" VerticalAlignment="Center" FontSize="11" Foreground="White" Text="{x:Static properties:Resources.Generic_Percent}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Margin="5">
-                <StackPanel Margin="5,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Content_PlayDefensiveCardHealthPercent}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.PlayDefensiveCardHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-                <StackPanel Margin="5,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Content_AoEHealThreshold}" />
-                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoEHealThreshold, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-
-            <StackPanel Margin="5">
-                <Grid Margin="5">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Ascend}" IsChecked="{Binding AstrologianSettings.SlowcastRes, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Grid.Column="1" Margin="5,0" Content="{x:Static properties:Resources.Astrologian_Content_Swiftcast_Ascend}" IsChecked="{Binding AstrologianSettings.SwiftcastRes, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <CheckBox Grid.Column="2" Margin="5,0" Content="{x:Static properties:Resources.Astrologian_Content_Ascend_Out_of_Combat}" IsChecked="{Binding AstrologianSettings.ResOutOfCombat, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </Grid>
-                <StackPanel Margin="0,5" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Resurrection_Delay}" />
-                    <controls:Numeric MinValue="0" MaxValue="10" Value="{Binding AstrologianSettings.ResDelay, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Seconds}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-        
-        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel>
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                    <RowDefinition />
-                </Grid.RowDefinitions>
-
-
-                <!--  Physick  -->
-                <Grid Grid.Row="0" Margin="5,5,0,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="112" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Benefic}" IsChecked="{Binding AstrologianSettings.Benefic, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.BeneficHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Grid.Column="2" Margin="2,0,3,1" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </Grid>
-
-                <Border Grid.Row="1" Padding="5,2" Background="{DynamicResource AlternatingSettingRow}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Benefic_2}" IsChecked="{Binding AstrologianSettings.Benefic2, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.Benefic2HealthPercent, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                        <CheckBox Grid.Column="3" Margin="2,0,3,0" Content="{x:Static properties:Resources.Astrologian_Content_Always_With_Enhanced_Benefic}" IsChecked="{Binding AstrologianSettings.Benefic2AlwaysWithEnhancedBenefic2, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    </Grid>
-                </Border>
-
-                <Grid Grid.Row="2" Margin="5,2">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="112" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-
-                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Essential_Dignity}" IsChecked="{Binding AstrologianSettings.EssentialDignity, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.EssentialDignityHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                    <CheckBox Grid.Column="3" Margin="2,0" Content="{x:Static properties:Resources.Generic_On_Tank_Only}" IsChecked="{Binding AstrologianSettings.EssentialDignityTankOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </Grid>
-
-                <Border Grid.Row="3" Padding="5,2" Background="{DynamicResource AlternatingSettingRow}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Helios}" IsChecked="{Binding AstrologianSettings.Helios, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.HeliosHealthPercent, Mode=TwoWay}" />
-                            <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_and}" />
-                            <controls:Numeric Grid.Column="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.HeliosMinManaPercent, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="6" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Minimum_Mana_To_Use}" />
-                    </Grid>
-                </Border>
-
-                <Border Grid.Row="4" Padding="5,2">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        
-                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unco}" IsChecked="{Binding AstrologianSettings.CollectiveUnconscious, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.CollectiveUnconsciousHealth, Mode=TwoWay}" />
-                            <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                        </Grid>
-                </Border>
-
-                <Border Grid.Row="5" Padding="5,2">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        
-                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}" IsChecked="{Binding AstrologianSettings.Exaltation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.ExaltationHealthPercent, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                    </Grid>
-                </Border>
-                <Border Grid.Row="6" Padding="5,2">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="112" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        
-                        <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}" IsChecked="{Binding AstrologianSettings.Macrocosmos, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.BeneficHealthPercent, Mode=TwoWay}" />
-                        <TextBlock Grid.Column="2" Margin="2,0,3,1" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_to_Pre_emptively_M}" />
-                    </Grid>
-                </Border>
-            </Grid>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel>
-                <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Synastry_When}" IsChecked="{Binding AstrologianSettings.Synastry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}" />
-                <controls:Numeric Margin="2,0" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.SynastryHealthPercent, Mode=TwoWay}" />
-                <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                <CheckBox Margin="10,0" Content="{x:Static properties:Resources.Generic_On_Tank_Only}" IsChecked="{Binding AstrologianSettings.SynastryTankOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
-
-                <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Horoscope_When}" IsChecked="{Binding AstrologianSettings.Horoscope, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}" />
-                <controls:Numeric Margin="2,0" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.HoroscopeHealthPercent, Mode=TwoWay}" />
-                <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,0,0,0" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel>
-                <StackPanel Margin="5" Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Earthly_Star}" IsChecked="{Binding AstrologianSettings.EarthlyStar, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                    <controls:Numeric Margin="2,0" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.EarthlyStarEnemiesNearTarget, Mode=TwoWay}" />
-                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Enemies_Near_Target}" />
-                </StackPanel>
-                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Stellar_Detonation}" IsChecked="{Binding AstrologianSettings.StellarDetonation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
-                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Burst_If}" />
-                    <controls:Numeric Margin="2,3" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.EarthlyDominanceCount, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}" />
-                    <controls:Numeric Margin="2,3" Increment="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.EarthlyDominanceHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Explosion_If}" />
-                    <controls:Numeric Margin="2,3" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.GiantDominanceCount, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}" />
-                    <controls:Numeric Margin="2,3" Increment="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.GiantDominanceHealthPercent, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
-                </StackPanel>
-                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Detonate_Early_When_Pull_Ends_Within}" />
-                    <controls:Numeric Margin="2,3" MaxValue="15" MinValue="1" Value="{Binding AstrologianSettings.StellarDetonationPullEndingSeconds, Mode=TwoWay}" />
-                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Seconds}" />
-                </StackPanel>
-            </StackPanel>
-
-
-        </controls:SettingsBlock>
-
-        <controls:SettingsBlock Margin="0,5,0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel>
-                <StackPanel Margin="5,5,0,0" Orientation="Horizontal">
-                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Weave_OGCD_Heals}" IsChecked="{Binding AstrologianSettings.WeaveOGCDHeals, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                </StackPanel>
-                <StackPanel Margin="5" Orientation="Horizontal">
-                    <TextBlock Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Fight_Logic}" />
-                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}" IsChecked="{Binding AstrologianSettings.FightLogic_Exaltation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_f}"/>
-                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unconscious}" IsChecked="{Binding AstrologianSettings.FightLogic_CollectiveUnconscious, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_C}"/>
-                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}" IsChecked="{Binding AstrologianSettings.FightLogic_Macrocosmos, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_M}"/>
-                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Neutral_Sect}" IsChecked="{Binding AstrologianSettings.FightLogic_NeutralSectAspectedHelios, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_N}"/>
-                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Lightspeed}" IsChecked="{Binding AstrologianSettings.FightLogic_Lightspeed, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_L}"/>
-
-                </StackPanel>
-            </StackPanel>
-        </controls:SettingsBlock>
-        </StackPanel>
-    </ScrollViewer>
+        </ScrollViewer>
 
 </UserControl>

--- a/Magitek/Views/UserControls/Astrologian/Healing.xaml
+++ b/Magitek/Views/UserControls/Astrologian/Healing.xaml
@@ -1,7 +1,7 @@
 ﻿<UserControl x:Class="Magitek.Views.UserControls.Astrologian.Healing"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:properties="clr-namespace:Magitek.Properties"
+        xmlns:properties="clr-namespace:Magitek.Properties"
              xmlns:controls="clr-namespace:Magitek.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,495 +10,261 @@
              d:DesignWidth="500"
              mc:Ignorable="d">
 
-        <UserControl.DataContext>
-                <Binding Source="{x:Static viewModels:BaseSettings.Instance}"/>
-        </UserControl.DataContext>
+    <UserControl.DataContext>
+        <Binding Source="{x:Static viewModels:BaseSettings.Instance}" />
+    </UserControl.DataContext>
 
-        <UserControl.Resources>
-                <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml"/>
-        </UserControl.Resources>
+    <UserControl.Resources>
+        <ResourceDictionary Source="/Magitek;component/Styles/Magitek.xaml" />
+    </UserControl.Resources>
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto">
-                <StackPanel Margin="10">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Margin="10">
 
-                        <controls:SettingsBlock Margin="0,5"
-                                                Background="{DynamicResource ClassSelectorBackground}">
-                                <StackPanel Margin="5">
-                                        <StackPanel Margin="5,0"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_AoE_Heal_When_Allies_Need_Healing}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Light_Party}"/>
-                                                <controls:Numeric MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.AoeNeedHealingLightParty, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Full_Party}"/>
-                                                <controls:Numeric MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.AoeNeedHealingFullParty, Mode=TwoWay}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0"
-                                                        Orientation="Horizontal">
-                                                <CheckBox Grid.Column="0"
-                                                                Content="{x:Static properties:Resources.Astrologian_Content_Disable_Single_Healing_When_Allies_Need_AoE}"
-                                                                IsChecked="{Binding AstrologianSettings.DisableSingleHealWhenNeedAoeHealing, Mode=TwoWay}"
-                                                                Style="{DynamicResource CheckBoxFlat}"/>
-                                                <controls:Numeric MaxValue="100"
-                                                                MinValue="1"
-                                                                Value="{Binding AstrologianSettings.AoEHealHealthPercent, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                                Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0"
-                                                    Orientation="Horizontal">
-                                                <CheckBox Grid.Column="0"
-                                                          Content="{x:Static properties:Resources.Generic_Interrupt_Healing_If_Target_HP_Gets_Over}"
-                                                          IsChecked="{Binding AstrologianSettings.InterruptHealing, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                <controls:Numeric Grid.Column="1"
-                                                                  Margin="3,0"
-                                                                  Value="{Binding AstrologianSettings.InterruptHealingHealthPercent, Mode=TwoWay}"/>
-                                                <TextBlock Grid.Column="2"
-                                                           VerticalAlignment="Center"
-                                                           FontSize="11"
-                                                           Foreground="White"
-                                                           Text="{x:Static properties:Resources.Generic_Percent}"/>
-                                        </StackPanel>
-                                </StackPanel>
-                        </controls:SettingsBlock>
-                        <controls:SettingsBlock Margin="0,5"
-                                                Background="{DynamicResource ClassSelectorBackground}">
-                                <StackPanel Margin="5">
-                                        <StackPanel Margin="5,0"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Content_AoEHealThreshold}"/>
-                                                <controls:Numeric MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.AoEHealThreshold, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                        </StackPanel>
-                                </StackPanel>
-                        </controls:SettingsBlock>
-
-                        <controls:SettingsBlock Margin="0,5"
-                                                Background="{DynamicResource ClassSelectorBackground}">
-
-                                <StackPanel Margin="5">
-                                        <Grid Margin="5">
-                                                <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                </Grid.ColumnDefinitions>
-
-                                                <CheckBox Grid.Column="0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Ascend}"
-                                                          IsChecked="{Binding AstrologianSettings.SlowcastRes, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                <CheckBox Grid.Column="1"
-                                                          Margin="5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Swiftcast_Ascend}"
-                                                          IsChecked="{Binding AstrologianSettings.SwiftcastRes, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                <CheckBox Grid.Column="2"
-                                                          Margin="5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Ascend_Out_of_Combat}"
-                                                          IsChecked="{Binding AstrologianSettings.ResOutOfCombat, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                        </Grid>
-                                        <StackPanel Margin="0,5"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Resurrection_Delay}"/>
-                                                <controls:Numeric MinValue="0"
-                                                                  MaxValue="10"
-                                                                  Value="{Binding AstrologianSettings.ResDelay, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Seconds}"/>
-                                        </StackPanel>
-                                </StackPanel>
-                        </controls:SettingsBlock>
-
-                        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
-                                <StackPanel>
-                                        <Grid>
-                                                <Grid.RowDefinitions>
-                                                        <RowDefinition/>
-                                                        <RowDefinition/>
-                                                        <RowDefinition/>
-                                                        <RowDefinition/>
-                                                        <RowDefinition/>
-                                                        <RowDefinition/>
-                                                        <RowDefinition/>
-                                                </Grid.RowDefinitions>
-
-
-                                                <!--  Physick  -->
-                                                <Grid Grid.Row="0"
-                                                      Margin="5,5,0,2">
-                                                        <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="112"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                        </Grid.ColumnDefinitions>
-
-                                                        <CheckBox Grid.Column="0"
-                                                                  Content="{x:Static properties:Resources.Astrologian_Content_Benefic}"
-                                                                  IsChecked="{Binding AstrologianSettings.Benefic, Mode=TwoWay}"
-                                                                  Style="{DynamicResource CheckBoxFlat}"/>
-                                                        <controls:Numeric Grid.Column="1"
-                                                                          MaxValue="100"
-                                                                          MinValue="1"
-                                                                          Value="{Binding AstrologianSettings.BeneficHealthPercent, Mode=TwoWay}"/>
-                                                        <TextBlock Grid.Column="2"
-                                                                   Margin="2,0,3,1"
-                                                                   Style="{DynamicResource TextBlockDefault}"
-                                                                   Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                                </Grid>
-
-                                                <Border Grid.Row="1"
-                                                        Padding="5,2"
-                                                        Background="{DynamicResource AlternatingSettingRow}">
-                                                        <Grid>
-                                                                <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="112"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                </Grid.ColumnDefinitions>
-
-                                                                <CheckBox Grid.Column="0"
-                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Benefic_2}"
-                                                                          IsChecked="{Binding AstrologianSettings.Benefic2, Mode=TwoWay}"
-                                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                                <controls:Numeric Grid.Column="1"
-                                                                                  MaxValue="100"
-                                                                                  MinValue="1"
-                                                                                  Value="{Binding AstrologianSettings.Benefic2HealthPercent, Mode=TwoWay}"/>
-                                                                <TextBlock Grid.Column="2"
-                                                                           Margin="2,0,3,0"
-                                                                           Style="{DynamicResource TextBlockDefault}"
-                                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                                                <CheckBox Grid.Column="3"
-                                                                          Margin="2,0,3,0"
-                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Always_With_Enhanced_Benefic}"
-                                                                          IsChecked="{Binding AstrologianSettings.Benefic2AlwaysWithEnhancedBenefic2, Mode=TwoWay}"
-                                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                        </Grid>
-                                                </Border>
-
-                                                <Grid Grid.Row="2"
-                                                      Margin="5,2">
-                                                        <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="112"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                                <ColumnDefinition Width="Auto"/>
-                                                        </Grid.ColumnDefinitions>
-
-                                                        <CheckBox Grid.Column="0"
-                                                                  Content="{x:Static properties:Resources.Astrologian_Content_Essential_Dignity}"
-                                                                  IsChecked="{Binding AstrologianSettings.EssentialDignity, Mode=TwoWay}"
-                                                                  Style="{DynamicResource CheckBoxFlat}"/>
-                                                        <controls:Numeric Grid.Column="1"
-                                                                          MaxValue="100"
-                                                                          MinValue="1"
-                                                                          Value="{Binding AstrologianSettings.EssentialDignityHealthPercent, Mode=TwoWay}"/>
-                                                        <TextBlock Grid.Column="2"
-                                                                   Margin="2,0,3,0"
-                                                                   Style="{DynamicResource TextBlockDefault}"
-                                                                   Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                                        <CheckBox Grid.Column="3"
-                                                                  Margin="2,0"
-                                                                  Content="{x:Static properties:Resources.Generic_On_Tank_Only}"
-                                                                  IsChecked="{Binding AstrologianSettings.EssentialDignityTankOnly, Mode=TwoWay}"
-                                                                  Style="{DynamicResource CheckBoxFlat}"/>
-                                                </Grid>
-
-                                                <Border Grid.Row="3"
-                                                        Padding="5,2"
-                                                        Background="{DynamicResource AlternatingSettingRow}">
-                                                        <Grid>
-                                                                <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="112"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                </Grid.ColumnDefinitions>
-
-                                                                <CheckBox Grid.Column="0"
-                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Helios}"
-                                                                          IsChecked="{Binding AstrologianSettings.Helios, Mode=TwoWay}"
-                                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                                <controls:Numeric Grid.Column="1"
-                                                                                  MaxValue="100"
-                                                                                  MinValue="1"
-                                                                                  Value="{Binding AstrologianSettings.HeliosHealthPercent, Mode=TwoWay}"/>
-                                                                <TextBlock Grid.Column="2"
-                                                                           Margin="2,0,3,0"
-                                                                           Style="{DynamicResource TextBlockDefault}"
-                                                                           Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_and}"/>
-                                                                <controls:Numeric Grid.Column="5"
-                                                                                  MaxValue="100"
-                                                                                  MinValue="1"
-                                                                                  Value="{Binding AstrologianSettings.HeliosMinManaPercent, Mode=TwoWay}"/>
-                                                                <TextBlock Grid.Column="6"
-                                                                           Margin="2,0,3,0"
-                                                                           Style="{DynamicResource TextBlockDefault}"
-                                                                           Text="{x:Static properties:Resources.Astrologian_Text_Minimum_Mana_To_Use}"/>
-                                                        </Grid>
-                                                </Border>
-
-                                                <Border Grid.Row="4"
-                                                        Padding="5,2">
-                                                        <Grid>
-                                                                <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="112"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                </Grid.ColumnDefinitions>
-
-                                                                <CheckBox Grid.Column="0"
-                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unco}"
-                                                                          IsChecked="{Binding AstrologianSettings.CollectiveUnconscious, Mode=TwoWay}"
-                                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                                <controls:Numeric Grid.Column="1"
-                                                                                  MaxValue="100"
-                                                                                  MinValue="1"
-                                                                                  Value="{Binding AstrologianSettings.CollectiveUnconsciousHealth, Mode=TwoWay}"/>
-                                                                <TextBlock Grid.Column="2"
-                                                                           Margin="2,0,3,0"
-                                                                           Style="{DynamicResource TextBlockDefault}"
-                                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                                        </Grid>
-                                                </Border>
-
-                                                <Border Grid.Row="5"
-                                                        Padding="5,2">
-                                                        <Grid>
-                                                                <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="112"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                </Grid.ColumnDefinitions>
-
-                                                                <CheckBox Grid.Column="0"
-                                                                          Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}"
-                                                                          IsChecked="{Binding AstrologianSettings.Exaltation, Mode=TwoWay}"
-                                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                                <controls:Numeric Grid.Column="1"
-                                                                                  MaxValue="100"
-                                                                                  MinValue="1"
-                                                                                  Value="{Binding AstrologianSettings.ExaltationHealthPercent, Mode=TwoWay}"/>
-                                                                <TextBlock Grid.Column="2"
-                                                                           Margin="2,0,3,0"
-                                                                           Style="{DynamicResource TextBlockDefault}"
-                                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                                        </Grid>
-                                                </Border>
-                                                <Border Grid.Row="6"
-                                                        Padding="5,2">
-                                                        <Grid>
-                                                                <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="112"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                        <ColumnDefinition Width="Auto"/>
-                                                                </Grid.ColumnDefinitions>
-
-                                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}"
-                                                                          IsChecked="{Binding AstrologianSettings.Macrocosmos, Mode=TwoWay}"
-                                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                                <controls:Numeric Grid.Column="1"
-                                                                                  MaxValue="100"
-                                                                                  MinValue="1"
-                                                                                  Value="{Binding AstrologianSettings.MacrocosmosHealthPercent, Mode=TwoWay}"/>
-                                                                <TextBlock Grid.Column="2"
-                                                                           Margin="2,0,3,1"
-                                                                           Style="{DynamicResource TextBlockDefault}"
-                                                                           Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_to_Pre_emptively_M}"/>
-                                                        </Grid>
-                                                </Border>
-                                        </Grid>
-                                </StackPanel>
-                        </controls:SettingsBlock>
-
-                        <controls:SettingsBlock Margin="0,5"
-                                                Background="{DynamicResource ClassSelectorBackground}">
-                                <StackPanel>
-                                        <StackPanel Margin="5"
-                                                    Orientation="Horizontal">
-                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Synastry_When}"
-                                                          IsChecked="{Binding AstrologianSettings.Synastry, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                <TextBlock Margin="2,0,3,0"
-                                                           Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}"/>
-                                                <controls:Numeric Margin="2,0"
-                                                                  MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.SynastryHealthPercent, Mode=TwoWay}"/>
-                                                <TextBlock Margin="2,0,3,0"
-                                                           Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                                <CheckBox Margin="10,0"
-                                                          Content="{x:Static properties:Resources.Generic_On_Tank_Only}"
-                                                          IsChecked="{Binding AstrologianSettings.SynastryTankOnly, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                        </StackPanel>
-
-                                        <StackPanel Margin="5"
-                                                    Orientation="Horizontal">
-                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Horoscope_When}"
-                                                          IsChecked="{Binding AstrologianSettings.Horoscope, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                <TextBlock Margin="2,0,3,0"
-                                                           Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}"/>
-                                                <controls:Numeric Margin="2,0"
-                                                                  MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.HoroscopeHealthPercent, Mode=TwoWay}"/>
-                                                <TextBlock Margin="2,0,3,0"
-                                                           Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                        </StackPanel>
-                                </StackPanel>
-                        </controls:SettingsBlock>
-
-                        <controls:SettingsBlock Margin="0,0,0,0"
-                                                Background="{DynamicResource ClassSelectorBackground}">
-                                <StackPanel>
-                                        <StackPanel Margin="5"
-                                                    Orientation="Horizontal">
-                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Earthly_Star}"
-                                                          IsChecked="{Binding AstrologianSettings.EarthlyStar, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                                <controls:Numeric Margin="2,0"
-                                                                  MaxValue="10"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.EarthlyStarEnemiesNearTarget, Mode=TwoWay}"/>
-                                                <TextBlock Margin="2,0,3,0"
-                                                           Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Enemies_Near_Target}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0,0,0"
-                                                    Orientation="Horizontal">
-                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Stellar_Detonation}"
-                                                          IsChecked="{Binding AstrologianSettings.StellarDetonation, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0,0,0"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Burst_If}"/>
-                                                <controls:Numeric Margin="2,3"
-                                                                  MaxValue="10"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.EarthlyDominanceCount, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}"/>
-                                                <controls:Numeric Margin="2,3"
-                                                                  Increment="5"
-                                                                  MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.EarthlyDominanceHealthPercent, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0,0,0"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Explosion_If}"/>
-                                                <controls:Numeric Margin="2,3"
-                                                                  MaxValue="10"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.GiantDominanceCount, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}"/>
-                                                <controls:Numeric Margin="2,3"
-                                                                  Increment="5"
-                                                                  MaxValue="100"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.GiantDominanceHealthPercent, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Health_Percent}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5,0,0,0"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Detonate_Early_When_Pull_Ends_Within}"/>
-                                                <controls:Numeric Margin="2,3"
-                                                                  MaxValue="15"
-                                                                  MinValue="1"
-                                                                  Value="{Binding AstrologianSettings.StellarDetonationPullEndingSeconds, Mode=TwoWay}"/>
-                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Generic_Seconds}"/>
-                                        </StackPanel>
-                                </StackPanel>
-
-
-                        </controls:SettingsBlock>
-
-                        <controls:SettingsBlock Margin="0,5,0,5"
-                                                Background="{DynamicResource ClassSelectorBackground}">
-                                <StackPanel>
-                                        <StackPanel Margin="5,5,0,0"
-                                                    Orientation="Horizontal">
-                                                <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Weave_OGCD_Heals}"
-                                                          IsChecked="{Binding AstrologianSettings.WeaveOGCDHeals, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"/>
-                                        </StackPanel>
-                                        <StackPanel Margin="5"
-                                                    Orientation="Horizontal">
-                                                <TextBlock Margin="0,0,3,0"
-                                                           Style="{DynamicResource TextBlockDefault}"
-                                                           Text="{x:Static properties:Resources.Astrologian_Text_Fight_Logic}"/>
-                                                <CheckBox Margin="0,0,5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}"
-                                                          IsChecked="{Binding AstrologianSettings.FightLogic_Exaltation, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"
-                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_f}"/>
-                                                <CheckBox Margin="0,0,5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unconscious}"
-                                                          IsChecked="{Binding AstrologianSettings.FightLogic_CollectiveUnconscious, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"
-                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_C}"/>
-                                                <CheckBox Margin="0,0,5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}"
-                                                          IsChecked="{Binding AstrologianSettings.FightLogic_Macrocosmos, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"
-                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_M}"/>
-                                                <CheckBox Margin="0,0,5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Neutral_Sect}"
-                                                          IsChecked="{Binding AstrologianSettings.FightLogic_NeutralSectAspectedHelios, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"
-                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_N}"/>
-                                                <CheckBox Margin="0,0,5,0"
-                                                          Content="{x:Static properties:Resources.Astrologian_Content_Lightspeed}"
-                                                          IsChecked="{Binding AstrologianSettings.FightLogic_Lightspeed, Mode=TwoWay}"
-                                                          Style="{DynamicResource CheckBoxFlat}"
-                                                          ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_L}"/>
-
-                                        </StackPanel>
-                                </StackPanel>
-                        </controls:SettingsBlock>
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel Margin="5">
+                <StackPanel Margin="5,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_AoE_Heal_When_Allies_Need_Healing}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Light_Party}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoeNeedHealingLightParty, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Full_Party}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoeNeedHealingFullParty, Mode=TwoWay}" />
                 </StackPanel>
-        </ScrollViewer>
+                <StackPanel Margin="5,0" Orientation="Horizontal">
+                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Disable_Single_Healing_When_Allies_Need_AoE}" IsChecked="{Binding AstrologianSettings.DisableSingleHealWhenNeedAoeHealing, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.AoEHealHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+                <StackPanel Margin="5,0" Orientation="Horizontal">
+                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Generic_Interrupt_Healing_If_Target_HP_Gets_Over}" IsChecked="{Binding AstrologianSettings.InterruptHealing, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Column="1" Margin="3,0" Value="{Binding AstrologianSettings.InterruptHealingHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Column="2" VerticalAlignment="Center" FontSize="11" Foreground="White" Text="{x:Static properties:Resources.Generic_Percent}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+
+            <StackPanel Margin="5">
+                <Grid Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Ascend}" IsChecked="{Binding AstrologianSettings.SlowcastRes, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="1" Margin="5,0" Content="{x:Static properties:Resources.Astrologian_Content_Swiftcast_Ascend}" IsChecked="{Binding AstrologianSettings.SwiftcastRes, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <CheckBox Grid.Column="2" Margin="5,0" Content="{x:Static properties:Resources.Astrologian_Content_Ascend_Out_of_Combat}" IsChecked="{Binding AstrologianSettings.ResOutOfCombat, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </Grid>
+                <StackPanel Margin="0,5" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Resurrection_Delay}" />
+                    <controls:Numeric MinValue="0" MaxValue="10" Value="{Binding AstrologianSettings.ResDelay, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Seconds}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+        
+        <controls:SettingsBlock Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+
+
+                <!--  Physick  -->
+                <Grid Grid.Row="0" Margin="5,5,0,2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="112" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Benefic}" IsChecked="{Binding AstrologianSettings.Benefic, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.BeneficHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Column="2" Margin="2,0,3,1" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </Grid>
+
+                <Border Grid.Row="1" Padding="5,2" Background="{DynamicResource AlternatingSettingRow}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="112" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Benefic_2}" IsChecked="{Binding AstrologianSettings.Benefic2, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.Benefic2HealthPercent, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                        <CheckBox Grid.Column="3" Margin="2,0,3,0" Content="{x:Static properties:Resources.Astrologian_Content_Always_With_Enhanced_Benefic}" IsChecked="{Binding AstrologianSettings.Benefic2AlwaysWithEnhancedBenefic2, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    </Grid>
+                </Border>
+
+                <Grid Grid.Row="2" Margin="5,2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="112" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Essential_Dignity}" IsChecked="{Binding AstrologianSettings.EssentialDignity, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.EssentialDignityHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                    <CheckBox Grid.Column="3" Margin="2,0" Content="{x:Static properties:Resources.Generic_On_Tank_Only}" IsChecked="{Binding AstrologianSettings.EssentialDignityTankOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </Grid>
+
+                <Border Grid.Row="3" Padding="5,2" Background="{DynamicResource AlternatingSettingRow}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="112" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Helios}" IsChecked="{Binding AstrologianSettings.Helios, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.HeliosHealthPercent, Mode=TwoWay}" />
+                            <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_and}" />
+                            <controls:Numeric Grid.Column="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.HeliosMinManaPercent, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="6" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Minimum_Mana_To_Use}" />
+                    </Grid>
+                </Border>
+
+                <Border Grid.Row="4" Padding="5,2">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="112" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unco}" IsChecked="{Binding AstrologianSettings.CollectiveUnconscious, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.CollectiveUnconsciousHealth, Mode=TwoWay}" />
+                            <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                        </Grid>
+                </Border>
+
+                <Border Grid.Row="5" Padding="5,2">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="112" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <CheckBox Grid.Column="0" Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}" IsChecked="{Binding AstrologianSettings.Exaltation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.ExaltationHealthPercent, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="2" Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                    </Grid>
+                </Border>
+                <Border Grid.Row="6" Padding="5,2">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="112" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}" IsChecked="{Binding AstrologianSettings.Macrocosmos, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                        <controls:Numeric Grid.Column="1" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.BeneficHealthPercent, Mode=TwoWay}" />
+                        <TextBlock Grid.Column="2" Margin="2,0,3,1" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Health_Percent_to_Pre_emptively_M}" />
+                    </Grid>
+                </Border>
+            </Grid>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Synastry_When}" IsChecked="{Binding AstrologianSettings.Synastry, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}" />
+                <controls:Numeric Margin="2,0" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.SynastryHealthPercent, Mode=TwoWay}" />
+                <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                <CheckBox Margin="10,0" Content="{x:Static properties:Resources.Generic_On_Tank_Only}" IsChecked="{Binding AstrologianSettings.SynastryTankOnly, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Horoscope_When}" IsChecked="{Binding AstrologianSettings.Horoscope, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Allies_Are_Below}" />
+                <controls:Numeric Margin="2,0" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.HoroscopeHealthPercent, Mode=TwoWay}" />
+                <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,0,0,0" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Earthly_Star}" IsChecked="{Binding AstrologianSettings.EarthlyStar, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric Margin="2,0" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.EarthlyStarEnemiesNearTarget, Mode=TwoWay}" />
+                    <TextBlock Margin="2,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Enemies_Near_Target}" />
+                </StackPanel>
+                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Stellar_Detonation}" IsChecked="{Binding AstrologianSettings.StellarDetonation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Burst_If}" />
+                    <controls:Numeric Margin="2,3" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.EarthlyDominanceCount, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}" />
+                    <controls:Numeric Margin="2,3" Increment="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.EarthlyDominanceHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Stellar_Explosion_If}" />
+                    <controls:Numeric Margin="2,3" MaxValue="10" MinValue="1" Value="{Binding AstrologianSettings.GiantDominanceCount, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Party_Members_Near_Earthly_Star_Are_Below}" />
+                    <controls:Numeric Margin="2,3" Increment="5" MaxValue="100" MinValue="1" Value="{Binding AstrologianSettings.GiantDominanceHealthPercent, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Health_Percent}" />
+                </StackPanel>
+                <StackPanel Margin="5,0,0,0" Orientation="Horizontal">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Detonate_Early_When_Pull_Ends_Within}" />
+                    <controls:Numeric Margin="2,3" MaxValue="15" MinValue="1" Value="{Binding AstrologianSettings.StellarDetonationPullEndingSeconds, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Seconds}" />
+                </StackPanel>
+            </StackPanel>
+
+
+        </controls:SettingsBlock>
+
+        <controls:SettingsBlock Margin="0,5,0,5" Background="{DynamicResource ClassSelectorBackground}">
+            <StackPanel>
+                <StackPanel Margin="5,5,0,0" Orientation="Horizontal">
+                    <CheckBox Content="{x:Static properties:Resources.Astrologian_Content_Weave_OGCD_Heals}" IsChecked="{Binding AstrologianSettings.WeaveOGCDHeals, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                </StackPanel>
+                <StackPanel Margin="5" Orientation="Horizontal">
+                    <TextBlock Margin="0,0,3,0" Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Astrologian_Text_Fight_Logic}" />
+                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Exaltation}" IsChecked="{Binding AstrologianSettings.FightLogic_Exaltation, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_f}"/>
+                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Collective_Unconscious}" IsChecked="{Binding AstrologianSettings.FightLogic_CollectiveUnconscious, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_C}"/>
+                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Macrocosmos}" IsChecked="{Binding AstrologianSettings.FightLogic_Macrocosmos, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_M}"/>
+                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Neutral_Sect}" IsChecked="{Binding AstrologianSettings.FightLogic_NeutralSectAspectedHelios, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_N}"/>
+                    <CheckBox Margin="0,0,5,0" Content="{x:Static properties:Resources.Astrologian_Content_Lightspeed}" IsChecked="{Binding AstrologianSettings.FightLogic_Lightspeed, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" ToolTip="{x:Static properties:Resources.Astrologian_ToolTip_This_will_automatically_cast_L}"/>
+
+                </StackPanel>
+            </StackPanel>
+        </controls:SettingsBlock>
+        </StackPanel>
+    </ScrollViewer>
 
 </UserControl>

--- a/Magitek/Views/UserControls/Scholar/Buffs.xaml
+++ b/Magitek/Views/UserControls/Scholar/Buffs.xaml
@@ -33,10 +33,16 @@
         <StackPanel Margin="10">
 
         <controls:SettingsBlock Margin="0,5" Background="{DynamicResource ClassSelectorBackground}">
-            <StackPanel Orientation="Horizontal" Margin="5">
-                <CheckBox Content="{x:Static properties:Resources.Scholar_Content_Deployment_Tactics_Crit_Adlo_When}" IsChecked="{Binding ScholarSettings.DeploymentTactics, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
-                <controls:Numeric MaxValue="30" MinValue="1" Value="{Binding ScholarSettings.DeploymentTacticsAllyInRange, Mode=TwoWay}" />
-                <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Players_Are_In_Range_For_Buff}" />
+            <StackPanel Margin="5">
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <CheckBox Content="{x:Static properties:Resources.Scholar_Content_Deployment_Tactics_Crit_Adlo_When}" IsChecked="{Binding ScholarSettings.DeploymentTactics, Mode=TwoWay}" Style="{DynamicResource CheckBoxFlat}" />
+                    <controls:Numeric MaxValue="30" MinValue="1" Value="{Binding ScholarSettings.DeploymentTacticsAllyInRange, Mode=TwoWay}" />
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Generic_Players_Are_In_Range_For_Buff}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="5">
+                    <TextBlock Style="{DynamicResource TextBlockDefault}" Text="{x:Static properties:Resources.Scholar_Text_Deployment_Tactics_Minimum_Shield_Seconds}" />
+                    <controls:Numeric MaxValue="25" MinValue="0" Value="{Binding ScholarSettings.DeploymentTacticsMinimumShieldSeconds, Mode=TwoWay}" />
+                </StackPanel>
             </StackPanel>
         </controls:SettingsBlock>
 

--- a/MagitekLoader/MagitekLoader.cs
+++ b/MagitekLoader/MagitekLoader.cs
@@ -130,8 +130,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
 #endif
     private static readonly Color LogColor = Colors.CornflowerBlue;
 
-    private static readonly string GreyMagicAssembly = Path.Combine(Environment.CurrentDirectory, @"GreyMagic.dll");
-
     private string _currentDirectory = string.Empty;
     private string _projectAssembly = string.Empty;
     private string _versionPath = string.Empty;
@@ -188,7 +186,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
     private void RedirectAssembly()
     {
         AppDomain.CurrentDomain.AssemblyResolve += Handler;
-        AppDomain.CurrentDomain.AssemblyResolve += GreyMagicHandler;
     }
 
     Assembly? Handler(object sender, ResolveEventArgs args)
@@ -196,12 +193,6 @@ public class CombatRoutineLoader : IAddonProxy<CombatRoutine>
         var name = Assembly.GetEntryAssembly()?.GetName().Name;
         var requestedAssembly = new AssemblyName(args.Name);
         return requestedAssembly.Name != name ? null : Assembly.GetEntryAssembly();
-    }
-
-    Assembly? GreyMagicHandler(object sender, ResolveEventArgs args)
-    {
-        var requestedAssembly = new AssemblyName(args.Name);
-        return requestedAssembly.Name != "GreyMagic" ? null : Assembly.LoadFrom(GreyMagicAssembly);
     }
 
     private static Assembly? LoadAssembly(string path, MagitekLoadContext context)

--- a/MagitekLoader/MagitekLoader.csproj
+++ b/MagitekLoader/MagitekLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <SccProjectName></SccProjectName>
     <SccLocalPath></SccLocalPath>
@@ -33,7 +33,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.803" />
+    <PackageReference Include="RebornBuddy.ReferenceAssemblies" Version="1.0.902" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Supersedes #256, keeping lokibunny's branch history and his Helios Conjunction aura fix as his own commit. Cards: utility cards play on tankbusters or hurt allies and dump before the next draw so a held card can never block the cycle; Balance/Spear align with Divination in both directions. Details in the #256 close comment.