### PR TITLE
FightLogic - Answer more of the Heavyweight Arcadion raids' mechanics

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7903,12 +7903,7 @@ namespace Magitek.Utilities
                         AoeLockOns = null,
                         Knockbacks = null,
                         SharedTankBusters = null,
-                        BigAoes = new List<uint> {
-                            // Sets every player to 1 HP (the log shows set-HP effects, not damage, which
-                            // is why it reads as zero damage). Shields do nothing against it — the value
-                            // of the response is the heal-back after it lands.
-                            46039, // Charybdistopia
-                        }
+                        BigAoes = null
                     },
                 }
             },

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7842,11 +7842,20 @@ namespace Magitek.Utilities
                             46470, // Alley-oop Inferno
                             46466, // Divers' Dare
                             46472, // Pyrotation
+                            46474, // Hot Aerial — tower soak; the tower damage is unavoidable by design
+                            46478, // Cutback Blaze — marked spread cones, every cast dealt party damage
+                            46497, // Xtreme Spectacular — tag-team multi-hit raidwide chain
+                            47251, // Insane Air — intro cast for the baited-cone rounds
+                            47253, // Insane Air — per-round baited cones, rolling party damage
                         },
                         AoeLockOns = null,
                         Knockbacks = null,
                         SharedTankBusters = null,
-                        BigAoes = null
+                        BigAoes = new List<uint> {
+                            // Fires simultaneously with Deep Blue's Watersnaking; together they cover
+                            // all eight players in one instant with most hits above half a health bar.
+                            46462, // Firesnaking
+                        }
                     },
                     new Enemy {
                         Id = 14369,
@@ -7856,11 +7865,16 @@ namespace Magitek.Utilities
                         },
                         Aoes = new List<uint> {
                             46467, // Divers' Dare
+                            46498, // Xtreme Spectacular — Deep Blue's castbar for the shared chain
+                            47252, // Insane Air — intro cast
+                            47254, // Insane Air — per-round baited cones
                         },
                         AoeLockOns = null,
                         Knockbacks = null,
                         SharedTankBusters = null,
-                        BigAoes = null
+                        BigAoes = new List<uint> {
+                            46463, // Watersnaking — simultaneous half of Firesnaking, same coverage
+                        }
                     },
                 }
             },
@@ -7883,11 +7897,18 @@ namespace Magitek.Utilities
                             46016, // Raw Steel
                             46043, // One and Only
                             46079, // Heartbreak Kick
+                            46024, // Void Stardust — unavoidable spread on every player, comet rain follows
+                            46056, // Flatliner — the damage rides a hidden twin that hits all eight ~6s later
                         },
                         AoeLockOns = null,
                         Knockbacks = null,
                         SharedTankBusters = null,
-                        BigAoes = null
+                        BigAoes = new List<uint> {
+                            // Sets every player to 1 HP (the log shows set-HP effects, not damage, which
+                            // is why it reads as zero damage). Shields do nothing against it — the value
+                            // of the response is the heal-back after it lands.
+                            46039, // Charybdistopia
+                        }
                     },
                 }
             },

--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7927,6 +7927,8 @@ namespace Magitek.Utilities
                             46228, // The Fixer
                             47552, // Splattershed
                             48096, // Splattershed
+                            47549, // Splattershed — third castbar of the same family; its damage hit
+                                   // every living player ~5.5s after the bar starts
                             46208, // Venomous Scourge — marked AoE on every player. Measured 22 hits
                                    // across all eight at up to 62.2% of a health bar, and its damage
                                    // lands 5.0s after the cast, so mitigation applied on the cast is


### PR DESCRIPTION
## What this changes

Fills the response gaps in the Heavyweight Arcadion tier, from measured combat logs of full clears:

**M2 (The X-Ring)** - Red Hot: Hot Aerial (tower soaks, unavoidable distributed damage), Cutback Blaze (marked spreads, damage on every use), Xtreme Spectacular (tag-team multi-hit chain, ~25-30% per player cumulative), Insane Air x2 (baited-cone rounds), and **Firesnaking as a big AoE**; Deep Blue: its simultaneous Xtreme Spectacular and Insane Air castbars, and **Watersnaking as a big AoE** - the snaking pair fires simultaneously, covers all eight players, and most hits exceeded half a health bar.

**M3 (The Crown)** - Void Stardust (unavoidable spread with comet rain following), Flatliner (damage rides a hidden twin that hits all eight ~6s later), and **Charybdistopia as a big AoE** - it sets every player to 1 HP (the log shows set-HP effects rather than damage), so the response's value is the heal-back after it lands.

**M4 (Arcadia)** - Splattershed's third castbar, completing the family already catalogued.

**M1 (Ring Noir)** is deliberately unchanged: every remaining uncatalogued id there measured as a dodge callout, an add kill-check, or a fully-dodged telegraph - party responses would fire for zero or one out-of-position victims.

The big-AoE entries follow the existing list form (Levinwhorl, Omen): big-AoE list only, relying on the null-fallback for everything else.

**Tested:** AST Lv100, all four fights cleared 2026-08-22/23. The additions were derived from those clears' combat logs; the new entries themselves haven't been exercised by a return visit yet.

**Sources:** measured hit counts and percentages from combat logs (figures above); cactbot raidboss triggers corroborate each classification (aoe responses on the snaking pair and the Spectacular chain; hp-to-1 on Charybdistopia).

**Anything removed:** nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
