### PR TITLE
HEALERS - Stop the Doom response healing the same ally twice in a row

### DIFF
--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -214,7 +214,14 @@ namespace Magitek.Logic.Roles
             if (BaseSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo($"[Doom Response] Cast {heal.Name} on {doomed.Name}");
 
-            return await heal.Heal(doomed, false);
+            if (!await heal.Heal(doomed, false))
+                return false;
+
+            // The heal is now in flight, and the aura will not clear until the server applies it -
+            // so this carrier is off the table until it has resolved. Without this the very next
+            // GCD answers the same Doom a second time.
+            FightLogic.PaceDoomResponse(doomed, heal);
+            return true;
         }
     }
 }

--- a/Magitek/Logic/Roles/CommonFightLogic.cs
+++ b/Magitek/Logic/Roles/CommonFightLogic.cs
@@ -206,7 +206,9 @@ namespace Magitek.Logic.Roles
                 && !Core.Me.HasAura(Utilities.Auras.Dualcast))
                 return false;
 
-            var doomed = FightLogic.DoomedHealTarget();
+            // Skips a carrier whose last Doom heal landed less than a GCD ago - the aura outlives
+            // the cast by a server round trip, so without that the next GCD answers it again.
+            var doomed = FightLogic.DoomedHealTarget(heal);
 
             if (doomed == null)
                 return false;
@@ -214,14 +216,7 @@ namespace Magitek.Logic.Roles
             if (BaseSettings.Instance.DebugFightLogic)
                 Logger.WriteInfo($"[Doom Response] Cast {heal.Name} on {doomed.Name}");
 
-            if (!await heal.Heal(doomed, false))
-                return false;
-
-            // The heal is now in flight, and the aura will not clear until the server applies it -
-            // so this carrier is off the table until it has resolved. Without this the very next
-            // GCD answers the same Doom a second time.
-            FightLogic.PaceDoomResponse(doomed, heal);
-            return true;
+            return await heal.Heal(doomed, false);
         }
     }
 }

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -47,6 +47,10 @@ namespace Magitek.Utilities
         /// </summary>
         public static string CommonAoeLockOnsDisplay => string.Join(", ", CommonAoeLockOns.OrderBy(x => x));
 
+        // Doom carriers we have already sent a heal at, and the moment that heal stops being in
+        // flight. Keyed by ObjectId, pruned on every write, so it cannot grow past the party.
+        private static readonly Dictionary<uint, DateTime> DoomResponseSettlesAt = new Dictionary<uint, DateTime>();
+
         /// <summary>
         /// The ally (or ourselves when solo) carrying a heal-to-full Doom, or null. This Doom
         /// recurs across content - dungeon bosses apply it as well as the Occult Crescent
@@ -60,9 +64,49 @@ namespace Magitek.Utilities
             // sitting at full is already cleansing (removal latency) and healing them again
             // only wastes the GCD.
             if (Globals.InParty)
-                return Group.CastableAlliesWithin30.FirstOrDefault(r => r.HasAura(Auras.Doom) && r.CurrentHealth < r.MaxHealth);
+                return Group.CastableAlliesWithin30.FirstOrDefault(r => r.HasAura(Auras.Doom) && r.CurrentHealth < r.MaxHealth && !DoomResponseInFlight(r));
 
-            return Core.Me.HasAura(Auras.Doom) && Core.Me.CurrentHealth < Core.Me.MaxHealth ? Core.Me : null;
+            return Core.Me.HasAura(Auras.Doom) && Core.Me.CurrentHealth < Core.Me.MaxHealth && !DoomResponseInFlight(Core.Me) ? Core.Me : null;
+        }
+
+        /// <summary>
+        /// Records that a Doom heal has just gone out at <paramref name="carrier"/> and paces the
+        /// next one at that same carrier by the cast plus a full GCD.
+        /// <para>
+        /// Without this the response answers the same Doom twice, back to back. The aura only clears
+        /// once the SERVER applies the heal, which is a round trip after the client says the cast
+        /// finished - so on the pulse right after it lands the carrier still reads as doomed and
+        /// still reads as below full, and the next GCD is spent on a Doom that is already answered.
+        /// Seen five times on one party member in a single Occult Crescent CE, each pair 2.0-2.8s
+        /// apart, which is one GCD.
+        /// </para>
+        /// <para>
+        /// The window is derived rather than fixed so it tracks the healer's spell speed and
+        /// whichever heal the job passed: the cast has to finish, and then a whole GCD has to pass -
+        /// "put a normal action in between", stated as a duration. A duration rather than "did we
+        /// cast anything else" on purpose, because an oGCD weaved on top of the heal satisfies the
+        /// second phrasing while still landing inside the round trip.
+        /// </para>
+        /// <para>
+        /// Paced per carrier rather than globally, so a second doomed ally is still answered at once.
+        /// </para>
+        /// </summary>
+        public static void PaceDoomResponse(Character carrier, SpellData heal)
+        {
+            if (carrier == null || heal == null)
+                return;
+
+            var now = DateTime.UtcNow;
+
+            foreach (var settled in DoomResponseSettlesAt.Where(r => r.Value <= now).Select(r => r.Key).ToList())
+                DoomResponseSettlesAt.Remove(settled);
+
+            DoomResponseSettlesAt[carrier.ObjectId] = now + heal.AdjustedCastTime + heal.AdjustedCooldown;
+        }
+
+        private static bool DoomResponseInFlight(Character carrier)
+        {
+            return DoomResponseSettlesAt.TryGetValue(carrier.ObjectId, out var settlesAt) && DateTime.UtcNow < settlesAt;
         }
 
         private static TimeSpan FlCooldown
