### PR TITLE
Core - AoE abilities now count the enemies they will actually hit

### DIFF
--- a/Magitek/Extensions/GameObjectExtensions.cs
+++ b/Magitek/Extensions/GameObjectExtensions.cs
@@ -52,6 +52,11 @@ namespace Magitek.Extensions
             return lp != null && lp.TargetGameObject == unit;
         }
 
+        /// <summary>
+        /// Can we reach <paramref name="unit"/> with a spell of this range? Edge to edge: both
+        /// hitboxes come off, because both ends are physical objects. Not the same geometry as an
+        /// AoE radius - see EnemiesNearby.
+        /// </summary>
         public static bool WithinSpellRange(this GameObject unit, float range)
         {
             if (unit == null)
@@ -276,15 +281,41 @@ namespace Magitek.Extensions
         }
 
 
+        /// <summary>
+        /// Enemies inside an AoE of radius <paramref name="distance"/> centred on <paramref name="unit"/>.
+        /// An enemy counts once its own hitbox edge is within the radius, and only the
+        /// counted enemy's combat reach applies - the AoE centre itself adds nothing.
+        /// </summary>
+        /// <remarks>
+        /// Not WithinSpellRange, which is a range check and subtracts both hitboxes.
+        ///
+        /// Measured in game: a radius-5 AoE hit out to 5 + the target's own combat reach and no
+        /// further, across hitboxes of 0.5, 2.4 and 3.2, centred on us and on another mob alike.
+        /// A striking dummy reports 1.5 but resolves AoE like 0.5 - retest on real monsters.
+        /// </remarks>
         public static IEnumerable<BattleCharacter> EnemiesNearby(this GameObject unit, float distance)
         {
-            if (unit == null || Core.Me == null)
+            if (unit == null)
                 return Enumerable.Empty<BattleCharacter>();
 
-            var meCombatReach = Core.Me.CombatReach;
-            var unitCombatReach = unit.CombatReach;
+            return Combat.Enemies.Where(r => r != null && r.Distance(unit) <= distance + r.CombatReach);
+        }
 
-            return Combat.Enemies.Where(r => r != null && r.Distance(unit) <= distance + meCombatReach + unitCombatReach);
+        /// <summary>
+        /// Enemies inside a frontal cone of LENGTH <paramref name="maxdistance"/> from the player.
+        /// Same rule as EnemiesNearby. Returns the count, not the sequence.
+        /// </summary>
+        /// <remarks>
+        /// Width is a hardcoded 0.9599 rad half-angle (~110 degree cone), not read from spell data,
+        /// so every cone ability is checked against the same shape whatever its real one is.
+        ///
+        /// Heading is the post-auto-face one, not where we point now: RadiansFromPlayerHeading uses
+        /// the heading we will have after facing the target, when FaceTargetOnAction and
+        /// UseAutoFaceChecks are both on and a target exists.
+        /// </remarks>
+        public static int EnemiesInCone(this LocalPlayer player, float maxdistance)
+        {
+            return Combat.Enemies.Count(r => r.Distance(Core.Me) <= maxdistance + r.CombatReach && r.RadiansFromPlayerHeading() < 0.9599f);
         }
 
         public static IEnumerable<BattleCharacter> EnemiesNearbyOoc(this GameObject unit, float distance)

--- a/Magitek/Extensions/PlayerExtensions.cs
+++ b/Magitek/Extensions/PlayerExtensions.cs
@@ -1,10 +1,7 @@
-﻿using ff14bot;
-using ff14bot.Managers;
+﻿using ff14bot.Managers;
 using ff14bot.Objects;
-using Magitek.Utilities;
 using Magitek.ViewModels;
 using System.Collections.Generic;
-using System.Linq;
 
 
 namespace Magitek.Extensions
@@ -106,10 +103,5 @@ namespace Magitek.Extensions
             1269, // Phantom Village
             1237, // Sinus Adorum
         };
-
-        public static int EnemiesInCone(this LocalPlayer player, float maxdistance)
-        {
-            return Combat.Enemies.Count(r => r.Distance(Core.Me) <= maxdistance + r.CombatReach && r.RadiansFromPlayerHeading() < 0.9599f);
-        }
     }
 }


### PR DESCRIPTION
One line of behaviour in `EnemiesNearby`:

```diff
- r.Distance(unit) <= distance + Core.Me.CombatReach + unit.CombatReach
+ r.Distance(unit) <= distance + r.CombatReach
```

**Tested:** The rule was measured in game — SCH Art of War and BLM Fire II, Lv100, Middle La Noscea and striking dummies. Tested in roulettes.

Radius-5 AoE, boundary = 5 + the counted target's own combat reach:

| target | combat reach | predicted | measured bracket |
|---|---|---|---|
| striking dummy | 1.5 reported / 0.5 effective | 5.5 | 5.4821 hit – 5.5039 miss |
| overworld mob | 2.4 | 7.4 | 7.36 hit – 7.57 miss |
| Megalocrab | 3.2 | 8.2 | 7.373 hit – 8.693 miss |

Three hitbox values, linear, intercept at the spell's radius. The boundary was identical whether the AoE was centred on the player (Art of War) or on another mob (Fire II) — same cast type, differing only in range.

Note for anyone retesting: **a striking dummy reports a combat reach of 1.5 but resolves AoE as though it were 0.5.** Live mobs behave as reported.

**Sources:** the measurements above. Cross-checked against other projects, which agree that the counted target's hitbox applies and the caster's does not:
- RotationSolver — `Distance(point, t.Position) - t.HitboxRadius <= EffectRange`
- WrathCombo — `PointInCircle(o.Position - origin, size + o.HitboxRadius)`
- BossMod rotation path — `target.Position.InCircle(origin, radius + target.HitboxRadius)`

**Removed:**
- `Core.Me.CombatReach` and `unit.CombatReach` from the radius calculation — measured as wrong. Neither the caster's hitbox nor the AoE centre's extends an AoE.
- The `Core.Me == null` guard in `EnemiesNearby`, since nothing in the body reads `Core.Me` any more.

**Also here, bundled at the maintainer's request rather than split out:** `EnemiesInCone` moved from `PlayerExtensions` to `GameObjectExtensions`, next to `EnemiesNearby` and the `RadiansFromPlayerHeading` it calls. Same namespace, no call-site changes, no behaviour change. Three usings dropped from `PlayerExtensions` that only the cone needed.

**Blast radius:** 34 call sites across BLM, SMN, BRD, NIN, PCT, RPR, SCH, AST and the Bard/Ninja cached counts. The largest effect is around big targets — `CurrentTarget.EnemiesNearby(5)` on something with a 6.0 hitbox previously reached 11.5 yalms.
