### PR TITLE
OC - Phantom Mystic Knight now casts Holy Spellblade instead of repeating Blazing Spellblade

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -55,6 +55,13 @@ namespace Magitek.Logic.Roles
             Mesmerized = 4802,
             MagicShell = 4788,
             HonedSpellblade = 4789,
+            // Blazing Spellblade applies BOTH halves of a pair from a single cast, 70s each:
+            // 4790 lands on us (+5% damage dealt), 4791 on the enemy (+5% damage taken). The
+            // English names are no guide to which is which - Japanese marks the harmful half
+            // with ［害］ (まほうけんフレア vs まほうけんフレア［害］) and the client's ReactionFlag
+            // reads 1 for 4790 against 2 for 4791. Do not swap these.
+            BlazingSpellblade = 4790,
+            BlazingBane = 4791,
             FinishingFervor = 4793,
             Defend = 4792,
             // Elemental weaknesses revealed on an enemy by Occult Libra (North Horn). A matching
@@ -3639,8 +3646,20 @@ namespace Magitek.Logic.Roles
             if (!target.WithinSpellRange(OCSpells.BlazingSpellblade.Range))
                 return false;
 
-            // Don't recast if target already has Vulnerability Up (70s duration)
-            if (target.HasAura(Auras.VulnerabilityUp))
+            // Re-cast if EITHER half of the pair is missing. A freshly pulled enemy has no
+            // Blazing Bane even while our own Blazing Spellblade is still running, and another
+            // Mystic Knight's Bane on the target does nothing for our personal damage buff.
+            //
+            // All three Spellblades share one 30s recast, so cast windows land at 0/30/60/90
+            // while the pair expires at 70 - waiting for a clean expiry leaves a 20s hole. At
+            // the third window the pair has exactly 10s left, and msLeft compares with >=, so
+            // the threshold has to clear 10s to catch it. Half a shared window does that with
+            // room for the real cadence drifting late, and spends every other window on Blazing
+            // while the rest go to Holy Spellblade, which is the bigger hit.
+            const int refreshMs = 15000;
+
+            if (Core.Me.HasAura(OCAuras.BlazingSpellblade, msLeft: refreshMs)
+                && target.HasAura(OCAuras.BlazingBane, msLeft: refreshMs))
                 return false;
 
             return await OCSpells.BlazingSpellblade.Cast(target);


### PR DESCRIPTION
## What this changes

Phantom Mystic Knight now alternates Blazing Spellblade and Holy
Spellblade instead of casting Blazing every time. Blazing's pair of
buffs is kept at full uptime, and the windows it doesn't need go to Holy
Spellblade, which hits for 300 (500 against undead) rather than 200.

## Why

Sundering, Holy and Blazing Spellblade all share one 30s recast, so the
priority list decides which of the three ever fires. Blazing sits at the
top of that list, gated by a "don't reapply while the debuff is up"
check - except the check watched Vulnerability Up, the generic
raid-mechanic debuff, which Blazing does not apply. It never matched, so
Blazing took every window and Holy Spellblade never cast at all.

The guard could also fail the other way: HasAura defaults to matching
any caster, so an unrelated Vulnerability Up landing on the target would
have suppressed Blazing for a reason unconnected to it.

**Tested:** Phantom Mystic Knight in Occult Crescent.

**Sources:**

- https://ffxiv.consolegameswiki.com/wiki/Phantom_Mystic_Knight -
Sundering, Holy and Blazing Spellblade each state they share a recast
timer with the other two. Blazing's buffs run 70s against that 30s
recast.
- Status ids read off the live client. Blazing Spellblade applies both
halves of a pair from one cast: 4790 "Blazing Spellblade" is the +5%
damage dealt buff on the caster, 4791 "Blazing Bane" the +5% damage
taken debuff on the enemy. The English names are no guide to which is
which - Japanese marks the harmful half ［害］ (まほうけんフレア vs
まほうけんフレア［害］) and the client's ReactionFlag reads 1 against 2.
ReactionFlag was checked against 14 known buffs and
debuffs first (Vulnerability Up, Paralysis, Stun, Petrification, Slow,
Occult Toad, Magic Shell, Honed Spellblade, Occult Blink, Smoke, Occult
Mighty Guard, Rampart, Battle Litany) and matched every one.

**Anything removed:** the `target.HasAura(Auras.VulnerabilityUp)` guard,
replaced by a check on both real auras. It is deliberately an OR - cast
if either half is missing - so a freshly pulled enemy gets the debuff
even while our own buff is still running, and a second Mystic Knight's
debuff on the target can't leave us without our personal damage buff.
The 15s refresh threshold clears the 10s the pair has left at the third
30s window, which is what keeps uptime at 100%; msLeft compares with >=,
so 10s exactly would have skipped and left a 20s hole.

Known consequence: on trash where targets change faster than the 30s
recast, each new enemy's missing debuff means Blazing takes most windows
and Holy rarely fires.
