### PR TITLE
Occult Crescent - Chemist items no longer interrupt Machinist overheat windows

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -2048,6 +2048,14 @@ namespace Magitek.Logic.Roles
             if (potionTarget == null)
                 return false;
 
+            // An item cast carries a ~2s animation lock: fired inside Machinist's overheat
+            // it locks out a Heat Blast (measured as recurring ~4.4s dead space right after
+            // Hypercharge). Overheat lasts 10s at most, so unless the target is in real
+            // danger - below half the configured threshold - the potion waits the window out.
+            if (Core.Me.HasAura(Auras.Overheated)
+                && potionTarget.CurrentHealthPercent > OccultCrescentSettings.Instance.OccultPotionHealthPercent / 2)
+                return false;
+
             return await OCSpells.OccultPotion.Cast(potionTarget);
         }
 
@@ -2088,6 +2096,11 @@ namespace Magitek.Logic.Roles
             }
 
             if (etherTarget == null)
+                return false;
+
+            // Same item animation lock as Occult Potion: never worth a Heat Blast, and
+            // nobody is in danger from low MP for the few seconds overheat lasts.
+            if (Core.Me.HasAura(Auras.Overheated))
                 return false;
 
             return await OCSpells.OccultEther.Cast(etherTarget);
@@ -2165,6 +2178,22 @@ namespace Magitek.Logic.Roles
             // Only cast if multiple people need help (justify the 300k cost)
             if (partyMembersNeedingHelp < 2)
                 return false;
+
+            // Same item animation lock as Occult Potion, and the trigger above counts low
+            // MP as "needing help" - two casters dipping mana must not break a Machinist
+            // overheat. During overheat only a real HP emergency (two allies below half
+            // the configured threshold) justifies it; Revive is deliberately NOT gated
+            // anywhere in this kit - a raise always outranks a burst window.
+            if (Core.Me.HasAura(Auras.Overheated))
+            {
+                var hpEmergencies = Group.CastableAlliesWithin30.Count(ally =>
+                    ally.IsValid && ally.IsAlive
+                    && ally.CurrentHealthPercent <= OccultCrescentSettings.Instance.OccultElixirPartyHealthPercent / 2)
+                    + (Core.Me.CurrentHealthPercent <= OccultCrescentSettings.Instance.OccultElixirPartyHealthPercent / 2 ? 1 : 0);
+
+                if (hpEmergencies < 2)
+                    return false;
+            }
 
             return await OCSpells.OccultElixir.Cast(Core.Me);
         }


### PR DESCRIPTION
One commit, Chemist block of the Occult Crescent role logic. Covers the complete Chemist kit.

## What changed

Occult Potion and Occult Ether are item-type casts with a ~2s animation lock. Fired inside Machinist's overheat they lock out a Heat Blast — measured as a recurring 4.4s dead space right after Hypercharge (four occurrences in one tower run, every one with the potion at HC+1.6–1.9s). Overheat lasts 10 seconds at most, so:

- **Occult Potion** now waits out overheat unless the intended target is in real danger — below **half** the user's configured threshold (scales with their setting; no new knob).
- **Occult Ether** waits unconditionally during overheat — nobody is in danger from low MP for a few seconds.
- **Occult Elixir** (party restore) has the same item lock, and its trigger counts low MP as "needing help" — two casters dipping mana must not break a burst. During overheat it requires a real HP emergency: two or more allies below half its configured threshold.
- **Revive is deliberately NOT gated** — a raise always outranks a burst window. That completes the kit: all four Chemist actions considered, three gated, one excluded on purpose.

No heals are suppressed, only relocated: the validation run fired 12 Occult Potions, every one landing 8+ seconds clear of any Hypercharge, and the post-fix census showed 0/33 overheat windows with a stall (the potion collisions were the last remaining source).

## Tested

MCH Lv100 with Phantom Chemist, Forked Tower: Magic + North Horn CEs, 2026-08-24. Before/after ACT censuses (stall detection keyed on Hypercharge-to-first-blast delay; potion placement measured against every Hypercharge timestamp). The Potion and Ether gates are what those runs validated; the Elixir gate is the same guard shape extended to the same defect class but was added after the runs — **not separately tested in game** (Elixir never fired during the test windows).

## Removals

None — two added guards, no existing conditions touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