@@ -700,4 +744,4 @@ namespace Magitek.Utilities
         internal FfxivExpansion Expansion { get; set; }
         internal List<Enemy> Enemies { get; set; }
     }
-}
+}

--- a/Magitek/Utilities/FightLogic.cs
+++ b/Magitek/Utilities/FightLogic.cs
@@ -47,10 +47,6 @@ namespace Magitek.Utilities
         /// </summary>
         public static string CommonAoeLockOnsDisplay => string.Join(", ", CommonAoeLockOns.OrderBy(x => x));
 
-        // Doom carriers we have already sent a heal at, and the moment that heal stops being in
-        // flight. Keyed by ObjectId, pruned on every write, so it cannot grow past the party.
-        private static readonly Dictionary<uint, DateTime> DoomResponseSettlesAt = new Dictionary<uint, DateTime>();
-
         /// <summary>
         /// The ally (or ourselves when solo) carrying a heal-to-full Doom, or null. This Doom
         /// recurs across content - dungeon bosses apply it as well as the Occult Crescent
@@ -58,55 +54,47 @@ namespace Magitek.Utilities
         /// first, so healers treat the carrier as the top-priority heal target. Deliberately
         /// not zone-gated, unlike the enemy-cast catalogues.
         /// </summary>
-        public static Character DoomedHealTarget()
+        public static Character DoomedHealTarget(SpellData heal)
         {
             // The below-full check matters: full HP is what removes the aura, so a carrier
             // sitting at full is already cleansing (removal latency) and healing them again
             // only wastes the GCD.
             if (Globals.InParty)
-                return Group.CastableAlliesWithin30.FirstOrDefault(r => r.HasAura(Auras.Doom) && r.CurrentHealth < r.MaxHealth && !DoomResponseInFlight(r));
+                return Group.CastableAlliesWithin30.FirstOrDefault(r => r.HasAura(Auras.Doom) && r.CurrentHealth < r.MaxHealth && !DoomResponseInFlight(r, heal));
 
-            return Core.Me.HasAura(Auras.Doom) && Core.Me.CurrentHealth < Core.Me.MaxHealth && !DoomResponseInFlight(Core.Me) ? Core.Me : null;
+            return Core.Me.HasAura(Auras.Doom) && Core.Me.CurrentHealth < Core.Me.MaxHealth && !DoomResponseInFlight(Core.Me, heal) ? Core.Me : null;
         }
 
         /// <summary>
-        /// Records that a Doom heal has just gone out at <paramref name="carrier"/> and paces the
-        /// next one at that same carrier by the cast plus a full GCD.
+        /// True while a Doom heal that already landed on <paramref name="carrier"/> is still
+        /// resolving, so the response leaves that one carrier alone and still answers anyone else
+        /// immediately.
         /// <para>
-        /// Without this the response answers the same Doom twice, back to back. The aura only clears
-        /// once the SERVER applies the heal, which is a round trip after the client says the cast
-        /// finished - so on the pulse right after it lands the carrier still reads as doomed and
-        /// still reads as below full, and the next GCD is spent on a Doom that is already answered.
-        /// Seen five times on one party member in a single Occult Crescent CE, each pair 2.0-2.8s
-        /// apart, which is one GCD.
+        /// Without this the response answers the same Doom twice, back to back. The aura only
+        /// clears once the SERVER applies the heal, which is a round trip after the cast finishes -
+        /// so on the pulse right after it the carrier still reads as doomed and still reads as
+        /// below full, and the next GCD is spent on a Doom that is already answered. Seen five
+        /// times on one party member in a single Occult Crescent CE, each duplicate 0.27-0.9s
+        /// after its predecessor completed.
         /// </para>
         /// <para>
-        /// The window is derived rather than fixed so it tracks the healer's spell speed and
-        /// whichever heal the job passed: the cast has to finish, and then a whole GCD has to pass -
-        /// "put a normal action in between", stated as a duration. A duration rather than "did we
-        /// cast anything else" on purpose, because an oGCD weaved on top of the heal satisfies the
-        /// second phrasing while still landing inside the round trip.
+        /// Read off <see cref="Casting"/> rather than stamped when the cast is fired, because
+        /// those fields are written only by CheckForSuccessfulCast: a Doom heal that started and
+        /// was then cancelled - movement, target invalidation, a job interrupt check - paces
+        /// nothing, and the carrier stays eligible on the very next pulse.
         /// </para>
         /// <para>
