### PR TITLE
SMN - Optimize Searing Light and Energy Drain Aetherflow generation

### DIFF
--- a/Magitek/Logic/Summoner/Aoe.cs
+++ b/Magitek/Logic/Summoner/Aoe.cs
@@ -222,8 +222,10 @@ namespace Magitek.Logic.Summoner
             if (SmnResources.Aetherflow + ArcResources.Aetherflow != 0)
                 return false;
 
-            if (ArcResources.TranceTimer + SmnResources.TranceTimer == 0)
-                return false;
+            //This explicitly forbids the bot from casting Energy Drain unless you are currently in a Bahamut or Phoenix phase. 
+            //If it comes off cooldown during Titan/Ifrit/Garuda, it will sit unused for up to 45 seconds, completely destroying your DPS.
+            //if (ArcResources.TranceTimer + SmnResources.TranceTimer == 0)
+            //    return false;
 
             if (!GlobalCooldown.CanWeave())
                 return false;

--- a/Magitek/Logic/Summoner/Buff.cs
+++ b/Magitek/Logic/Summoner/Buff.cs
@@ -117,9 +117,10 @@ namespace Magitek.Logic.Summoner
 
             if (Core.Me.HasAura(Auras.SearingLight))
                 return false;
-
-            if (Core.Me.SummonedPet() != SmnPets.Carbuncle)
-                return false;
+                
+            //In Shadowbringers, Searing Light was cast by your Carbuncle. In modern FFXIV, it is cast directly by the Summoner.
+            //if (Core.Me.SummonedPet() != SmnPets.Carbuncle)
+            //    return false;
 
             return await Spells.SearingLight.Cast(Core.Me);
         }

--- a/Magitek/Logic/Summoner/Pets.cs
+++ b/Magitek/Logic/Summoner/Pets.cs
@@ -114,18 +114,8 @@ namespace Magitek.Logic.Summoner
                 && Combat.CombatTotalTimeLeft < SummonerSettings.Instance.ThrottleTranceSummonsSeconds)
                 return false;
 
-            if (!SummonerSettings.Instance.SearingLight)
-                return await bahamutSpell.Cast(Core.Me.CurrentTarget);
-
-            if (!Spells.SearingLight.IsReady() && !Core.Me.HasAura(Auras.SearingLight))
-                return await bahamutSpell.Cast(Core.Me.CurrentTarget);
-
-            if (Spells.SearingLight.IsReady() && GlobalCooldown.CanWeave())
-                return await Buff.SearingLight();
-
-            if (!Core.Me.HasAura(Auras.SearingLight))
-                return false;
-
+            // Dawntrail Optimization: Decoupled Searing Light from Bahamut. 
+            // It is now an independent oGCD that should weave naturally without stalling Demi summons.
             return await bahamutSpell.Cast(Core.Me.CurrentTarget);
         }
 

--- a/Magitek/Logic/Summoner/SingleTarget.cs
+++ b/Magitek/Logic/Summoner/SingleTarget.cs
@@ -108,9 +108,11 @@ namespace Magitek.Logic.Summoner
 
             if (SmnResources.Aetherflow + ArcResources.Aetherflow != 0)
                 return false;
-
-            if (ArcResources.TranceTimer + SmnResources.TranceTimer == 0)
-                return false;
+            
+            //This explicitly forbids the bot from casting Energy Drain unless you are currently in a Bahamut or Phoenix phase. 
+            //If it comes off cooldown during Titan/Ifrit/Garuda, it will sit unused for up to 45 seconds, completely destroying your DPS.
+            //if (ArcResources.TranceTimer + SmnResources.TranceTimer == 0)
+            //    return false;
 
             if (!GlobalCooldown.CanWeave())
                 return false;

--- a/Magitek/Rotations/Summoner.cs
+++ b/Magitek/Rotations/Summoner.cs
@@ -70,6 +70,7 @@ namespace Magitek.Rotations
             if (await Aoe.CrimsonStrike()) return true;
             if (await Buff.LucidDreaming()) return true;
             if (await Pets.SummonCarbuncleOrEgi()) return true;
+            if (await Buff.SearingLight()) return true;
             if (await Aoe.EnergySiphon()) return true;
             if (await Aoe.SearingFlash()) return true;
             if (await SingleTarget.EnergyDrain()) return true;


### PR DESCRIPTION
Description
This PR strictly isolates logic improvements for Summoner, focusing on refining the Aetherflow economy and raid buff timing to prevent resource overcapping and cooldown drift.

Key Changes
Searing Light Optimization: Refined weaving logic to ensure Searing Light goes out reliably during the burst window, maximizing raid buff alignment without delaying the GCD.

Energy Drain & Aetherflow Generation: Updated the conditions for casting Energy Drain to ensure Aetherflow stacks are generated efficiently. This prevents accidental overcapping while keeping the cooldown rolling strictly on time.