### PR TITLE
Core - Phoenix Down no longer spams while moving, and is skipped on jobs that can raise - OC - Phantom White Mage can now revive party members, and phantom healers no longer revive ahead of healing the living

### DIFF
--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -893,16 +893,19 @@ namespace Magitek.Logic.Roles
         /// <returns>True if an action was executed, false otherwise</returns>
         private static async Task<bool> ExecuteChemistPhantomJob()
         {
-            // Revive - resurrect dead party members first
-            if (await Revive())
-                return true;
-
             // OccultElixir - party-wide HP/MP restoration (most expensive)
             if (await OccultElixir())
                 return true;
 
             // OccultPotion - HP restoration (expensive)
             if (await OccultPotion())
+                return true;
+
+            // Revive - resurrect dead party members, below the heals that keep the living alive and
+            // above the MP top-up that does not. Revive used to run first, which meant stopping to
+            // pick someone up off the floor while a party member on the edge died waiting. Same order
+            // as Phantom White Mage's Occult Raise.
+            if (await Revive())
                 return true;
 
             // OccultEther - MP restoration

--- a/Magitek/Logic/Roles/OccultCrescent.cs
+++ b/Magitek/Logic/Roles/OccultCrescent.cs
@@ -4295,11 +4295,65 @@ namespace Magitek.Logic.Roles
             if (await WhiteMageOccultCureII())
                 return true;
 
+            // Occult Raise - below the mitigation and the heals, above the damage. Someone already on
+            // the floor can wait the couple of seconds it takes to finish a cure; someone about to join
+            // them cannot. Instant cast, so being outranked here costs a pulse, not a cast.
+            if (await OccultRaise())
+                return true;
+
             // Occult Holy - 60s recast, the job's only damage
             if (await OccultHoly())
                 return true;
 
             return false;
+        }
+
+        /// <summary>
+        /// Cast Occult Raise - resurrects a dead party member
+        /// Instant cast, so no swiftcast handling, and it uniquely works on targets flagged
+        /// Resurrection Restricted
+        /// </summary>
+        /// <returns>True if spell was cast, false otherwise</returns>
+        private static async Task<bool> OccultRaise()
+        {
+            if (!OccultCrescentSettings.Instance.UseOccultRaise)
+                return false;
+
+            // Occult Raise already had a call site in ExecuteNonPartyResurrection(), which works off
+            // the alliance list. This is the party-side path it was missing, so a Phantom White Mage
+            // now picks up their own party members and Trust NPCs rather than only strangers.
+            //
+            // Find dead allies using the same logic as Healer.Raise — including the raw 3D
+            // distance, which is deliberate there and must stay deliberate here. It is the
+            // exception to the "always use WithinSpellRange" rule in AGENTS.md: a corpse has
+            // no usable CombatReach, so raise range is centre to centre, and WithinSpellRange
+            // uses Distance2D so it would ignore height entirely. Leave this as Distance.
+            var deadList = Group.DeadAllies.Where(u => u.CurrentHealth == 0 &&
+                                                       !u.HasAura(Auras.Raise) &&
+                                                       u.Distance(Core.Me) <= 30 &&
+                                                       u.IsVisible &&
+                                                       u.InLineOfSight() &&
+                                                       u.IsTargetable &&
+                                                       Group.GetDeathTime(u)?.AddSeconds(OccultCrescentSettings.Instance.OccultRaiseDelay) <= DateTime.Now)
+                .OrderByDescending(r => r.GetResurrectionWeight());
+
+            var deadTarget = deadList.FirstOrDefault();
+
+            if (deadTarget == null)
+                return false;
+
+            if (!deadTarget.IsTargetable)
+                return false;
+
+            if (!OCSpells.OccultRaise.CanCast(deadTarget))
+                return false;
+
+            // Check combat restrictions - only check out of combat restriction
+            if (!Core.Me.InCombat && !OccultCrescentSettings.Instance.OccultRaiseOutOfCombat)
+                return false;
+
+            // Occult Raise is instant - no swiftcast needed
+            return await OCSpells.OccultRaise.CastAura(deadTarget, Auras.Raise);
         }
         #endregion
 