-        /// Paced per carrier rather than globally, so a second doomed ally is still answered at once.
+        /// One GCD measured from cast COMPLETION, derived from whichever heal the job passed so it
+        /// tracks the healer's spell speed. Measuring from completion is also what keeps this
+        /// honest when Swiftcast or Dualcast makes the heal instant: the window is the GCD either
+        /// way, never the nominal cast time on top of it. Doom runs 10s, so a carrier the first
+        /// heal did not top off still gets several more attempts.
         /// </para>
         /// </summary>
-        public static void PaceDoomResponse(Character carrier, SpellData heal)
+        private static bool DoomResponseInFlight(Character carrier, SpellData heal)
         {
-            if (carrier == null || heal == null)
-                return;
-
-            var now = DateTime.UtcNow;
-
-            foreach (var settled in DoomResponseSettlesAt.Where(r => r.Value <= now).Select(r => r.Key).ToList())
-                DoomResponseSettlesAt.Remove(settled);
-
-            DoomResponseSettlesAt[carrier.ObjectId] = now + heal.AdjustedCastTime + heal.AdjustedCooldown;
-        }
-
-        private static bool DoomResponseInFlight(Character carrier)
-        {
-            return DoomResponseSettlesAt.TryGetValue(carrier.ObjectId, out var settlesAt) && DateTime.UtcNow < settlesAt;
+            return Casting.LastSpellWas(heal, (int)heal.AdjustedCooldown.TotalMilliseconds)
+                   && Casting.LastSpellTarget?.ObjectId == carrier.ObjectId;
         }
 
         private static TimeSpan FlCooldown
@@ -744,4 +732,4 @@ namespace Magitek.Utilities
         internal FfxivExpansion Expansion { get; set; }
         internal List<Enemy> Enemies { get; set; }
     }
-}
+}


### PR DESCRIPTION
## What this changes

The fight-logic Doom response now paces itself per carrier: once a Doom heal lands on someone, that same person drops off the response's target list for a full GCD. Other doomed allies are unaffected and still answered immediately.

## Why

The heal only clears Doom once the **server** applies it, which is a round trip after the client reports the cast finished. On the pulse right after that, the carrier still reads as doomed and still reads as below full HP — so the very next GCD answered the same Doom a second time, spending a heal on a Doom that was already resolved.

Five pairs on one party member in a single Occult Crescent CE, each pair 2.0–2.8s apart (one GCD), with the duplicate landing 0.27–0.9s after the first cast completed:

```
[10:02:26.795] [Doom Response] Cast Cure II
[10:02:28.528] Successfully Casted Cure II
[10:02:28.796] [Doom Response] Cast Cure II   <- 268ms later
```

Doom is the only fight-logic responder with no pacing at all. Every other one routes through `FightLogic.DoAndBuffer()`, which stamps the mechanic as answered and starts the 5s response cooldown — but `DoAndBuffer` bails when no enemy is mid-cast, and Doom is keyed on a player's aura rather than an enemy cast, so it could never use it.

The window is one GCD measured from cast **completion**, derived from whichever heal the job passed so it tracks the healer's spell speed and the spell actually in use. A duration rather than "did we cast something else in between" on purpose: an oGCD weaved on top of the heal satisfies that test while still landing inside the round trip.

It reads Magitek's existing cast bookkeeping rather than stamping a window when the heal is fired. `Casting.LastSpellWas` and `Casting.LastSpellTarget` are written only by `CheckForSuccessfulCast`, so a heal that started and was then cancelled — movement, target invalidation, a job interrupt check — paces nothing, and the carrier is eligible again on the very next pulse. Measuring from completion is also what keeps this honest when Swiftcast or Dualcast makes the heal instant: the window is the GCD either way, never a nominal cast bar the heal never showed.

Doom runs 10s, so a carrier whose first heal genuinely did not top them off still gets several more attempts.

**Tested:** WHM Lv100, Occult Crescent CE — against the **first** revision (`47e4891d`). Before the change, five back-to-back pairs in one run's log; after, the CE ran clean with no back-to-back Doom heals.

The current revision (`b65b1be8`) reworks how the window is derived, in response to review, and is **not tested in game**. It builds clean. The behavior it targets is the same one the log above exercises, but the timing source changed, so treat the in-game result as covering the first revision only.

**Sources:** combat-log analysis as above; cast and recast values read off the live client. No game-behavior claims beyond observed cast timelines and the 10s Doom duration already recorded in the Necromancer logic.

**Anything removed:** against master, nothing — a condition was added, none removed. (The second commit deletes the per-carrier dictionary the first commit introduced, in favour of the `Casting` fields that already track this.) `Healer.HealWalkingDeadTank` has the same aura-driven heal-to-full shape and is deliberately untouched: Walking Dead wants healing pumped into it, so back-to-back heals are correct there.
