### PR TITLE
FightLogic - Answer Starflare and the Nemean Lion's twin fulmination in Windurst: The Third Walk

### DIFF
--- a/Magitek/Utilities/FightLogicEncounters.cs
+++ b/Magitek/Utilities/FightLogicEncounters.cs
@@ -7397,6 +7397,8 @@ namespace Magitek.Utilities
                         Aoes = new List<uint> {
                             49179, // Empty Proclamation
                             49182, // Super Nova
+                            49174, // Starflare — same structure as Shinryu's catalogued Starflare: the
+                                   // bar is the parent cast and the hits ride hidden twins ~8-10s later
                             // Celestial Trail family 49139-49144/49147: only 49140 has a castbar
                             // (7.7s, from HP-44 helper copies sharing the boss's NpcId); the rest are
                             // echoes and damage ids — do not catalogue them. Needs the
@@ -7426,7 +7428,9 @@ namespace Magitek.Utilities
                         TankBusters = null,
                         SharedTankBusters = null,
                         Aoes = new List<uint> {
-                            50092,
+                            50092, // Fulmination Khalkeos
+                            50093, // Fulmination Khryseos — twin of Khalkeos with identical arena-wide
+                                   // geometry; seen in earlier sessions but not yet hit-confirmed
                         },
                         BigAoes = null,
                         Knockbacks = null,


### PR DESCRIPTION
## What this changes

Two additive raidwide entries for Windurst: The Third Walk:

- **Starflare** under the Hollow King - same structure as the already-catalogued Shinryu Starflare in this zone: the visible bar is a parent cast and the hits ride hidden twins ~8-10s later (max 78% of a health bar observed).
- **Fulmination Khryseos** under the Nemean Lion - twin of the catalogued Fulmination Khalkeos with identical arena-wide geometry.

## Honest caveats

Khryseos was not cast in the runs reviewed - the classification rests on its geometry being identical to the catalogued sibling (which cactbot answers with a plain raidwide response). Starflare's classification leans on the same-zone Shinryu precedent; its raw hit pattern alone could read as a dodgeable spread. Both entries are additive AoE responses, so the cost of either being conservative-wrong is a spare mitigation, not a lost one.

**Tested:** two full runs (AST and DRK) on my test build 2026-08-23; neither mechanic happened to be cast in the post-addition run, so the entries are unexercised live.

**Sources:** combat logs from those runs; cactbot windurst data for the sibling and marker semantics.

**Anything removed:** nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