--- a/Magitek/Logic/Roles/PhoenixDown.cs
+++ b/Magitek/Logic/Roles/PhoenixDown.cs
@@ -1,10 +1,14 @@
 using Buddy.Coroutines;
 using ff14bot;
+using ff14bot.Enums;
 using ff14bot.Managers;
+using ff14bot.Objects;
 using Magitek.Extensions;
 using Magitek.Models.Account;
 using Magitek.Utilities;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Auras = Magitek.Utilities.Auras;
@@ -19,6 +23,32 @@ namespace Magitek.Logic.Roles
         private const uint PhoenixDownItemId = 4570;
         private const float PhoenixDownRange = 15f; // Phoenix Down reaches ~15 yalms.
 
+        // Minimum gap between our own attempts. Deliberately not a setting: this is an anti-spam floor
+        // on retries, not a tuning knob for when to revive — PhoenixDownDelaySeconds already owns that
+        // decision. It also sits well under the item's own 360s recast, so it can never delay a use the
+        // game would otherwise have permitted.
+        private const int RetryIntervalMs = 10000;
+
+        // Never started until the first attempt, so a fresh Stopwatch reads as "no attempt yet".
+        private static readonly Stopwatch RetryTimer = new Stopwatch();
+
+        // Each job's own raise, base classes included, since a Conjurer or Arcanist can be in a
+        // low-level duty before unlocking their job stone. Blue Mage's Angel Whisper is here too: it
+        // only reports known while it is actually on the active spell set, which is the condition that
+        // matters anyway.
+        private static readonly Dictionary<ClassJobType, SpellData> RaiseByJob = new Dictionary<ClassJobType, SpellData>
+        {
+            { ClassJobType.Conjurer,    Spells.Raise },
+            { ClassJobType.WhiteMage,   Spells.Raise },
+            { ClassJobType.Arcanist,    Spells.Resurrection },
+            { ClassJobType.Scholar,     Spells.Resurrection },
+            { ClassJobType.Summoner,    Spells.Resurrection },
+            { ClassJobType.Astrologian, Spells.Ascend },
+            { ClassJobType.Sage,        Spells.Egeiro },
+            { ClassJobType.RedMage,     Spells.Verraise },
+            { ClassJobType.BlueMage,    Spells.AngelWhisper }
+        };
+
         public static async Task<bool> Execute()
         {
             if (!BaseSettings.Instance.UsePhoenixDown)
@@ -31,6 +61,27 @@ namespace Magitek.Logic.Roles
             // pulse ends right here. Only .Count is this cheap — running the full corpse predicate
             // first would read eight properties per body and cost more than it saves.
             if (Group.DeadAllies.Count == 0)
+                return false;
+
+            // Phoenix Down is an 8 second hardcast, so a moving character cannot land one — UseItem
+            // refuses outright, and on the pulses where it doesn't, the cast dies to the first step
+            // taken. Bail before spending an attempt on it rather than after. This costs nothing while
+            // standing still, and deliberately does not touch the retry clock below: walking past a body
+            // should not put the next real attempt 10 seconds out, so the first pulse after coming to a
+            // stop is free to try.
+            if (MovementManager.IsMoving)
+                return false;
+
+            // Rate-limit the attempt, not the success. Every step below this can fail without consuming
+            // an item or starting the item's own recast — UseItem refuses outright while moving, and a
+            // cast that does start dies to the next movement step — and with nothing recording that we
+            // tried, the following pulse simply tries again. That turns one unreachable body into an
+            // attempt, and a log line, every pulse for as long as it is on the floor.
+            if (RetryTimer.IsRunning && RetryTimer.ElapsedMilliseconds < RetryIntervalMs)
+                return false;
+
+            // Anyone who can raise under their own power has no business spending a consumable on it.
+            if (HasOwnRaise())
                 return false;
 
             // Instanced content only (dungeons/trials/deep dungeons/field ops/etc.). The game's own
@@ -85,6 +136,10 @@ namespace Magitek.Logic.Roles
             if (target == null)
                 return false;
 
+            // From here we are committing to an attempt, so start the retry clock before making it
+            // rather than after it succeeds — a failure is precisely the case that would repeat.
+            RetryTimer.Restart();
+
             // One targeted use per pulse. NOT the shared UseItem() extension: it loops UseItem() with no
             // target and no inter-use delay, which would fire on the wrong unit and re-fire every frame
             // until the revive lands (burning multiple Phoenix Downs).
@@ -124,6 +179,41 @@ namespace Magitek.Logic.Roles
             Casting.CastingTime.Restart();
 
             return true;
+        }
+
+        // True when this character can raise under its own power, and so should leave the Phoenix Downs
+        // in the bag.
+        //
+        // Gated on the raise being known rather than on job identity, because the two come apart under
+        // level sync: Verraise is Lv64, so a Red Mage synced into level 50 content has no raise at all,
+        // and counting them as a raiser there would leave the body on the floor for nothing.
+        //
+        // IsKnown, not IsKnownAndReady — a raise sitting on cooldown, or waiting on Swiftcast or MP, is
+        // a reason to wait for it, not a reason to burn a consumable.
+        private static bool HasOwnRaise()
+        {
+            if (RaiseByJob.TryGetValue(Core.Me.CurrentJob, out var raise) && raise.IsKnown())
+                return true;
+
+            // Occult Crescent's phantom raises belong to the phantom job rather than the base job, so
+            // any job at all can be carrying one. Checked second so a dictionary miss is all most
+            // characters pay, and behind the zone test so nobody outside the Crescent walks the
+            // phantom-job aura list. OccultCrescent.Execute() already runs ahead of PhoenixDown in the
+            // Heal pulse, so these two get first refusal on the body regardless of what we answer here.
+            if (!OccultCrescent.IsInOccultCrescent())
+                return false;
+
+            switch (OccultCrescent.GetCurrentPhantomJob())
+            {
+                case OccultCrescent.PhantomJob.Chemist:
+                    return OCSpells.Revive.IsKnown();
+
+                case OccultCrescent.PhantomJob.WhiteMage:
+                    return OCSpells.OccultRaise.IsKnown();
+
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
+++ b/Magitek/Models/OccultCrescent/OccultCrescentSettings.cs
@@ -664,6 +664,18 @@ namespace Magitek.Models.OccultCrescent
         [Setting]
         [DefaultValue(true)]
         public bool UseOccultHoly { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool UseOccultRaise { get; set; }
+
+        [Setting]
+        [DefaultValue(true)]
+        public bool OccultRaiseOutOfCombat { get; set; }
+
+        [Setting]
+        [DefaultValue(3.0f)]
+        public float OccultRaiseDelay { get; set; }
         #endregion
 
         #region Phantom Ninja

--- a/Magitek/Properties/Resources.Designer.cs
+++ b/Magitek/Properties/Resources.Designer.cs
@@ -9001,7 +9001,16 @@ namespace Magitek.Properties {
                 return ResourceManager.GetString("OccultCrescent_Content_Use_Occult_Quick_Speed_buff", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use Occult Raise (Resurrect dead party members).
+        /// </summary>
+        public static string OccultCrescent_Content_Use_Occult_Raise {
+            get {
+                return ResourceManager.GetString("OccultCrescent_Content_Use_Occult_Raise", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use Occult Slowga (Inflicts Slow on enemies).
         /// </summary>

--- a/Magitek/Properties/Resources.resx
+++ b/Magitek/Properties/Resources.resx
@@ -2096,6 +2096,9 @@ Does not work if Lightspeed is disabled.</value>
   <data name="OccultCrescent_Content_Use_Occult_Holy" xml:space="preserve">
     <value>Use Occult Holy</value>
   </data>
+  <data name="OccultCrescent_Content_Use_Occult_Raise" xml:space="preserve">
+    <value>Use Occult Raise (Resurrect dead party members)</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Occult_Blink" xml:space="preserve">
     <value>Use Occult Blink (nullifies one magic attack)</value>
   </data>

--- a/Magitek/Properties/Resources.zh-CN.resx
+++ b/Magitek/Properties/Resources.zh-CN.resx
@@ -2097,6 +2097,9 @@
   <data name="OccultCrescent_Content_Use_Occult_Holy" xml:space="preserve">
     <value>使用 魔神圣</value>
   </data>
+  <data name="OccultCrescent_Content_Use_Occult_Raise" xml:space="preserve">
+    <value>使用 魔复活 (复活死亡的小队成员)</value>
+  </data>
   <data name="OccultCrescent_Content_Use_Occult_Blink" xml:space="preserve">
     <value>使用 魔分身 (无效化一次魔法攻击)</value>
   </data>

--- a/Magitek/Views/UserControls/OccultCrescent/General.xaml
+++ b/Magitek/Views/UserControls/OccultCrescent/General.xaml
@@ -1362,6 +1362,28 @@
                                                           IsChecked="{Binding UseOccultHoly, Mode=TwoWay}"
                                                           Style="{DynamicResource CheckBoxFlat}"/>
                                         </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Use_Occult_Raise}"
+                                                          IsChecked="{Binding UseOccultRaise, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"/>
+                                                <CheckBox Content="{x:Static properties:Resources.OccultCrescent_Content_Revive_Out_of_Combat}"
+                                                          IsChecked="{Binding OccultRaiseOutOfCombat, Mode=TwoWay}"
+                                                          Style="{DynamicResource CheckBoxFlat}"
+                                                          Margin="20,0,0,0"/>
+                                        </StackPanel>
+
+                                        <StackPanel Margin="5"
+                                                    Orientation="Horizontal">
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Resurrection_Delay}"/>
+                                                <controls:Numeric MinValue="0"
+                                                                  MaxValue="10"
+                                                                  Value="{Binding OccultRaiseDelay, Mode=TwoWay}"/>
+                                                <TextBlock Style="{DynamicResource TextBlockDefault}"
+                                                           Text="{x:Static properties:Resources.Generic_Seconds}"/>
+                                        </StackPanel>
                                 </StackPanel>
                         </controls:SettingsBlock>
 


### PR DESCRIPTION
Two fixes to the Phoenix Down fallback revive. Kept in one PR because they are both
corrections to the same new feature and touch the same file; happy to split if you'd
rather review them separately.

**1. Anti-spam.** The only re-fire guard was the `Casting` registration at the *end* of
`Execute()`, which only exists once a cast bar is confirmed. Every path that returns
`false` before that — `UseItem` refusing while moving, or a started cast dying to the
movement step — left no state behind, so the next pulse re-entered at full speed. The
`Logger.WriteInfo` line also sat above `UseItem`, so it printed on attempts that never
happened.

- `RetryIntervalMs = 10000`, clocked from the point we commit to an attempt (above the
  log line and above `UseItem`), so failures are rate-limited the same as successes.
- `MovementManager.IsMoving` bail above the retry clock. It deliberately does **not**
  restart the clock: walking past a body should not push the next real attempt 10s out,
  so the first pulse after coming to a stop is free to try.
- Hardcoded const rather than a fourth setting — it is an anti-spam floor on our own
  retries, not a tuning knob for when to revive, and `PhoenixDownDelaySeconds` already
  owns that decision. Easy to promote if you want it exposed.

**2. Raise gate.** `HasOwnRaise()` — never spend a consumable on a body we can raise for
free. Keyed on the raise being `IsKnown()` rather than on job identity, because the two
come apart under level sync. Covers CNJ/WHM, ACN/SCH/SMN, AST, SGE, RDM, BLU, plus
Occult Crescent's Phantom Chemist (Revive) and Phantom White Mage (Occult Raise), which
belong to the phantom job rather than the base job.

`IsKnown()`, not `IsKnownAndReady()` — a raise on cooldown or waiting on Swiftcast/MP is
a reason to wait for it, not a reason to burn a consumable. `OccultCrescent.Execute()`
already runs ahead of `PhoenixDown` in the Heal pulse, so the phantom raises get first
refusal on the body regardless.

**Tested:** Not tested in game. Builds clean (0 errors; all 63 warnings pre-existing).

**Sources:** facts below read off the running client via `DataManager` / `ActionManager`,
not from datamining CSVs:

- Raise 125, Resurrection 173, Ascend 3603, Egeiro 24287 — all `LevelAcquired` 12.
  Verraise 7523 — `LevelAcquired` **64**. That gap is why the gate keys on `IsKnown()`:
  a Red Mage synced into level 50 content has no raise at all, and blocking them there
  would leave the body on the floor for nothing.
- `ActionManager.HasSpell` is job-aware — on AST, only Ascend returned `true` across all
  six raise IDs.
- Phoenix Down (4570) `BackingAction`: `Range` 15, `AdjustedCooldown` 360000. The 10s
  retry floor is 1/36th of the item's own recast, so it can never gate a use the game
  would have allowed.

**Removals:** none. No existing guard, condition, or comment was deleted or reworded.

**Known consequence:** for autonomous-bot users, `Movement.NavigateToUnitLos` in the
Combat pulse means the character can be moving a lot, so the revive now lands on the
first standstill rather than being attempted continuously. Not a regression — the 8s
cast could not have landed while moving — but worth knowing.

**Not addressed:** the root cause of the original report. Magitek's own movement step
walking away mid-cast is what the `Casting` registration block was written to prevent,
and it is evidently not holding. Separate change.

Co-Authored-By: Claude <noreply@anthropic.com>


---

## Second commit — `OC - Phantom White Mage now uses Occult Raise on dead party members`

Fallout from the raise gate above. Gating Phoenix Down on Phantom White Mage stranded
bodies, because `ExecuteWhiteMagePhantomJob()` had no raise call at all — `OCSpells.OccultRaise`'s
only call site was in `ExecuteNonPartyResurrection()`, which reads the alliance list rather than
`Group.DeadAllies`. A Phantom White Mage would pick up passing strangers and walk past their own
party members and Trust NPCs. Base job DRK plus Phantom WHM meant nothing could raise at all.

This was a deliberate scoping call when Phantom White Mage landed, not an oversight — the
non-party path was the only one implemented. Adds the party-side path.

`OccultRaise()` mirrors Phantom Chemist's `Revive()`: same `Group.DeadAllies` filter, same raw
3D `Distance` (the AGENTS.md raise-range exception, comment preserved), same
`GetResurrectionWeight()` ordering, same out-of-combat check, same `CastAura(target, Auras.Raise)`.
Instant cast, so no Swiftcast handling.

**Priority:** Occult Blink → Cure III → Cure II → **Occult Raise** → Occult Holy. Below the
mitigation and the heals, above the damage — someone already on the floor can wait out a cure,
someone about to join them cannot. Note this is deliberately *not* where Phantom Chemist puts
`Revive()`, which runs first; that ordering is arguably wrong for the same reason, but it is
existing behavior and out of scope here.

Three new settings, matching Chemist's trio rather than reusing them (Chemist's live under the
Phantom Chemist UI block, where a White Mage user would never find them): `UseOccultRaise` (true),
`OccultRaiseOutOfCombat` (true), `OccultRaiseDelay` (3.0s). Full treatment — property, XAML,
`Resources.resx`, `Resources.zh-CN.resx`, plus the manual `Resources.Designer.cs` property in
alphabetical position since that file only regenerates inside Visual Studio. One new string; the
rest reuse existing keys.

The non-party call site is untouched — both paths coexist.

**Tested:** Not tested in game. Needs a Phantom White Mage at phantom level 4+ in the Crescent
with a dead party member. Clean rebuild: 0 errors, 63 warnings, unchanged from master.

**Sources:** Occult Raise 49070 — phantom level 4, 30y, instant, ~5s recast, works on targets
flagged Resurrection Restricted.

**Removals:** none.


---

## Third commit — `OC - Phantom Chemist no longer stops to revive while a living party member is dying`

Same objection as the ordering above, applied to the job that had it first. `ExecuteChemistPhantomJob()`
called `Revive()` ahead of Occult Elixir and Occult Potion, so a Chemist would stop to pick someone up
off the floor while a party member on the edge died waiting.

New order: Occult Elixir → Occult Potion → **Revive** → Occult Ether. Below the two heals that keep the
living alive, above the MP top-up that does not.

Behavior change for anyone running Phantom Chemist, so calling it out explicitly rather than burying it.
No settings, no new strings — priority order only.

**Tested:** Not tested in game. Clean rebuild: 0 errors, 63 warnings, unchanged from master.

**Removals:** none. The `Revive()` guard chain is untouched; only its position in the priority list moved.
