### PR TITLE
FightLogic - Attack Hellmakers during the Meso Terminal cell phase

### DIFF
--- a/Magitek/Utilities/ImmunityEncounters.cs
+++ b/Magitek/Utilities/ImmunityEncounters.cs
@@ -139,8 +139,16 @@ namespace Magitek.Utilities
                 Name = "The Meso Terminal (Headsman mark mechanic)",
                 Expansion = FfxivExpansion.Dawntrail,
                 // While marked, a player can ONLY damage the Headsman whose Guard on Duty letter matches
-                // their Cell Block — "Attacks against other targets are nullified."
-                MarkMatch = MarkMatchDamageableEnemyAura
+                // their Cell Block — "Attacks against other targets are nullified." Hellmakers can spawn
+                // during the same cell phase without a Guard on Duty status and must still be attacked, so
+                // the mark rule is deliberately scoped to the four marked Headsmen rather than the zone.
+                MarkMatch = MarkMatchDamageableEnemyAura,
+                MarkMatchEnemies = new HashSet<string> {
+                    "Ravenous Headsman",
+                    "Bloody Headsman",
+                    "Pale Headsman",
+                    "Pestilent Headsman",
+                }
             },
 
             #endregion

--- a/Magitek/Utilities/ImmunityEncounters.cs
+++ b/Magitek/Utilities/ImmunityEncounters.cs
@@ -97,6 +97,16 @@ namespace Magitek.Utilities
             GuardOnDutyGamma = 4548,
             GuardOnDutyDelta = 4549;
 
+        // RebornBuddy exposes these BNpc name-row identifiers through GameObject.NpcId. Unlike display
+        // names they are stable across client languages, and the untargetable helper actors used by the
+        // Headsmen's cell attacks retain their owner's id, so the same mark restriction still covers the
+        // entire mechanic without accidentally including Hellmakers.
+        public const uint
+            BloodyHeadsmanNpcId = 14047,
+            RavenousHeadsmanNpcId = 14048,
+            PaleHeadsmanNpcId = 14049,
+            PestilentHeadsmanNpcId = 14050;
+
         /// <summary>Our Cell Block mark -> the Guard on Duty status an enemy needs to take our damage.</summary>
         public static readonly Dictionary<uint, uint> MarkMatchDamageableEnemyAura = new Dictionary<uint, uint>
         {
@@ -143,11 +153,11 @@ namespace Magitek.Utilities
                 // during the same cell phase without a Guard on Duty status and must still be attacked, so
                 // the mark rule is deliberately scoped to the four marked Headsmen rather than the zone.
                 MarkMatch = MarkMatchDamageableEnemyAura,
-                MarkMatchEnemies = new HashSet<string> {
-                    "Ravenous Headsman",
-                    "Bloody Headsman",
-                    "Pale Headsman",
-                    "Pestilent Headsman",
+                MarkMatchEnemyIds = new HashSet<uint> {
+                    BloodyHeadsmanNpcId,
+                    RavenousHeadsmanNpcId,
+                    PaleHeadsmanNpcId,
+                    PestilentHeadsmanNpcId,
                 }
             },
 

--- a/Magitek/Utilities/ImmunityLogic.cs
+++ b/Magitek/Utilities/ImmunityLogic.cs
@@ -58,7 +58,9 @@ namespace Magitek.Utilities
                 && !me.HasAura(requiredSelfAura))
                 return false;
 
-            if (encounter.MarkMatch != null && !DamageableByMyMark(unit, me, encounter.MarkMatch))
+            if (encounter.MarkMatch != null
+                && (encounter.MarkMatchEnemies == null || encounter.MarkMatchEnemies.Contains(name))
+                && !DamageableByMyMark(unit, me, encounter.MarkMatch))
                 return false;
 
             return true;
@@ -203,5 +205,12 @@ namespace Magitek.Utilities
 
         /// <summary>Our mark -> the aura an enemy must carry to take our damage while we are marked.</summary>
         internal Dictionary<uint, uint> MarkMatch { get; set; }
+
+        /// <summary>
+        /// Exact English enemy names that participate in <see cref="MarkMatch"/>. A zone can contain
+        /// ordinary adds while the player remains marked; leaving those adds outside this set prevents
+        /// the encounter rule from incorrectly suppressing otherwise valid attacks against them.
+        /// </summary>
+        internal HashSet<string> MarkMatchEnemies { get; set; }
     }
 }

--- a/Magitek/Utilities/ImmunityLogic.cs
+++ b/Magitek/Utilities/ImmunityLogic.cs
@@ -59,7 +59,7 @@ namespace Magitek.Utilities
                 return false;
 
             if (encounter.MarkMatch != null
-                && (encounter.MarkMatchEnemies == null || encounter.MarkMatchEnemies.Contains(name))
+                && (encounter.MarkMatchEnemyIds == null || encounter.MarkMatchEnemyIds.Contains(unit.NpcId))
                 && !DamageableByMyMark(unit, me, encounter.MarkMatch))
                 return false;
 
@@ -207,10 +207,11 @@ namespace Magitek.Utilities
         internal Dictionary<uint, uint> MarkMatch { get; set; }
 
         /// <summary>
-        /// Exact English enemy names that participate in <see cref="MarkMatch"/>. A zone can contain
-        /// ordinary adds while the player remains marked; leaving those adds outside this set prevents
-        /// the encounter rule from incorrectly suppressing otherwise valid attacks against them.
+        /// Stable RebornBuddy <see cref="GameObject.NpcId"/> values that participate in
+        /// <see cref="MarkMatch"/>. A zone can contain ordinary adds while the player remains marked;
+        /// leaving those adds outside this set prevents the encounter rule from incorrectly suppressing
+        /// otherwise valid attacks against them. A null set retains the original zone-wide behavior.
         /// </summary>
-        internal HashSet<string> MarkMatchEnemies { get; set; }
+        internal HashSet<uint> MarkMatchEnemyIds { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

- Scope the Meso Terminal Cell Block / Guard on Duty match rule to the four marked Headsmen.
- Leave ordinary adds such as Hellmaker attackable while the player still carries a Cell Block status.
- Preserve the existing zone-wide behavior for any mark-matching encounter that does not provide an enemy-name scope.

## Tested

- RDM Lv100 in The Meso Terminal with Duty Support, using a locally built Magitek v1.0.296 test assembly.
- Before the change, OrderBot selected Hellmaker as the kill target, but Magitek rejected it as undamageable despite valid range, line of sight, and cast checks.
- After the change, OrderBot selected Hellmaker and Magitek successfully cast Scorch, Resolution, Verfire, and Verthunder until it died.
- `dotnet build Magitek\Magitek.sln --configuration Release` completed with 0 errors. Existing repository warnings remain unchanged.

## Sources

- First-hand in-game observation and RebornBuddy logs from 2026-08-24. The four Headsmen carried Guard on Duty statuses matching the player's Cell Block status; Hellmaker carried no Guard on Duty status and accepted normal player damage.

## Removed or narrowed behavior

- No existing guards or comments were removed. The Meso Terminal mark check is narrowed from every enemy in the zone to the four Headsmen that actually participate in the matching-letter mechanic.
